### PR TITLE
Collected small changes and fixes

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -244,15 +244,6 @@ option(CMAKE_POSITION_INDEPENDENT_CODE "Create object compatible with shared lib
 option(BUILD_TOOLS "Build and install LAMMPS tools (msi2lmp, binary2txt, chain)" OFF)
 option(BUILD_LAMMPS_GUI "Build and install the LAMMPS GUI" OFF)
 
-# Support using clang-tidy for C++ files with selected options
-set(ENABLE_CLANG_TIDY OFF CACHE BOOL "Include clang-tidy processing when compiling")
-if(ENABLE_CLANG_TIDY)
-  set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-checks=-*,performance-trivially-destructible,performance-unnecessary-copy-initialization,performance-unnecessary-value-param,readability-redundant-control-flow,readability-redundant-declaration,readability-redundant-function-ptr-dereference,readability-redundant-member-init,readability-redundant-string-cstr,readability-redundant-string-init,readability-simplify-boolean-expr,readability-static-accessed-through-instance,readability-static-definition-in-anonymous-namespace,readability-qualified-auto,misc-unused-parameters,modernize-deprecated-ios-base-aliases,modernize-loop-convert,modernize-shrink-to-fit,modernize-use-auto,modernize-use-using,modernize-use-override,modernize-use-bool-literals,modernize-use-emplace,modernize-return-braced-init-list,modernize-use-equals-default,modernize-use-equals-delete,modernize-replace-random-shuffle,modernize-deprecated-headers,modernize-use-nullptr,modernize-use-noexcept,modernize-redundant-void-arg;-fix;-header-filter=.*,header-filter=library.h,header-filter=fmt/*.h" CACHE STRING "clang-tidy settings")
-else()
-  unset(CMAKE_CXX_CLANG_TIDY CACHE)
-endif()
-
-
 file(GLOB ALL_SOURCES CONFIGURE_DEPENDS ${LAMMPS_SOURCE_DIR}/[^.]*.cpp)
 file(GLOB MAIN_SOURCES CONFIGURE_DEPENDS ${LAMMPS_SOURCE_DIR}/main.cpp)
 list(REMOVE_ITEM ALL_SOURCES ${MAIN_SOURCES})

--- a/cmake/Modules/Packages/ML-PACE.cmake
+++ b/cmake/Modules/Packages/ML-PACE.cmake
@@ -53,6 +53,12 @@ else()
       add_library(yaml-cpp::yaml-cpp ALIAS yaml-cpp)
     endif()
 
+    # fixup yaml-cpp/emitterutils.cpp for GCC 15+ until patch is applied
+    file(READ ${lib-pace}/yaml-cpp/src/emitterutils.cpp yaml_emitterutils)
+    string(REPLACE "#include <sstream>" "#include <sstream>\n#include <cinttypes>" yaml_tmp_emitterutils "${yaml_emitterutils}")
+    string(REPLACE "#include <cinttypes>\n#include <cinttypes>" "#include <cinttypes>" yaml_emitterutils "${yaml_tmp_emitterutils}")
+    file(WRITE ${lib-pace}/yaml-cpp/src/emitterutils.cpp "${yaml_emitterutils}")
+
     add_subdirectory(${lib-pace} build-pace EXCLUDE_FROM_ALL)
     set_target_properties(pace PROPERTIES CXX_EXTENSIONS ON OUTPUT_NAME lammps_pace${LAMMPS_MACHINE})
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -99,8 +99,6 @@ html: xmlgen globbed-tocs $(VENV) $(SPHINXCONFIG)/conf.py $(ANCHORCHECK) $(MATHJ
 	@(\
 		. $(VENV)/bin/activate ; env PYTHONWARNINGS= PYTHONDONTWRITEBYTECODE=1 \
 		sphinx-build -E $(SPHINXEXTRA) -b html -c $(SPHINXCONFIG) -d $(BUILDDIR)/doctrees $(RSTDIR) html ;\
-		touch $(RSTDIR)/Fortran.rst ; env PYTHONWARNINGS= PYTHONDONTWRITEBYTECODE=1 \
-		sphinx-build $(SPHINXEXTRA) -b html -c $(SPHINXCONFIG) -d $(BUILDDIR)/doctrees $(RSTDIR) html ;\
 		ln -sf Manual.html html/index.html;\
 		rm -f $(BUILDDIR)/doxygen/xml/run.stamp;\
 		echo "############################################" ; env PYTHONWARNINGS= PYTHONDONTWRITEBYTECODE=1 \
@@ -162,8 +160,6 @@ epub: xmlgen globbed-tocs $(VENV) $(SPHINXCONFIG)/conf.py $(ANCHORCHECK)
 	@(\
 		. $(VENV)/bin/activate ; env PYTHONWARNINGS= PYTHONDONTWRITEBYTECODE=1 \
 		sphinx-build -E $(SPHINXEXTRA) -b epub -c $(SPHINXCONFIG) -d $(BUILDDIR)/doctrees $(RSTDIR) epub ;\
-		touch $(RSTDIR)/Fortran.rst ; env PYTHONWARNINGS= PYTHONDONTWRITEBYTECODE=1 \
-		sphinx-build $(SPHINXEXTRA) -b epub -c $(SPHINXCONFIG) -d $(BUILDDIR)/doctrees $(RSTDIR) epub ;\
 		rm -f $(BUILDDIR)/doxygen/xml/run.stamp;\
 		deactivate ;\
 	)
@@ -183,8 +179,6 @@ pdf: xmlgen globbed-tocs $(VENV) $(SPHINXCONFIG)/conf.py $(ANCHORCHECK)
 	@(\
 		. $(VENV)/bin/activate ; env PYTHONWARNINGS= PYTHONDONTWRITEBYTECODE=1 \
 		sphinx-build -E $(SPHINXEXTRA) -b latex -c $(SPHINXCONFIG) -d $(BUILDDIR)/doctrees $(RSTDIR) latex ;\
-		touch $(RSTDIR)/Fortran.rst ; env PYTHONWARNINGS= PYTHONDONTWRITEBYTECODE=1 \
-		sphinx-build  $(SPHINXEXTRA) -b latex -c $(SPHINXCONFIG) -d $(BUILDDIR)/doctrees $(RSTDIR) latex ;\
 		rm -f $(BUILDDIR)/doxygen/xml/run.stamp;\
 		echo "############################################" ; env PYTHONWARNINGS= PYTHONDONTWRITEBYTECODE=1 \
 		rst_anchor_check src/*.rst ;\

--- a/doc/src/Build_development.rst
+++ b/doc/src/Build_development.rst
@@ -28,28 +28,6 @@ variable VERBOSE set to 1:
 
 ----------
 
-.. _clang-tidy:
-
-Enable static code analysis with clang-tidy (CMake only)
---------------------------------------------------------
-
-The `clang-tidy tool <https://clang.llvm.org/extra/clang-tidy/>`_ is a
-static code analysis tool to diagnose (and potentially fix) typical
-programming errors or coding style violations.  It has a modular framework
-of tests that can be adjusted to help identifying problems before they
-become bugs and also assist in modernizing large code bases (like LAMMPS).
-It can be enabled for all C++ code with the following CMake flag
-
-.. code-block:: bash
-
-   -D ENABLE_CLANG_TIDY=value    # value = no (default) or yes
-
-With this flag enabled all source files will be processed twice, first to
-be compiled and then to be analyzed. Please note that the analysis can be
-significantly more time-consuming than the compilation itself.
-
-----------
-
 .. _iwyu_processing:
 
 Report missing and unneeded '#include' statements (CMake only)

--- a/doc/src/Errors_common.rst
+++ b/doc/src/Errors_common.rst
@@ -1,124 +1,149 @@
-Common problems
-===============
+Common issues that are often regarded as bugs
+=============================================
 
-If two LAMMPS runs do not produce the exact same answer on different
-machines or different numbers of processors, this is typically not a
-bug.  In theory you should get identical answers on any number of
-processors and on any machine.  In practice, numerical round-off can
-cause slight differences and eventual divergence of molecular dynamics
-phase space trajectories within a few 100s or few 1000s of timesteps.
-However, the statistical properties of the two runs (e.g. average
-energy or temperature) should still be the same.
+The list below are some random notes on behavior of LAMMPS that is
+sometimes unexpected or even considered a bug.  Most of the time, these
+are just issues of understanding how LAMMPS is implemented and
+parallelized.  Please also have a look at the :doc:`Error details
+discussions page <Errors_details>` that contains recommendations for
+tracking down issues and explanations for error messages that may
+sometimes be confusing or need additional explanations.
 
-If the :doc:`velocity <velocity>` command is used to set initial atom
-velocities, a particular atom can be assigned a different velocity
-when the problem is run on a different number of processors or on
-different machines.  If this happens, the phase space trajectories of
-the two simulations will rapidly diverge.  See the discussion of the
-*loop* option in the :doc:`velocity <velocity>` command for details and
-options that avoid this issue.
+- A LAMMPS simulation typically has two stages, 1) issuing commands
+  and 2) run or minimize.  Most LAMMPS errors are detected in stage 1),
+  others at the beginning of stage 2), and finally others like a bond
+  stretching too far may or lost atoms or bonds may not occur until the
+  middle of a run.
 
-Similarly, the :doc:`create_atoms <create_atoms>` command generates a
-lattice of atoms.  For the same physical system, the ordering and
-numbering of atoms by atom ID may be different depending on the number
-of processors.
+- If two LAMMPS runs do not produce the exact same answer on different
+  machines or different numbers of processors, this is typically not a
+  bug.  In theory you should get identical answers on any number of
+  processors and on any machine.  In practice, numerical round-off can
+  cause slight differences and eventual divergence of molecular dynamics
+  phase space trajectories within a few 100s or few 1000s of timesteps.
+  This can be triggered by different ordering of atoms due to different
+  domain decompositions, but also through different CPU architectures,
+  different operating systems, different compilers or compiler versions,
+  different compiler optimization levels, different FFT libraries.
+  However, the statistical properties of the two runs (e.g. average
+  energy or temperature) should still be the same.
 
-Some commands use random number generators which may be setup to
-produce different random number streams on each processor and hence
-will produce different effects when run on different numbers of
-processors.  A commonly-used example is the :doc:`fix langevin <fix_langevin>` command for thermostatting.
+- If the :doc:`velocity <velocity>` command is used to set initial atom
+  velocities, a particular atom can be assigned a different velocity
+  when the problem is run on a different number of processors or on
+  different machines.  If this happens, the phase space trajectories of
+  the two simulations will rapidly diverge.  See the discussion of the
+  *loop* option in the :doc:`velocity <velocity>` command for details
+  and options that avoid this issue.
 
-A LAMMPS simulation typically has two stages, setup and run.  Most
-LAMMPS errors are detected at setup time; others like a bond
-stretching too far may not occur until the middle of a run.
+- Similarly, the :doc:`create_atoms <create_atoms>` command generates a
+  lattice of atoms.  For the same physical system, the ordering and
+  numbering of atoms by atom ID may be different depending on the number
+  of processors.
 
-LAMMPS tries to flag errors and print informative error messages so
-you can fix the problem.  For most errors it will also print the last
-input script command that it was processing.  Of course, LAMMPS cannot
-figure out your physics or numerical mistakes, like choosing too big a
-timestep, specifying erroneous force field coefficients, or putting 2
-atoms on top of each other!  If you run into errors that LAMMPS
-does not catch that you think it should flag, please send an email to
-the `developers <https://www.lammps.org/authors.html>`_ or create an new
-topic on the dedicated `MatSci forum section <https://matsci.org/lammps/>`_.
+- Some commands use random number generators which may be setup to
+  produce different random number streams on each processor and hence
+  will produce different effects when run on different numbers of
+  processors.  A commonly-used example is the :doc:`fix langevin
+  <fix_langevin>` command for thermostatting.
 
-If you get an error message about an invalid command in your input
-script, you can determine what command is causing the problem by
-looking in the log.lammps file or using the :doc:`echo command <echo>`
-to see it on the screen.  If you get an error like "Invalid ...
-style", with ... being fix, compute, pair, etc, it means that you
-mistyped the style name or that the command is part of an optional
-package which was not compiled into your executable.  The list of
-available styles in your executable can be listed by using
-:doc:`the -h command-line switch <Run_options>`.  The installation and
-compilation of optional packages is explained on the
-:doc:`Build packages <Build_package>` doc page.
+- LAMMPS tries to flag errors and print informative error messages so
+  you can fix the problem.  For most errors it will also print the last
+  input script command that it was processing or even point to the
+  keyword that is causing troubles.  Of course, LAMMPS cannot figure out
+  your physics or numerical mistakes, like choosing too big a timestep,
+  specifying erroneous force field coefficients, or putting 2 atoms on
+  top of each other!  Also, LAMMPS does not know what you *intend* to
+  do, but very strictly applies the syntax as described in the
+  documentation.  If you run into errors that LAMMPS does not catch that
+  you think it should flag, please send an email to the `developers
+  <https://www.lammps.org/authors.html>`_ or create an new topic on the
+  dedicated `MatSci forum section <https://matsci.org/lammps/>`_.
 
-For a given command, LAMMPS expects certain arguments in a specified
-order.  If you mess this up, LAMMPS will often flag the error, but it
-may also simply read a bogus argument and assign a value that is
-valid, but not what you wanted.  E.g. trying to read the string "abc"
-as an integer value of 0.  Careful reading of the associated doc page
-for the command should allow you to fix these problems. In most cases,
-where LAMMPS expects to read a number, either integer or floating point,
-it performs a stringent test on whether the provided input actually
-is an integer or floating-point number, respectively, and reject the
-input with an error message (for instance, when an integer is required,
-but a floating-point number 1.0 is provided):
+- If you get an error message about an invalid command in your input
+  script, you can determine what command is causing the problem by
+  looking in the log.lammps file or using the :doc:`echo command <echo>`
+  to see it on the screen.  If you get an error like "Invalid ...
+  style", with ... being fix, compute, pair, etc, it means that you
+  mistyped the style name or that the command is part of an optional
+  package which was not compiled into your executable.  The list of
+  available styles in your executable can be listed by using
+  :doc:`the -h command-line switch <Run_options>`.  The installation and
+  compilation of optional packages is explained on the :doc:`Build
+  packages <Build_package>` doc page.
 
-.. parsed-literal::
+- For a given command, LAMMPS expects certain arguments in a specified
+  order.  If you mess this up, LAMMPS will often flag the error, but it
+  may also simply read a bogus argument and assign a value that is
+  valid, but not what you wanted.  E.g. trying to read the string "abc"
+  as an integer value of 0.  Careful reading of the associated doc page
+  for the command should allow you to fix these problems. In most cases,
+  where LAMMPS expects to read a number, either integer or floating
+  point, it performs a stringent test on whether the provided input
+  actually is an integer or floating-point number, respectively, and
+  reject the input with an error message (for instance, when an integer
+  is required, but a floating-point number 1.0 is provided):
 
-   ERROR: Expected integer parameter instead of '1.0' in input script or data file
+  .. parsed-literal::
 
-Some commands allow for using variable references in place of numeric
-constants so that the value can be evaluated and may change over the
-course of a run.  This is typically done with the syntax *v_name* for a
-parameter, where name is the name of the variable. On the other hand,
-immediate variable expansion with the syntax ${name} is performed while
-reading the input and before parsing commands,
+     ERROR: Expected integer parameter instead of '1.0' in input script or data file
 
-.. note::
+- Some commands allow for using variable references in place of numeric
+  constants so that the value can be evaluated and may change over the
+  course of a run.  This is typically done with the syntax *v_name* for
+  a parameter, where name is the name of the variable. On the other
+  hand, immediate variable expansion with the syntax ${name} is
+  performed while reading the input and before parsing commands,
 
-   Using a variable reference (i.e. *v_name*) is only allowed if
-   the documentation of the corresponding command explicitly says it is.
-   Otherwise, you will receive an error message of this kind:
+  .. note::
 
-.. parsed-literal::
+     Using a variable reference (i.e. *v_name*) is only allowed if
+     the documentation of the corresponding command explicitly says it is.
+     Otherwise, you will receive an error message of this kind:
 
-   ERROR: Expected floating point parameter instead of 'v_name' in input script or data file
+  .. parsed-literal::
 
-Generally, LAMMPS will print a message to the screen and logfile and
-exit gracefully when it encounters a fatal error.  Sometimes it will
-print a WARNING to the screen and logfile and continue on; you can
-decide if the WARNING is important or not.  A WARNING message that is
-generated in the middle of a run is only printed to the screen, not to
-the logfile, to avoid cluttering up thermodynamic output.  If LAMMPS
-crashes or hangs without spitting out an error message first then it
-could be a bug (see :doc:`this section <Errors_bugs>`) or one of the following
-cases:
+     ERROR: Expected floating point parameter instead of 'v_name' in input script or data file
 
-LAMMPS runs in the available memory a processor allows to be
-allocated.  Most reasonable MD runs are compute limited, not memory
-limited, so this should not be a bottleneck on most platforms.  Almost
-all large memory allocations in the code are done via C-style malloc's
-which will generate an error message if you run out of memory.
-Smaller chunks of memory are allocated via C++ "new" statements.  If
-you are unlucky you could run out of memory just when one of these
-small requests is made, in which case the code will crash or hang (in
-parallel), since LAMMPS does not trap on those errors.
+- Generally, LAMMPS will print a message to the screen and logfile and
+  exit gracefully when it encounters a fatal error.  When running in
+  parallel this message may be stuck in an I/O buffer and LAMMPS will be
+  terminated before that buffer is printed.  In that case you can try
+  adding the ``-nonblock`` or ``-nb`` command-line flag to turn off that
+  buffering.  Please note that this should not be used for production
+  runs, since turning off buffering usually has a significant negative
+  impact on performance (even worse than :doc:`thermo_modify flush yes
+  <thermo_modify>`).  Sometimes LAMMPS will print a WARNING to the
+  screen and logfile and continue on; you can decide if the WARNING is
+  important or not, but as a general rule do not ignore warnings that
+  you not understand.  A WARNING message that is generated in the middle
+  of a run is only printed to the screen, not to the logfile, to avoid
+  cluttering up thermodynamic output.  If LAMMPS crashes or hangs
+  without generating an error message first then it could be a bug
+  (see :doc:`this section <Errors_bugs>`).
 
-Illegal arithmetic can cause LAMMPS to run slow or crash.  This is
-typically due to invalid physics and numerics that your simulation is
-computing.  If you see wild thermodynamic values or NaN values in your
-LAMMPS output, something is wrong with your simulation.  If you
-suspect this is happening, it is a good idea to print out
-thermodynamic info frequently (e.g. every timestep) via the
-:doc:`thermo <thermo>` so you can monitor what is happening.
-Visualizing the atom movement is also a good idea to ensure your model
-is behaving as you expect.
+- LAMMPS runs in the available memory a processor allows to be
+  allocated.  Most reasonable MD runs are compute limited, not memory
+  limited, so this should not be a bottleneck on most platforms.  Almost
+  all large memory allocations in the code are done via C-style malloc's
+  which will generate an error message if you run out of memory.
+  Smaller chunks of memory are allocated via C++ "new" statements.  If
+  you are unlucky you could run out of memory just when one of these
+  small requests is made, in which case the code will crash or hang (in
+  parallel).
 
-In parallel, one way LAMMPS can hang is due to how different MPI
-implementations handle buffering of messages.  If the code hangs
-without an error message, it may be that you need to specify an MPI
-setting or two (usually via an environment variable) to enable
-buffering or boost the sizes of messages that can be buffered.
+- Illegal arithmetic can cause LAMMPS to run slow or crash.  This is
+  typically due to invalid physics and numerics that your simulation is
+  computing.  If you see wild thermodynamic values or NaN values in your
+  LAMMPS output, something is wrong with your simulation.  If you
+  suspect this is happening, it is a good idea to print out
+  thermodynamic info frequently (e.g. every timestep) via the
+  :doc:`thermo <thermo>` so you can monitor what is happening.
+  Visualizing the atom movement is also a good idea to ensure your model
+  is behaving as you expect.
+
+- When running in parallel with MPI, one way LAMMPS can hang is because
+  LAMMPS has come across an error condition, but only on one or a few
+  MPI processes and not all of them.  LAMMPS has two different "stop
+  with an error message" functions and the correct one has to be called
+  or else it will hang.

--- a/doc/src/Errors_details.rst
+++ b/doc/src/Errors_details.rst
@@ -51,8 +51,11 @@ Parallel versus serial
 ^^^^^^^^^^^^^^^^^^^^^^
 
 Issues where something is "lost" or "missing" often exhibit that issue
-only when running in parallel.  That doesn't mean there is no problem,
-only the symptoms are not triggering an error quickly.  Correspondingly,
+*only* when running in parallel.  That doesn't mean there is no problem
+when running in serial, only the symptoms are not triggering an error.
+This may be because there is no domain decomposition with just one
+processor and thus all atoms are accessible, or it may be because the
+problem will manifest faster with smaller subdomains.  Correspondingly,
 errors may be triggered faster with more processors and thus smaller
 sub-domains.
 
@@ -243,6 +246,25 @@ the wrong place.  This is not always obvious.  So index or string style
 equal style (or similar) variables can only be expanded before the box
 is defined if they do not reference anything that cannot be defined
 before the box (e.g. a compute or fix reference or a thermo keyword).
+
+.. _hint13:
+
+Illegal ... command
+^^^^^^^^^^^^^^^^^^^
+
+These are a catchall error messages that used to be used a lot in LAMMPS
+(also programmers are sometimes lazy).  They usually include the name of
+the source file and the line where the error happened.  This can be used
+to track down what caused the error (most often some form of syntax error)
+by looking at the source code.  However, this has two disadvantages: 1. one
+has to check the source file from the exact same LAMMPS version, or else
+the line number would be different or the core may have been rewritten and
+that specific error does not exist anymore.
+
+The LAMMPS developers are committed to replace these too generic error
+messages with more descriptive errors, e.g. listing *which* keyword was
+causing the error, so that it will be much simpler to look up the
+correct syntax in the manual (and without referring to the source code).
 
 ------
 

--- a/doc/src/Errors_details.rst
+++ b/doc/src/Errors_details.rst
@@ -1051,13 +1051,15 @@ Even though the LAMMPS error message recommends to increase the "one"
 parameter, this may not always be the correct solution.  The neighbor
 list overflow can also be a symptom for some other error that cannot be
 easily detected.  For example, a frequent reason for an (unexpected)
-high density are incorrect box boundaries (since LAMMPS wraps atoms back
+high density are incorrect box dimensions (since LAMMPS wraps atoms back
 into the principal box with periodic boundaries) or coordinates provided
-as fractional coordinates.  In both cases, LAMMPS cannot easily know
-whether the input geometry has such a high density (and thus requiring
-more neighbor list storage per atom) by intention.  Rather than blindly
-increasing the "one" parameter, it is thus worth checking if this is
-justified by the combination of density and cutoff.
+as fractional coordinates (LAMMPS does not support this for data files).
+In both cases, LAMMPS cannot easily know whether the input geometry has
+such a high density (and thus requiring more neighbor list storage per
+atom) on purpose or by accident.  Rather than blindly increasing the
+"one" parameter, it is thus worth checking if this is justified by the
+combination of density and cutoff.  This is particularly recommended
+when using some tool(s) to convert input or data files.
 
 When boosting (= increasing) the "one" parameter, it is recommended to
 also increase the value for the "page" parameter to maintain the ratio

--- a/doc/src/Howto_spc.rst
+++ b/doc/src/Howto_spc.rst
@@ -8,6 +8,18 @@ the two O-H bonds and the H-O-H angle rigid.  A bond style of
 *harmonic* and an angle style of *harmonic* or *charmm* should also be
 used.
 
+One suitable pair style with cutoff Coulomb would for instance be:
+
+* :doc:`pair_style lj/cut/coul/cut <pair_lj_cut_coul>`
+
+These commands are examples for a long-range Coulomb model:
+
+* :doc:`pair_style lj/cut/coul/long <pair_lj_cut_coul>`
+* :doc:`pair_style lj/cut/coul/long/soft <pair_fep_soft>`
+* :doc:`kspace_style pppm <kspace_style>`
+* :doc:`pair_style lj/long/coul/long <pair_lj_long>`
+* :doc:`kspace_style pppm/disp <kspace_style>`
+
 These are the additional parameters (in real units) to set for O and H
 atoms and the water molecule to run a rigid SPC model.
 
@@ -39,7 +51,9 @@ the SPC and SPC/E models.
 Below is the code for a LAMMPS input file and a molecule file
 (``spce.mol``) of SPC/E water for use with the :doc:`molecule command
 <molecule>` demonstrating how to set up a small bulk water system for
-SPC/E with rigid bonds.
+SPC/E with rigid bonds.  For simplicity and speed the example uses a
+cutoff Coulomb.  Most production simulations require long-range Coulomb
+instead.
 
 .. code-block:: LAMMPS
 

--- a/doc/src/Howto_tip3p.rst
+++ b/doc/src/Howto_tip3p.rst
@@ -5,16 +5,23 @@ The TIP3P water model as implemented in CHARMM :ref:`(MacKerell)
 <howto-tip3p>` specifies a 3-site rigid water molecule with charges and
 Lennard-Jones parameters assigned to each of the three atoms.
 
-A suitable pair style with cutoff Coulomb would be:
+One suitable pair style with cutoff Coulomb would for instance be:
 
 * :doc:`pair_style lj/cut/coul/cut <pair_lj_cut_coul>`
 
-or these commands for a long-range Coulomb model:
+These commands are examples for a long-range Coulomb model:
 
 * :doc:`pair_style lj/cut/coul/long <pair_lj_cut_coul>`
 * :doc:`pair_style lj/cut/coul/long/soft <pair_fep_soft>`
 * :doc:`kspace_style pppm <kspace_style>`
+* :doc:`pair_style lj/long/coul/long <pair_lj_long>`
 * :doc:`kspace_style pppm/disp <kspace_style>`
+
+And these pair styles are compatible with the CHARMM force field:
+
+* :doc:`pair_style lj/charmm/coul/charmm <pair_charmm>`
+* :doc:`pair_style lj/charmm/coul/long <pair_charmm>`
+* :doc:`pair_style lj/charmmfsw/coul/long <pair_charmm>`
 
 In LAMMPS the :doc:`fix shake or fix rattle <fix_shake>` command can be
 used to hold the two O-H bonds and the H-O-H angle rigid.  A bond style
@@ -100,7 +107,9 @@ ignored.
 Below is the code for a LAMMPS input file and a molecule file
 (``tip3p.mol``) of TIP3P water for use with the :doc:`molecule command
 <molecule>` demonstrating how to set up a small bulk water system for
-TIP3P with rigid bonds.
+TIP3P with rigid bonds.  For simplicity and speed the example uses a
+cutoff Coulomb.  Most production simulations require long-range Coulomb
+instead.
 
 .. code-block:: LAMMPS
 

--- a/doc/src/Howto_tip4p.rst
+++ b/doc/src/Howto_tip4p.rst
@@ -167,7 +167,9 @@ cutoffs are set in the :doc:`pair_style lj/cut/tip4p/long
 Below is the code for a LAMMPS input file using the implicit method and
 the :ref:`TIP3P molecule file <tip3p_molecule>`.  Because the TIP4P
 charges are different from TIP3P they need to be reset (or the molecule
-file changed):
+file changed).  For simplicity and speed the example uses a cutoff
+Coulomb.  Most production simulations require long-range Coulomb
+instead.
 
 .. code-block:: LAMMPS
 

--- a/doc/src/Howto_tip5p.rst
+++ b/doc/src/Howto_tip5p.rst
@@ -87,7 +87,9 @@ atom style full or use :doc:`fix property/atom mol <fix_property_atom>`
 so that fix rigid/small can identify rigid bodies by their molecule ID.
 Also a :doc:`neigh_modify exclude <neigh_modify>` command is added to
 exclude computing intramolecular non-bonded interactions, since those
-are removed by the rigid fix anyway:
+are removed by the rigid fix anyway.  For simplicity and speed the
+example uses a cutoff Coulomb.  Most production simulations require
+long-range Coulomb instead.
 
 .. code-block:: LAMMPS
 

--- a/doc/src/compute_msd.rst
+++ b/doc/src/compute_msd.rst
@@ -49,8 +49,6 @@ proportional to the diffusion coefficient of the diffusing atoms.
 The displacement of an atom is from its reference position. This is
 normally the original position at the time
 the compute command was issued, unless the *average* keyword is set to *yes*\ .
-The value of the displacement will be
-0.0 for atoms not in the specified compute group.
 
 If the *com* option is set to *yes* then the effect of any drift in
 the center-of-mass of the group of atoms is subtracted out before the

--- a/doc/src/compute_msd.rst
+++ b/doc/src/compute_msd.rst
@@ -111,7 +111,10 @@ distance\ :math:`^2` :doc:`units <units>`.
 Restrictions
 """"""""""""
 
-Compute *msd* cannot be used with a dynamic group.
+Compute *msd* cannot be used with a dynamic group and the number of
+atoms in the compute group must not be changed by some fixes like,
+for example, :doc:`fix deposit <fix_deposit>` or
+:doc:`fix evaporate <fix_evaporate>`.
 
 Related commands
 """"""""""""""""

--- a/doc/src/molecule.rst
+++ b/doc/src/molecule.rst
@@ -209,7 +209,7 @@ defining a *body* particle, which requires setting the number of
 
 .. list-table::
       :header-rows: 1
-      :widths: 20 13 42 15
+      :widths: 21 12 47 20
 
       * - Number(s)
         - Keyword
@@ -218,7 +218,7 @@ defining a *body* particle, which requires setting the number of
       * - N
         - atoms
         - # of atoms N in molecule
-        - 0
+        - keyword is *required*
       * - Nb
         - bonds
         - # of bonds Nb in molecule
@@ -241,8 +241,8 @@ defining a *body* particle, which requires setting the number of
         - 0
       * - Ninteger Ndouble
         - body
-        - # of integer and floating-point values in body particle
-        - 0
+        - # of integer and floating-point values in :doc:`body particle <Howto_body>`
+        - 0 0
       * - Mtotal
         - mass
         - total mass of molecule

--- a/doc/src/molecule.rst
+++ b/doc/src/molecule.rst
@@ -970,7 +970,7 @@ JSON file above in case the molecule command needs to be issued earlier.
                [3,  ["OW-HO1",  "OW-HO1", "HO1-OW-HO1"]]
            ]
        }
-   }                
+   }
 
 
 Below is a minimal example of a JSON format molecule template for a body

--- a/doc/src/molecule.rst
+++ b/doc/src/molecule.rst
@@ -76,7 +76,9 @@ contains multiple molecules.  The :doc:`atom_style template
 system with more than one templated molecule.
 
 The molecule file can be either in a *native* format or in `JSON format
-<https://www.json.org/>`_.  The details of the two formats are described
+<https://www.json.org/>`_.  JSON formal filenames **must** have the
+extension ".json".  Files with any other name will be assumed to be in
+the "native" format.  The details of the two formats are described
 below.  When referencing multiple molecule files in a single *molecule*
 command, each of those files may be either format.
 

--- a/doc/src/molecule.rst
+++ b/doc/src/molecule.rst
@@ -695,12 +695,15 @@ and thus the data in the file must follow suitable conventions to be
 correctly processed.  LAMMPS provides a `JSON schema file
 <https://json-schema.org/>`_ for JSON format molecule files in the
 :ref:`tools/json folder <json>` to represent those conventions.  Using
-the schema file any JSON format molecule files can be validated.
+the schema file any JSON format molecule files can be validated.  Please
+note that the format requirement for JSON are very strict and the JSON
+reader in LAMMPS does not accept files with extensions like comments.
 Validating a particular JSON format molecule file against this schema
 ensures that both, the JSON syntax requirement *and* the LAMMPS
-conventions for molecule templates are followed.  This is a formal check
-only and thus it **cannot** check whether the file contents are
-physically meaningful.
+conventions for molecule template files are followed.  LAMMPS should be
+able to read and parse any JSON file that passes the schema check.  This
+is a formal check only and thus it **cannot** check whether the file
+contents are consistent or physically meaningful.
 
 Here is a simple example for the same TIP3P water molecule from above in
 JSON format and also using :doc:`type labels <labelmap>` instead of
@@ -864,6 +867,155 @@ for the "native" molecule file format.
      - a data block
      - no
      - defines impropers in the molecule template with the format "improper-type", "atom1", "atom2", "atom3", "atom4" (same as Impropers without improper-ID)
+   * - shake
+     - 3 JSON objects
+     - no
+     - contains the sub-sections "flags", "atoms", "bonds" described below
+   * - special
+     - 2 JSON objects
+     - no
+     - contains the sub-sections "counts" and "bonds" described below
+   * - body
+     - 2 JSON objects
+     - no
+     - contains the "integers" and "doubles" sub-sections with arrays with the same data as Body Integers and Body Doubles, respectively
+
+The following table describes the sub-sections for the "special" entry from above:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Subsection
+     - Argument(s)
+     - Required
+     - Description
+   * - counts
+     - a data block
+     - yes
+     - contains the counts of 1-2, 1-3, and 1-4 special neighbors with the format "atom-id", "n12", "n13", "n14" (same as Special Bond Counts)
+   * - bonds
+     - a data block
+     - yes
+     - contains the lists of special neighbors to atoms with the format "atom-id", "atom-id-list" (same as Special Bonds)
+
+The following table describes the sub-sections for the "shake" entry from above:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Subsection
+     - Argument(s)
+     - Required
+     - Description
+   * - flags
+     - a data block
+     - yes
+     - contains the counts shake flags for atoms with the format "atom-id", "flag" (same as Shake Flags)
+   * - atoms
+     - a data block
+     - yes
+     - contains the lists of shake cluster atom-ids for atoms with the format "atom-id", "atom-id-list" (same as Shake Atoms)
+   * - bonds
+     - a data block
+     - yes
+     - contains the lists of shake bond or angle types for atoms with the format "atom-id", "type-list" (same as Shake Bonds)
+
+The "special" and "shake" sections are usually not needed, since the
+data can be auto-generated as soon as the simulation box is defined.
+Below is an example for what would have to be *added* to the example
+JSON file above in case the molecule command needs to be issued earlier.
+
+.. code-block:: json
+
+   "special": {
+       "counts": {
+           "format": ["atom-id", "n12", "n13", "n14"],
+           "data": [
+               [1, 2, 0, 0],
+               [2, 1, 1, 0],
+               [3, 1, 1, 0]
+           ]
+       },
+       "bonds": {
+           "format": ["atom-id", "atom-id-list"],
+           "data": [
+               [1,  [2, 3]],
+               [2,  [1, 3]],
+               [3,  [1, 2]]
+           ]
+       }
+   },
+   "shake": {
+       "flags": {
+           "format": ["atom-id", "flag"],
+           "data": [
+               [1, 1],
+               [2, 1],
+               [3, 1]
+           ]
+       },
+       "atoms": {
+           "format": ["atom-id", "atom-id-list"],
+           "data": [
+               [1,  [1, 2, 3]],
+               [2,  [1, 2, 3]],
+               [3,  [1, 2, 3]]
+           ]
+       },
+       "types": {
+           "format": ["atom-id", "type-list"],
+           "data": [
+               [1,  ["OW-HO1",  "OW-HO1", "HO1-OW-HO1"]],
+               [2,  ["OW-HO1",  "OW-HO1", "HO1-OW-HO1"]],
+               [3,  ["OW-HO1",  "OW-HO1", "HO1-OW-HO1"]]
+           ]
+       }
+   }                
+
+
+Below is a minimal example of a JSON format molecule template for a body
+particle for :doc:`pair style body/nparticle
+<pair_body_nparticle>`. Molecule templates for body particles must
+contain only one atom:
+
+.. code-block:: json
+
+   {
+       "application": "LAMMPS",
+       "format": "molecule",
+       "revision": 1,
+       "title": "Square body for body/nparticles",
+       "schema": "https://download.lammps.org/json/molecule-schema.json",
+       "units": "real",
+       "coords": {
+           "format": ["atom-id", "x", "y", "z"],
+           "data": [
+               [1,  0.00000,  0.00000,  0.00000]
+           ]
+       },
+       "types": {
+           "format": ["atom-id", "type"],
+           "data": [
+               [1,  1]
+           ]
+       },
+       "masses": {
+           "format": ["atom-id", "mass"],
+           "data": [
+               [1,  1.0]
+           ]
+       },
+       "body": {
+           "integers": [4],
+           "doubles": [
+               1.0, 1.0, 4.0, 0.0, 0.0, 0.0,
+               -0.70710678118654752440, -0.70710678118654752440, 0.0,
+               -0.70710678118654752440,  0.70710678118654752440, 0.0,
+               0.70710678118654752440,  0.70710678118654752440, 0.0,
+               0.70710678118654752440, -0.70710678118654752440, 0.0
+           ]
+       }
+   }
 
 ----------
 

--- a/doc/src/variable.rst
+++ b/doc/src/variable.rst
@@ -68,7 +68,8 @@ Syntax
                            bound(group,dir,region), gyration(group,region), ke(group,reigon),
                            angmom(group,dim,region), torque(group,dim,region),
                            inertia(group,dimdim,region), omega(group,dim,region)
-         special functions = sum(x), min(x), max(x), ave(x), trap(x), slope(x), sort(x), rsort(x), \                                  gmask(x), rmask(x), grmask(x,y), next(x), is_file(name), is_os(name),
+         special functions = sum(x), min(x), max(x), ave(x), trap(x), slope(x), sort(x), rsort(x),
+                             gmask(x), rmask(x), grmask(x,y), next(x), is_file(name), is_os(name),
                              extract_setting(name), label2type(kind,label),
                              is_typelabel(kind,label), is_timeout()
          feature functions = is_available(category,feature), is_active(category,feature),

--- a/doc/utils/requirements.txt
+++ b/doc/utils/requirements.txt
@@ -11,3 +11,4 @@ six
 pyyaml
 linkchecker
 ipython
+numpy

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -33,6 +33,7 @@ activationfunctions
 acylindricity
 addforce
 Addington
+addstep
 addtorque
 adf
 Adhikari
@@ -532,6 +533,7 @@ civ
 CKD
 ckk
 Clang
+clearstep
 clearstore
 Cleary
 Clebsch

--- a/fortran/lammps.f90
+++ b/fortran/lammps.f90
@@ -3440,6 +3440,7 @@ CONTAINS
     TYPE(c_ptr) :: c_id, c_caller
     TYPE(c_funptr) :: c_callback
     INTEGER :: i, this_fix
+    TYPE(fix_external_data), DIMENSION(:), ALLOCATABLE :: tmp_ext_data
 
     c_id = f2c_string(id)
     IF (ALLOCATED(ext_data)) THEN
@@ -3451,9 +3452,13 @@ CONTAINS
         END IF
       END DO
       IF (this_fix > SIZE(ext_data)) THEN
-        ! reallocates ext_data; this requires us to re-bind "caller" on the C
+        ! reallocate ext_data in a pre-fortran 2008 compatible way.
+        ALLOCATE(tmp_ext_data(this_fix))
+        tmp_ext_data(1:this_fix-1) = ext_data(1:this_fix-1)
+        tmp_ext_data(this_fix) = fix_external_data()
+        CALL move_alloc(tmp_ext_data, ext_data)
+        ! this requires us to re-bind "caller" on the C
         ! side to the new data structure, which likely moved to a new address
-        ext_data = [ext_data, fix_external_data()] ! extends ext_data by 1
         CALL rebind_external_callback_data()
       END IF
     ELSE

--- a/fortran/lammps.f90
+++ b/fortran/lammps.f90
@@ -1162,6 +1162,9 @@ CONTAINS
         CALL lammps_mpi_finalize()
         CALL lammps_python_finalize()
         CALL lammps_plugin_finalize()
+        IF (ALLOCATED(ext_data)) THEN
+            DEALLOCATE(ext_data)
+        END IF
       END IF
     END IF
   END SUBROUTINE lmp_close

--- a/python/lammps/.pylintrc.toml
+++ b/python/lammps/.pylintrc.toml
@@ -264,7 +264,7 @@ max-bool-expr = 5
 max-branches = 50
 
 # Maximum number of locals for function / method body.
-max-locals = 20
+max-locals = 25
 
 # Maximum number of parents for a class (see R0901).
 max-parents = 7
@@ -282,7 +282,7 @@ max-returns = 15
 max-statements = 500
 
 # Minimum number of public methods for a class (see R0903).
-min-public-methods = 2
+min-public-methods = 0
 
 [tool.pylint.exceptions]
 # Exceptions that will emit a warning when caught.

--- a/python/lammps/.pylintrc.toml
+++ b/python/lammps/.pylintrc.toml
@@ -1,0 +1,556 @@
+[tool.pylint.main]
+# Analyse import fallback blocks. This can be used to support both Python 2 and 3
+# compatible code, which means that the block might have code that exists only in
+# one or another interpreter, leading to false positives when analysed.
+# analyse-fallback-blocks =
+
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint in
+# a server-like mode.
+# clear-cache-post-run =
+
+# Always return a 0 (non-error) status code, even if lint errors are found. This
+# is primarily useful in continuous integration scripts.
+# exit-zero =
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+# extension-pkg-allow-list =
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+# extension-pkg-whitelist =
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+# fail-on =
+
+# Specify a score threshold under which the program will exit with error.
+fail-under = 10
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+# from-stdin =
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore = ["CVS"]
+
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\\' represents the directory delimiter on Windows systems, it
+# can't be used as an escape character.
+# ignore-paths =
+
+# Files or directories matching the regular expression patterns are skipped. The
+# regex matches against base names, not paths. The default value ignores Emacs
+# file locks
+ignore-patterns = ["^\\.#"]
+
+# List of module names for which member attributes should not be checked and will
+# not be imported (useful for modules/projects where namespaces are manipulated
+# during runtime and thus existing member attributes cannot be deduced by static
+# analysis). It supports qualified module names, as well as Unix pattern
+# matching.
+# ignored-modules =
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+# init-hook =
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
+jobs = 1
+
+# Control the amount of potential inferred values when inferring a single object.
+# This can help the performance when dealing with large functions or complex,
+# nested conditions.
+limit-inference-results = 100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+# load-plugins =
+
+# Pickle collected data for later comparisons.
+persistent = true
+
+# Resolve imports to .pyi stubs if available. May reduce no-member messages and
+# increase not-an-iterable messages.
+# prefer-stubs =
+
+# Minimum Python version to use for version dependent checks. Will default to the
+# version used to run pylint.
+py-version = "3.13"
+
+# Discover python modules and packages in the file system subtree.
+# recursive =
+
+# Add paths to the list of the source roots. Supports globbing patterns. The
+# source root is an absolute path or a path relative to the current working
+# directory used to determine a package namespace for modules located under the
+# source root.
+# source-roots =
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode = true
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+# unsafe-load-any-extension =
+
+[tool.pylint.basic]
+# Naming style matching correct argument names.
+argument-naming-style = "snake_case"
+
+# Regular expression matching correct argument names. Overrides argument-naming-
+# style. If left empty, argument names will be checked with the set naming style.
+# argument-rgx =
+
+# Naming style matching correct attribute names.
+attr-naming-style = "snake_case"
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+# attr-rgx =
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names = ["foo", "bar", "baz", "toto", "tutu", "tata"]
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+# bad-names-rgxs =
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style = "any"
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+# class-attribute-rgx =
+
+# Naming style matching correct class constant names.
+class-const-naming-style = "UPPER_CASE"
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+# class-const-rgx =
+
+# Naming style matching correct class names.
+class-naming-style = "PascalCase"
+
+# Regular expression matching correct class names. Overrides class-naming-style.
+# If left empty, class names will be checked with the set naming style.
+# class-rgx =
+
+# Naming style matching correct constant names.
+const-naming-style = "UPPER_CASE"
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming style.
+# const-rgx =
+
+# Minimum line length for functions/classes that require docstrings, shorter ones
+# are exempt.
+docstring-min-length = -1
+
+# Naming style matching correct function names.
+function-naming-style = "snake_case"
+
+# Regular expression matching correct function names. Overrides function-naming-
+# style. If left empty, function names will be checked with the set naming style.
+# function-rgx =
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names = ["i", "j", "k", "ex", "Run", "_"]
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+# good-names-rgxs =
+
+# Include a hint for the correct naming format with invalid-name.
+# include-naming-hint =
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style = "any"
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+# inlinevar-rgx =
+
+# Naming style matching correct method names.
+method-naming-style = "snake_case"
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+# method-rgx =
+
+# Naming style matching correct module names.
+module-naming-style = "snake_case"
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+# module-rgx =
+
+# Colon-delimited sets of names that determine each other's naming style when the
+# name regexes allow several styles.
+# name-group =
+
+# Regular expression which should only match function or class names that do not
+# require a docstring.
+no-docstring-rgx = "^_"
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties. These
+# decorators are taken in consideration only for invalid-name.
+property-classes = ["abc.abstractproperty"]
+
+# Regular expression matching correct type alias names. If left empty, type alias
+# names will be checked with the set naming style.
+# typealias-rgx =
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+# typevar-rgx =
+
+# Naming style matching correct variable names.
+variable-naming-style = "snake_case"
+
+# Regular expression matching correct variable names. Overrides variable-naming-
+# style. If left empty, variable names will be checked with the set naming style.
+# variable-rgx =
+
+[tool.pylint.classes]
+# Warn about protected attribute access inside special methods
+# check-protected-access-in-special-methods =
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods = ["__init__", "__new__", "setUp", "asyncSetUp", "__post_init__"]
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected = ["_asdict", "_fields", "_replace", "_source", "_make", "os._exit"]
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg = ["cls"]
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg = ["mcs"]
+
+[tool.pylint.design]
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+# exclude-too-few-public-methods =
+
+# List of qualified class names to ignore when counting class parents (see R0901)
+# ignored-parents =
+
+# Maximum number of arguments for function / method.
+max-args = 10
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes = 20
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr = 5
+
+# Maximum number of branch for function / method body.
+max-branches = 50
+
+# Maximum number of locals for function / method body.
+max-locals = 20
+
+# Maximum number of parents for a class (see R0901).
+max-parents = 7
+
+# Maximum number of positional arguments for function / method.
+max-positional-arguments = 10
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods = 100
+
+# Maximum number of return / yield for function / method body.
+max-returns = 15
+
+# Maximum number of statements in function / method body.
+max-statements = 500
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods = 2
+
+[tool.pylint.exceptions]
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions = ["builtins.BaseException", "builtins.Exception"]
+
+[tool.pylint.format]
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+# expected-line-ending-format =
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines = "^\\s*(# )?<?https?://\\S+>?$"
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren = 2
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string = "  "
+
+# Maximum number of characters on a single line.
+max-line-length = 160
+
+# Maximum number of lines in a module.
+max-module-lines = 5000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+# single-line-class-stmt =
+
+# Allow the body of an if to be on the same line as the test if there is no else.
+# single-line-if-stmt =
+
+[tool.pylint.imports]
+# List of modules that can be imported at any level, not just the top level one.
+# allow-any-import-level =
+
+# Allow explicit reexports by alias from a package __init__.
+# allow-reexport-from-package =
+
+# Allow wildcard imports from modules that define __all__.
+# allow-wildcard-with-all =
+
+# Deprecated modules which should not be used, separated by a comma.
+# deprecated-modules =
+
+# Output a graph (.gv or any supported image format) of external dependencies to
+# the given file (report RP0402 must not be disabled).
+# ext-import-graph =
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be disabled).
+# import-graph =
+
+# Output a graph (.gv or any supported image format) of internal dependencies to
+# the given file (report RP0402 must not be disabled).
+# int-import-graph =
+
+# Force import order to recognize a module as part of the standard compatibility
+# libraries.
+# known-standard-library =
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party = ["enchant"]
+
+# Couples of modules and preferred modules, separated by a comma.
+# preferred-modules =
+
+[tool.pylint.logging]
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style = "old"
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules = ["logging"]
+
+[tool.pylint."messages control"]
+# Only show warnings with the listed confidence levels. Leave empty to show all.
+# Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence = ["HIGH", "CONTROL_FLOW", "INFERENCE", "INFERENCE_FAILURE", "UNDEFINED"]
+
+# Disable the message, report, category or checker with the given id(s). You can
+# either give multiple identifiers separated by comma (,) or put this option
+# multiple times (only on the command line, not in the configuration file where
+# it should appear only once). You can also use "--disable=all" to disable
+# everything first and then re-enable specific checks. For example, if you want
+# to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable = ["raw-checker-failed", "bad-inline-option", "locally-disabled", "file-ignored", "suppressed-message", "useless-suppression", "deprecated-pragma", "use-implicit-booleaness-not-comparison-to-string", "use-implicit-booleaness-not-comparison-to-zero", "use-symbolic-message-instead"]
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where it
+# should appear only once). See also the "--disable" option for examples.
+# enable =
+
+[tool.pylint.method_args]
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods = ["requests.api.delete", "requests.api.get", "requests.api.head", "requests.api.options", "requests.api.patch", "requests.api.post", "requests.api.put", "requests.api.request"]
+
+[tool.pylint.miscellaneous]
+# List of note tags to take in consideration, separated by a comma.
+notes = ["FIXME", "XXX", "TODO"]
+
+# Regular expression of note tags to take in consideration.
+# notes-rgx =
+
+[tool.pylint.refactoring]
+# Maximum number of nested blocks for function / method body
+max-nested-blocks = 5
+
+# Complete name of functions that never returns. When checking for inconsistent-
+# return-statements if a never returning function is called then it will be
+# considered as an explicit return statement and no message will be printed.
+never-returning-functions = ["sys.exit", "argparse.parse_error"]
+
+# Let 'consider-using-join' be raised when the separator to join on would be non-
+# empty (resulting in expected fixes of the type: ``"- " + " - ".join(items)``)
+suggest-join-with-non-empty-separator = true
+
+[tool.pylint.reports]
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each category,
+# as well as 'statement' which is the total number of statements analyzed. This
+# score is used by the global evaluation report (RP0004).
+evaluation = "max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))"
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+# msg-template =
+
+# Set the output format. Available formats are: 'text', 'parseable', 'colorized',
+# 'json2' (improved json format), 'json' (old json format), msvs (visual studio)
+# and 'github' (GitHub actions). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+# output-format =
+
+# Tells whether to display a full report or only the messages.
+# reports =
+
+# Activate the evaluation score.
+score = true
+
+[tool.pylint.similarities]
+# Comments are removed from the similarity computation
+ignore-comments = true
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings = true
+
+# Imports are removed from the similarity computation
+ignore-imports = true
+
+# Signatures are removed from the similarity computation
+ignore-signatures = true
+
+# Minimum lines number of a similarity.
+min-similarity-lines = 4
+
+[tool.pylint.spelling]
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions = 4
+
+# Spelling dictionary name. Available dictionaries: en_AG (hunspell), en_AU
+# (hunspell), en_BS (hunspell), en_BW (hunspell), en_BZ (hunspell), en_CA
+# (hunspell), en_DK (hunspell), en_GB (hunspell), en_GH (hunspell), en_HK
+# (hunspell), en_IE (hunspell), en_IN (hunspell), en_JM (hunspell), en_MW
+# (hunspell), en_NA (hunspell), en_NG (hunspell), en_NZ (hunspell), en_PH
+# (hunspell), en_SG (hunspell), en_TT (hunspell), en_US (hunspell), en_ZA
+# (hunspell), en_ZM (hunspell), en_ZW (hunspell).
+# spelling-dict =
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives = "fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:"
+
+# List of comma separated words that should not be checked.
+# spelling-ignore-words =
+
+# A path to a file that contains the private dictionary; one word per line.
+# spelling-private-dict-file =
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+# spelling-store-unknown-words =
+
+[tool.pylint.typecheck]
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators = ["contextlib.contextmanager"]
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+# generated-members =
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# class is considered mixin if its name matches the mixin-class-rgx option.
+# Tells whether to warn about missing members when the owner of the attribute is
+# inferred to be None.
+ignore-none = true
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference can
+# return multiple potential results while evaluating a Python object, but some
+# branches might not be evaluated, which results in partial inference. In that
+# case, it might be useful to still emit no-member and other checks for the rest
+# of the inferred objects.
+ignore-on-opaque-inference = true
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins = ["no-member", "not-async-context-manager", "not-context-manager", "attribute-defined-outside-init"]
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes = ["optparse.Values", "thread._local", "_thread._local", "argparse.Namespace"]
+
+# Show a hint with possible names when a member name was not found. The aspect of
+# finding the hint is based on edit distance.
+missing-member-hint = true
+
+# The maximum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance = 1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices = 1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx = ".*[Mm]ixin"
+
+# List of decorators that change the signature of a decorated function.
+# signature-mutators =
+
+[tool.pylint.variables]
+# List of additional names supposed to be defined in builtins. Remember that you
+# should avoid defining new builtins when possible.
+# additional-builtins =
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables = true
+
+# List of names allowed to shadow builtins
+# allowed-redefined-builtins =
+
+# List of strings which can identify a callback function by name. A callback name
+# must start or end with one of those strings.
+callbacks = ["cb_", "_cb"]
+
+# A regular expression matching the name of dummy variables (i.e. expected to not
+# be used).
+dummy-variables-rgx = "_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_"
+
+# Argument names that match this expression will be ignored.
+ignored-argument-names = "_.*|^ignored_|^unused_"
+
+# Tells whether we should check for unused import in __init__ files.
+# init-import =
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules = ["six.moves", "past.builtins", "future.builtins", "builtins", "io"]
+
+

--- a/python/lammps/__init__.py
+++ b/python/lammps/__init__.py
@@ -52,3 +52,8 @@ def get_version_number():
   return t.tm_year*10000 + t.tm_mon*100 + t.tm_mday
 
 __version__ = get_version_number()
+
+# Local Variables:
+# fill-column: 100
+# python-indent-offset: 2
+# End:

--- a/python/lammps/__init__.py
+++ b/python/lammps/__init__.py
@@ -15,38 +15,39 @@ from .pylammps import *                 # lgtm [py/polluting-import]
 
 # convert installed module string version to numeric version
 def get_version_number():
-    import time
-    from os.path import join
-    from sys import version_info
+  # pylint: disable=C0415
+  import time
+  from os import path
+  from sys import version_info
 
-    # must report 0 when inside LAMMPS source tree
-    if __file__.find(join('python', 'lammps', '__init__.py')) > 0:
-        return 0
+  # must report 0 when inside LAMMPS source tree
+  if __file__.find(path.join('python', 'lammps', '__init__.py')) > 0:
+    return 0
 
-    if version_info.major < 3 or (version_info.major == 3 and version_info.minor < 6):
-        raise SystemError('LAMMPS only supports Python version 3.6 or later')
+  if version_info.major < 3 or (version_info.major == 3 and version_info.minor < 6):
+    raise SystemError('LAMMPS only supports Python version 3.6 or later')
 
-    vstring = None
-    if version_info.major == 3 and version_info.minor >= 8:
-        from importlib.metadata import version, PackageNotFoundError
-        try:
-            vstring = version('lammps')
-        except PackageNotFoundError:
-            # nothing to do, ignore
-            pass
+  vstring = None
+  if version_info.major == 3 and version_info.minor >= 8:
+    from importlib.metadata import version, PackageNotFoundError
+    try:
+      vstring = version('lammps')
+    except PackageNotFoundError:
+      # nothing to do, ignore
+      pass
 
-    else:
-        from pkg_resources import get_distribution, DistributionNotFound
-        try:
-            vstring = get_distribution('lammps').version
-        except DistributionNotFound:
-            # nothing to do, ignore
-            pass
+  else:
+    from pkg_resources import get_distribution, DistributionNotFound
+    try:
+      vstring = get_distribution('lammps').version
+    except DistributionNotFound:
+      # nothing to do, ignore
+      pass
 
-    if not vstring:
-        return 0
+  if not vstring:
+    return 0
 
-    t = time.strptime(vstring, "%Y.%m.%d")
-    return t.tm_year*10000 + t.tm_mon*100 + t.tm_mday
+  t = time.strptime(vstring, "%Y.%m.%d")
+  return t.tm_year*10000 + t.tm_mon*100 + t.tm_mday
 
 __version__ = get_version_number()

--- a/python/lammps/__init__.py
+++ b/python/lammps/__init__.py
@@ -15,6 +15,7 @@ from .pylammps import *                 # lgtm [py/polluting-import]
 
 # convert installed module string version to numeric version
 def get_version_number():
+  """Extract LAMMPS version string and convert to number"""
   # pylint: disable=C0415
   import time
   from os import path

--- a/python/lammps/constants.py
+++ b/python/lammps/constants.py
@@ -65,3 +65,8 @@ def get_ctypes_int(size):
   if size == 8:
     return c_int64
   return c_int
+
+# Local Variables:
+# fill-column: 100
+# python-indent-offset: 2
+# End:

--- a/python/lammps/constants.py
+++ b/python/lammps/constants.py
@@ -11,8 +11,10 @@
 #   See the README file in the top-level LAMMPS directory.
 # -------------------------------------------------------------------------
 
-# various symbolic constants to be used
-# in certain calls to select data formats
+"""
+various symbolic constants to be used
+in certain calls to select data formats
+"""
 
 # these must be kept in sync with the enums in src/library.h, src/lmptype.h,
 # tools/swig/lammps.i, examples/COUPLE/plugin/liblammpsplugin.h,
@@ -55,9 +57,11 @@ LMP_BUFSIZE        = 1024
 # -------------------------------------------------------------------------
 
 def get_ctypes_int(size):
+  """return ctypes type matching the configured C/C++ integer size in LAMMPS"""
+  # pylint: disable=C0415
   from ctypes import c_int, c_int32, c_int64
   if size == 4:
     return c_int32
-  elif size == 8:
+  if size == 8:
     return c_int64
   return c_int

--- a/python/lammps/core.py
+++ b/python/lammps/core.py
@@ -87,9 +87,9 @@ class command_wrapper:
         args = list(args)
         args[0] = lammps(ptr=args[0])
         x(*args)
-        setattr(__main__, func_name, handler)
-        return func_name
-      return x
+      setattr(__main__, func_name, handler)
+      return func_name
+    return x
 
   def __getattr__(self, name):
     """
@@ -112,7 +112,7 @@ class command_wrapper:
       # Python 3.6+ maintains ordering of kwarg keys
       for kw, arg in kwargs.items():
         cmd_args.append(kw)
-        if isinstance(arg,bool):
+        if isinstance(arg, bool):
           cmd_args.append("true" if arg else "false")
         else:
           cmd_args.append(str(self._wrap_args(arg)))

--- a/python/lammps/core.py
+++ b/python/lammps/core.py
@@ -90,7 +90,6 @@ class command_wrapper:
         setattr(__main__, func_name, handler)
         return func_name
       return x
-    return None
 
   def __getattr__(self, name):
     """

--- a/python/lammps/core.py
+++ b/python/lammps/core.py
@@ -12,11 +12,10 @@
 # -------------------------------------------------------------------------
 # Python wrapper for the LAMMPS library via ctypes
 
-# for python2/3 compatibility
-
-from __future__ import print_function
-
+# avoid pylint warnings about naming conventions
+# pylint: disable=C0103
 import os
+import platform
 from ctypes import CDLL, POINTER, RTLD_GLOBAL, CFUNCTYPE, py_object, byref, cast, sizeof, \
   create_string_buffer, c_int, c_int32, c_int64, c_double, c_void_p, c_char_p, c_char,    \
   pythonapi
@@ -58,14 +57,10 @@ class ExceptionCheck:
 
 # -------------------------------------------------------------------------
 
-class command_wrapper(object):
+class command_wrapper:
   def __init__(self, lmp):
     self.lmp = lmp
     self.auto_flush = False
-
-  def lmp_print(self, s):
-    """ needed for Python2 compatibility, since print is a reserved keyword """
-    return self.__getattr__("print")(s)
 
   def __dir__(self):
     return sorted(set(['angle_coeff', 'angle_style', 'atom_modify', 'atom_style', 'atom_style',
@@ -81,19 +76,21 @@ class command_wrapper(object):
     'variable', 'velocity', 'write_restart'] + self.lmp.available_styles("command")))
 
   def _wrap_args(self, x):
-      if callable(x):
-          import hashlib
-          import __main__
-          sha = hashlib.sha256()
-          sha.update(str(x).encode())
-          func_name = f"_lmp_cb_{sha.hexdigest()}"
-          def handler(*args, **kwargs):
-              args = list(args)
-              args[0] = lammps(ptr=args[0])
-              x(*args)
-          setattr(__main__, func_name, handler)
-          return func_name
+    if callable(x):
+      # pylint: disable=C0415
+      import hashlib
+      import __main__
+      sha = hashlib.sha256()
+      sha.update(str(x).encode())
+      func_name = f"_lmp_cb_{sha.hexdigest()}"
+      def handler(*args, **kwargs):
+        args = list(args)
+        args[0] = lammps(ptr=args[0])
+        x(*args)
+        setattr(__main__, func_name, handler)
+        return func_name
       return x
+    return None
 
   def __getattr__(self, name):
     """
@@ -114,22 +111,22 @@ class command_wrapper(object):
       cmd_args = [name] + [str(self._wrap_args(x)) for x in args]
 
       # Python 3.6+ maintains ordering of kwarg keys
-      for k in kwargs.keys():
-          cmd_args.append(k)
-          if type(kwargs[k]) == bool:
-              cmd_args.append("true" if kwargs[k] else "false")
-          else:
-              cmd_args.append(str(self._wrap_args(kwargs[k])))
+      for kw, arg in kwargs.items():
+        cmd_args.append(kw)
+        if isinstance(arg,bool):
+          cmd_args.append("true" if arg else "false")
+        else:
+          cmd_args.append(str(self._wrap_args(arg)))
 
       cmd = ' '.join(cmd_args)
       self.lmp.command(cmd)
       if self.auto_flush:
-          self.lmp.flush_buffers()
+        self.lmp.flush_buffers()
     return handler
 
 # -------------------------------------------------------------------------
 
-class lammps(object):
+class lammps:
   """Create an instance of the LAMMPS Python class.
 
   .. _mpi4py_docs: https://mpi4py.readthedocs.io/
@@ -169,7 +166,7 @@ class lammps(object):
     # for windows installers the shared library is in a different folder
     winpath = abspath(os.path.join(modpath,'..','..','bin'))
     # allow override for running tests on Windows
-    if (os.environ.get("LAMMPSDLLPATH")):
+    if os.environ.get("LAMMPSDLLPATH"):
       winpath = os.environ.get("LAMMPSDLLPATH")
     self.lib = None
     self.lmp = None
@@ -183,7 +180,8 @@ class lammps(object):
     # load a shared object.
 
     try:
-      if ptr is not None: self.lib = CDLL("",RTLD_GLOBAL)
+      if ptr is not None:
+        self.lib = CDLL("",RTLD_GLOBAL)
     except OSError:
       self.lib = None
 
@@ -196,21 +194,17 @@ class lammps(object):
     #   typically requires LD_LIBRARY_PATH to be set appropriately
     # guess shared library extension based on OS, if not inferred from actual file
 
-    if any([f.startswith('liblammps') and f.endswith('.dylib')
-            for f in os.listdir(modpath)]):
+    if any(f.startswith('liblammps') and f.endswith('.dylib') for f in os.listdir(modpath)):
       lib_ext = ".dylib"
-    elif any([f.startswith('liblammps') and f.endswith('.dll')
-              for f in os.listdir(modpath)]):
+    elif any(f.startswith('liblammps') and f.endswith('.dll') for f in os.listdir(modpath)):
       lib_ext = ".dll"
-    elif os.path.exists(winpath) and any([f.startswith('liblammps') and f.endswith('.dll')
-                  for f in os.listdir(winpath)]):
+    elif os.path.exists(winpath) and \
+         any(f.startswith('liblammps') and f.endswith('.dll') for f in os.listdir(winpath)):
       lib_ext = ".dll"
       modpath = winpath
-    elif any([f.startswith('liblammps') and f.endswith('.so')
-              for f in os.listdir(modpath)]):
+    elif any(f.startswith('liblammps') and f.endswith('.so') for f in os.listdir(modpath)):
       lib_ext = ".so"
     else:
-      import platform
       if platform.system() == "Darwin":
         lib_ext = ".dylib"
       elif platform.system() == "Windows":
@@ -220,14 +214,14 @@ class lammps(object):
 
     if not self.lib:
       if name:
-        libpath = join(modpath,"liblammps_%s" % name + lib_ext)
+        libpath = join(modpath,f'liblammps_{name + lib_ext}')
       else:
-        libpath = join(modpath,"liblammps" + lib_ext)
+        libpath = join(modpath,'liblammps' + lib_ext)
       if not os.path.isfile(libpath):
         if name:
-          libpath = "liblammps_%s" % name + lib_ext
+          libpath = f'liblammps_{name + lib_ext}'
         else:
-          libpath = "liblammps" + lib_ext
+          libpath = 'liblammps' + lib_ext
       self.lib = CDLL(libpath,RTLD_GLOBAL)
 
     # declare all argument and return types for all library methods here.
@@ -442,10 +436,11 @@ class lammps(object):
     # only needed if LAMMPS has been compiled with MPI support.
     self.has_mpi4py = False
     if self.has_mpi_support:
+      # pylint: disable=C0415
       try:
         from mpi4py import __version__ as mpi4py_version
         # tested to work with mpi4py versions 2, 3, and 4
-        self.has_mpi4py = mpi4py_version.split('.')[0] in ['2','3','4']
+        self.has_mpi4py = mpi4py_version.split('.',maxsplit=1)[0] in ['2','3','4']
       except ImportError:
         # ignore failing import
         pass
@@ -464,14 +459,16 @@ class lammps(object):
       # need to adjust for type of MPI communicator object
       # allow for int (like MPICH) or void* (like OpenMPI)
       if self.has_mpi_support and self.has_mpi4py:
+        # pylint: disable=C0415
         from mpi4py import MPI
         self.MPI = MPI
 
       if comm is not None:
+        # pylint: disable=I1101
         if not self.has_mpi_support:
-          raise Exception('LAMMPS not compiled with real MPI library')
+          raise RuntimeError('LAMMPS not compiled with real MPI library')
         if not self.has_mpi4py:
-          raise Exception('Python mpi4py version is not 2, 3, or 4')
+          raise RuntimeError('Python mpi4py version is not 2, 3, or 4')
         if self.MPI._sizeof(self.MPI.Comm) == sizeof(c_int):
           MPI_Comm = c_int
         else:
@@ -479,7 +476,7 @@ class lammps(object):
 
         # Detect whether LAMMPS and mpi4py definitely use different MPI libs
         if sizeof(MPI_Comm) != self.lib.lammps_config_has_mpi_support():
-          raise Exception('Inconsistent MPI library in LAMMPS and mpi4py')
+          raise RuntimeError('Inconsistent MPI library in LAMMPS and mpi4py')
 
         narg = 0
         cargs = None
@@ -487,9 +484,9 @@ class lammps(object):
           myargs = ["lammps".encode()]
           narg = len(cmdargs) + 1
           for arg in cmdargs:
-            if type(arg) is str:
+            if isinstance(arg,str):
               myargs.append(arg.encode())
-            elif type(arg) is bytes:
+            elif isinstance(arg,bytes):
               myargs.append(arg)
             else:
               raise TypeError('Unsupported cmdargs type ', type(arg))
@@ -506,15 +503,16 @@ class lammps(object):
 
       else:
         if self.has_mpi4py and self.has_mpi_support:
+          # pylint: disable=I1101
           self.comm = self.MPI.COMM_WORLD
         self.opened = 1
         if cmdargs is not None:
           myargs = ["lammps".encode()]
           narg = len(cmdargs) + 1
           for arg in cmdargs:
-            if type(arg) is str:
+            if isinstance(arg,str):
               myargs.append(arg.encode())
-            elif type(arg) is bytes:
+            elif isinstance(arg,bytes):
               myargs.append(arg)
             else:
               raise TypeError('Unsupported cmdargs type ', type(arg))
@@ -535,7 +533,7 @@ class lammps(object):
 
     # check if library initilialization failed
     if not self.lmp:
-      raise(RuntimeError("Failed to initialize LAMMPS object"))
+      raise RuntimeError("Failed to initialize LAMMPS object")
 
     # optional numpy support (lazy loading)
     self._numpy = None
@@ -545,14 +543,16 @@ class lammps(object):
 
     # check if liblammps version matches the installed python module version
     # but not for in-place usage, i.e. when the version is 0
-    import lammps
-    if lammps.__version__ > 0 and lammps.__version__ != self.lib.lammps_version(self.lmp):
-        raise(AttributeError("LAMMPS Python module installed for LAMMPS version %d, but shared library is version %d" \
-                % (lammps.__version__, self.lib.lammps_version(self.lmp))))
+    # pylint: disable=C0415 disable=C0209
+    import lammps as mylammps
+    if mylammps.__version__ > 0 and mylammps.__version__ != self.lib.lammps_version(self.lmp):
+      raise AttributeError("LAMMPS Python module installed for LAMMPS version %d, but shared library is version %d" \
+                           % (mylammps.__version__, self.lib.lammps_version(self.lmp)))
 
     # add way to insert Python callback for fix external
     self.callback = {}
-    self.FIX_EXTERNAL_CALLBACK_FUNC = CFUNCTYPE(None, py_object, self.c_bigint, c_int, POINTER(self.c_tagint), POINTER(POINTER(c_double)), POINTER(POINTER(c_double)))
+    self.FIX_EXTERNAL_CALLBACK_FUNC = CFUNCTYPE(None, py_object, self.c_bigint, c_int, \
+                                                POINTER(self.c_tagint), POINTER(POINTER(c_double)), POINTER(POINTER(c_double)))
     self.lib.lammps_set_fix_external_callback.argtypes = [c_void_p, c_char_p, self.FIX_EXTERNAL_CALLBACK_FUNC, py_object]
     self.lib.lammps_set_fix_external_callback.restype = None
 
@@ -585,6 +585,7 @@ class lammps(object):
     :rtype: numpy_wrapper
     """
     if not self._numpy:
+      # pylint: disable=C0415
       from .numpy_wrapper import numpy_wrapper
       self._numpy = numpy_wrapper(self)
     return self._numpy
@@ -640,6 +641,7 @@ class lammps(object):
     :rtype: ipython.wrapper
     """
     if not self._ipython:
+      # pylint: disable=C0415
       from .ipython import wrapper
       self._ipython = wrapper(self)
     return self._ipython
@@ -687,8 +689,10 @@ class lammps(object):
     :param error_text:
     :type error_text:  string
     """
-    if error_text: new_error_text = error_text.encode()
-    else: new_error_text = "(unknown error)".encode()
+    if error_text:
+      new_error_text = error_text.encode()
+    else:
+      new_error_text = "(unknown error)".encode()
 
     with ExceptionCheck(self):
       self.lib.lammps_error(self.lmp, error_type, new_error_text)
@@ -735,12 +739,12 @@ class lammps(object):
     """
 
     if self.has_mpi4py and self.has_mpi_support:
-        from mpi4py import MPI
-        f_comm = self.lib.lammps_get_mpi_comm(self.lmp)
-        c_comm = MPI.Comm.f2py(f_comm)
-        return c_comm
-    else:
-        return None
+      # pylint: disable=I1101 disable=C0415
+      from mpi4py import MPI
+      f_comm = self.lib.lammps_get_mpi_comm(self.lmp)
+      c_comm = MPI.Comm.f2py(f_comm)
+      return c_comm
+    return None
 
   # -------------------------------------------------------------------------
 
@@ -767,8 +771,10 @@ class lammps(object):
     :return: expanded string
     :rtype: string
     """
-    if line: newline = line.encode()
-    else: return None
+    if line:
+      newline = line.encode()
+    else:
+      return None
 
     with ExceptionCheck(self):
       strptr = self.lib.lammps_expand(self.lmp, newline)
@@ -797,8 +803,10 @@ class lammps(object):
     :param path: Name of the file/path with LAMMPS commands
     :type path:  string
     """
-    if path: newpath = path.encode()
-    else: return
+    if path:
+      newpath = path.encode()
+    else:
+      return
 
     with ExceptionCheck(self):
       self.lib.lammps_file(self.lmp, newpath)
@@ -814,8 +822,10 @@ class lammps(object):
     :param cmd: a single lammps command
     :type cmd:  string
     """
-    if cmd: newcmd = cmd.encode()
-    else: return
+    if cmd:
+      newcmd = cmd.encode()
+    else:
+      return
 
     with ExceptionCheck(self):
       self.lib.lammps_command(self.lmp, newcmd)
@@ -832,7 +842,7 @@ class lammps(object):
     :param cmdlist: a single lammps command
     :type cmdlist:  list of strings
     """
-    cmds = [x.encode() for x in cmdlist if type(x) is str]
+    cmds = [x.encode() for x in cmdlist if isinstance(x,str)]
     narg = len(cmdlist)
     args = (c_char_p * narg)(*cmds)
     self.lib.lammps_commands_list.argtypes = [c_void_p, c_int, c_char_p * narg]
@@ -852,8 +862,10 @@ class lammps(object):
     :param multicmd: text block of lammps commands
     :type multicmd:  string
     """
-    if type(multicmd) is str: newmulticmd = multicmd.encode()
-    else: newmulticmd = multicmd
+    if isinstance(multicmd,str):
+      newmulticmd = multicmd.encode()
+    else:
+      newmulticmd = multicmd
 
     with ExceptionCheck(self):
       self.lib.lammps_commands_string(self.lmp,c_char_p(newmulticmd))
@@ -942,8 +954,10 @@ class lammps(object):
     :return: value of thermo keyword
     :rtype: double or None
     """
-    if name: newname = name.encode()
-    else: return None
+    if name:
+      newname = name.encode()
+    else:
+      return None
 
     with ExceptionCheck(self):
       return self.lib.lammps_get_thermo(self.lmp, newname)
@@ -972,7 +986,7 @@ class lammps(object):
     :rtype: dict or None
     """
 
-    rv = dict()
+    rv = {}
     mystep = self.last_thermo_step
     if mystep < 0:
       return None
@@ -1020,8 +1034,10 @@ class lammps(object):
     :return: value of the setting
     :rtype: int
     """
-    if name: newname = name.encode()
-    else: return None
+    if name:
+      newname = name.encode()
+    else:
+      return None
     return int(self.lib.lammps_extract_setting(self.lmp, newname))
 
   # -------------------------------------------------------------------------
@@ -1043,8 +1059,10 @@ class lammps(object):
     :return: data type of global property, see :ref:`py_datatype_constants`
     :rtype: int
     """
-    if name: newname = name.encode()
-    else: return None
+    if name:
+      newname = name.encode()
+    else:
+      return None
     return self.lib.lammps_extract_global_datatype(self.lmp, newname)
 
   # -------------------------------------------------------------------------
@@ -1089,8 +1107,10 @@ class lammps(object):
     else:
       veclen = 1
 
-    if name: newname = name.encode()
-    else: return None
+    if name:
+      newname = name.encode()
+    else:
+      return None
 
     if dtype == LAMMPS_INT:
       self.lib.lammps_extract_global.restype = POINTER(c_int32)
@@ -1116,7 +1136,7 @@ class lammps(object):
         for i in range(0,veclen):
           result.append(target_type(ptr[i]))
         return result
-      else: return target_type(ptr[0])
+      return target_type(ptr[0])
     return None
 
   # -------------------------------------------------------------------------
@@ -1145,8 +1165,7 @@ class lammps(object):
 
     if dim < 0:
       return None
-    else:
-      return dim;
+    return dim
 
   # -------------------------------------------------------------------------
   # get access to pair style extractable data
@@ -1178,7 +1197,7 @@ class lammps(object):
     dim = self.extract_pair_dimension(name)
     if dim is None:
       return None
-    elif dim == 0:
+    if dim == 0:
       self.lib.lammps_extract_pair.restype = POINTER(c_double)
     elif dim == 1:
       self.lib.lammps_extract_pair.restype = POINTER(c_double)
@@ -1192,12 +1211,12 @@ class lammps(object):
     if ptr:
       if dim == 0:
         return float(ptr[0])
-      elif dim == 1:
+      if dim == 1:
         result = [0.0]
         for i in range(1,ntypes+1):
           result.append(float(ptr[i]))
         return result
-      elif dim == 2:
+      if dim == 2:
         result = []
         inner = []
         for i in range(0,ntypes+1):
@@ -1209,26 +1228,25 @@ class lammps(object):
             inner.append(float(ptr[i][j]))
           result.append(inner)
         return result
-      else:
-        return None
+      return None
     return None
 
   # -------------------------------------------------------------------------
   # map global atom ID to local atom index
 
-  def map_atom(self, id):
+  def map_atom(self, atomid):
     """Map a global atom ID (aka tag) to the local atom index
 
     This is a wrapper around the :cpp:func:`lammps_map_atom`
     function of the C-library interface.
 
-    :param id: atom ID
-    :type id:  int
+    :param atomid: atom ID
+    :type atomid:  int
     :return: local index
     :rtype: int
     """
 
-    tag = self.c_tagint(id)
+    tag = self.c_tagint(atomid)
     return self.lib.lammps_map_atom(self.lmp, byref(tag))
 
   # -------------------------------------------------------------------------
@@ -1250,8 +1268,10 @@ class lammps(object):
     :return: data type of per-atom property (see :ref:`py_datatype_constants`)
     :rtype: int
     """
-    if name: newname = name.encode()
-    else: return None
+    if name:
+      newname = name.encode()
+    else:
+      return None
     return self.lib.lammps_extract_atom_datatype(self.lmp, newname)
 
   # -------------------------------------------------------------------------
@@ -1278,8 +1298,10 @@ class lammps(object):
     :return: data type of per-atom property (see :ref:`py_datatype_constants`)
     :rtype: int
     """
-    if name: newname = name.encode()
-    else: return None
+    if name:
+      newname = name.encode()
+    else:
+      return None
     return self.lib.lammps_extract_atom_size(self.lmp, newname, dtype)
 
   # -------------------------------------------------------------------------
@@ -1322,8 +1344,10 @@ class lammps(object):
     if dtype == LAMMPS_AUTODETECT:
       dtype = self.extract_atom_datatype(name)
 
-    if name: newname = name.encode()
-    else: return None
+    if name:
+      newname = name.encode()
+    else:
+      return None
 
     if dtype == LAMMPS_INT:
       self.lib.lammps_extract_atom.restype = POINTER(c_int32)
@@ -1340,9 +1364,9 @@ class lammps(object):
     else: return None
 
     ptr = self.lib.lammps_extract_atom(self.lmp, newname)
-    if ptr: return ptr
-    else:   return None
-
+    if ptr:
+      return ptr
+    return None
 
   # -------------------------------------------------------------------------
 
@@ -1367,8 +1391,10 @@ class lammps(object):
     :return: requested data as scalar, pointer to 1d or 2d double array, or None
     :rtype: c_double, ctypes.POINTER(c_double), ctypes.POINTER(ctypes.POINTER(c_double)), or NoneType
     """
-    if cid: newcid = cid.encode()
-    else: return None
+    if cid:
+      newcid = cid.encode()
+    else:
+      return None
 
     if ctype == LMP_TYPE_SCALAR:
       if cstyle == LMP_STYLE_GLOBAL:
@@ -1376,9 +1402,9 @@ class lammps(object):
         with ExceptionCheck(self):
           ptr = self.lib.lammps_extract_compute(self.lmp,newcid,cstyle,ctype)
         return ptr[0]
-      elif cstyle == LMP_STYLE_ATOM:
+      if cstyle == LMP_STYLE_ATOM:
         return None
-      elif cstyle == LMP_STYLE_LOCAL:
+      if cstyle == LMP_STYLE_LOCAL:
         self.lib.lammps_extract_compute.restype = POINTER(c_int)
         with ExceptionCheck(self):
           ptr = self.lib.lammps_extract_compute(self.lmp,newcid,cstyle,ctype)
@@ -1397,14 +1423,14 @@ class lammps(object):
       return ptr
 
     elif ctype == LMP_SIZE_COLS:
-      if cstyle == LMP_STYLE_GLOBAL or cstyle == LMP_STYLE_ATOM or cstyle == LMP_STYLE_LOCAL:
+      if cstyle in (LMP_STYLE_GLOBAL,LMP_STYLE_ATOM,LMP_STYLE_LOCAL):
         self.lib.lammps_extract_compute.restype = POINTER(c_int)
         with ExceptionCheck(self):
           ptr = self.lib.lammps_extract_compute(self.lmp,newcid,cstyle,ctype)
         return ptr[0]
 
-    elif ctype == LMP_SIZE_VECTOR or ctype == LMP_SIZE_ROWS:
-      if cstyle == LMP_STYLE_GLOBAL or cstyle == LMP_STYLE_LOCAL:
+    elif ctype in (LMP_SIZE_VECTOR,LMP_SIZE_ROWS):
+      if cstyle in (LMP_STYLE_GLOBAL,LMP_STYLE_LOCAL):
         self.lib.lammps_extract_compute.restype = POINTER(c_int)
         with ExceptionCheck(self):
           ptr = self.lib.lammps_extract_compute(self.lmp,newcid,cstyle,ctype)
@@ -1452,8 +1478,10 @@ class lammps(object):
     :rtype: c_double, ctypes.POINTER(c_double), ctypes.POINTER(ctypes.POINTER(c_double)), or NoneType
 
     """
-    if fid: newfid = fid.encode()
-    else: return None
+    if fid:
+      newfid = fid.encode()
+    else:
+      return None
 
     if fstyle == LMP_STYLE_GLOBAL:
       if ftype in (LMP_TYPE_SCALAR, LMP_TYPE_VECTOR, LMP_TYPE_ARRAY):
@@ -1463,15 +1491,14 @@ class lammps(object):
         result = ptr[0]
         self.lib.lammps_free(ptr)
         return result
-      elif ftype in (LMP_SIZE_VECTOR, LMP_SIZE_ROWS, LMP_SIZE_COLS):
+      if ftype in (LMP_SIZE_VECTOR, LMP_SIZE_ROWS, LMP_SIZE_COLS):
         self.lib.lammps_extract_fix.restype = POINTER(c_int)
         with ExceptionCheck(self):
           ptr = self.lib.lammps_extract_fix(self.lmp,newfid,fstyle,ftype,nrow,ncol)
         return ptr[0]
-      else:
-        return None
+      return None
 
-    elif fstyle == LMP_STYLE_ATOM:
+    if fstyle == LMP_STYLE_ATOM:
       if ftype == LMP_TYPE_VECTOR:
         self.lib.lammps_extract_fix.restype = POINTER(c_double)
       elif ftype == LMP_TYPE_ARRAY:
@@ -1484,10 +1511,9 @@ class lammps(object):
         ptr = self.lib.lammps_extract_fix(self.lmp,newfid,fstyle,ftype,nrow,ncol)
       if ftype == LMP_SIZE_COLS:
         return ptr[0]
-      else:
-        return ptr
+      return ptr
 
-    elif fstyle == LMP_STYLE_LOCAL:
+    if fstyle == LMP_STYLE_LOCAL:
       if ftype == LMP_TYPE_VECTOR:
         self.lib.lammps_extract_fix.restype = POINTER(c_double)
       elif ftype == LMP_TYPE_ARRAY:
@@ -1500,10 +1526,8 @@ class lammps(object):
         ptr = self.lib.lammps_extract_fix(self.lmp,newfid,fstyle,ftype,nrow,ncol)
       if ftype in (LMP_TYPE_VECTOR, LMP_TYPE_ARRAY):
         return ptr
-      else:
-        return ptr[0]
-    else:
-      return None
+      return ptr[0]
+    return None
 
   # -------------------------------------------------------------------------
   # extract variable info
@@ -1538,32 +1562,40 @@ class lammps(object):
     :return: the requested data
     :rtype: c_double, (c_double), or NoneType
     """
-    if name: newname = name.encode()
-    else: return None
-    if group: newgroup = group.encode()
-    else: newgroup = None
+    if name:
+      newname = name.encode()
+    else:
+      return None
+    if group:
+      newgroup = group.encode()
+    else:
+      newgroup = None
     if vartype is None :
       vartype = self.lib.lammps_extract_variable_datatype(self.lmp, newname)
     if vartype == LMP_VAR_EQUAL:
       self.lib.lammps_extract_variable.restype = POINTER(c_double)
       with ExceptionCheck(self):
         ptr = self.lib.lammps_extract_variable(self.lmp, newname, newgroup)
-      if ptr: result = ptr[0]
-      else: return None
+      if ptr:
+        result = ptr[0]
+      else:
+        return None
       self.lib.lammps_free(ptr)
       return result
-    elif vartype == LMP_VAR_ATOM:
+    if vartype == LMP_VAR_ATOM:
       nlocal = self.extract_global("nlocal")
       result = (c_double*nlocal)()
       self.lib.lammps_extract_variable.restype = POINTER(c_double)
       with ExceptionCheck(self):
         ptr = self.lib.lammps_extract_variable(self.lmp, newname, newgroup)
       if ptr:
-        for i in range(nlocal): result[i] = ptr[i]
+        for i in range(nlocal):
+          result[i] = ptr[i]
         self.lib.lammps_free(ptr)
-      else: return None
+      else:
+        return None
       return result
-    elif vartype == LMP_VAR_VECTOR :
+    if vartype == LMP_VAR_VECTOR :
       nvector = 0
       self.lib.lammps_extract_variable.restype = POINTER(c_int)
       ptr = self.lib.lammps_extract_variable(self.lmp, newname,
@@ -1581,9 +1613,8 @@ class lammps(object):
           result[i] = values[i]
         # do NOT free the values pointer (points to internal vector data)
         return result
-      else:
-        return None
-    elif vartype == LMP_VAR_STRING :
+      return None
+    if vartype == LMP_VAR_STRING :
       self.lib.lammps_extract_variable.restype = c_char_p
       with ExceptionCheck(self) :
         ptr = self.lib.lammps_extract_variable(self.lmp, newname, newgroup)
@@ -1592,7 +1623,7 @@ class lammps(object):
 
   # -------------------------------------------------------------------------
 
-  def clearstep_compute(self, nextstep):
+  def clearstep_compute(self):
     with ExceptionCheck(self):
       return self.lib.lammps_clearstep_compute(self.lmp)
 
@@ -1637,10 +1668,14 @@ class lammps(object):
     :return: either 0 on success or -1 on failure
     :rtype: int
     """
-    if name: newname = name.encode()
-    else: return -1
-    if value: newvalue = str(value).encode()
-    else: return -1
+    if name:
+      newname = name.encode()
+    else:
+      return -1
+    if value:
+      newvalue = str(value).encode()
+    else:
+      return -1
     with ExceptionCheck(self):
       return self.lib.lammps_set_variable(self.lmp, newname, newvalue)
 
@@ -1661,10 +1696,14 @@ class lammps(object):
     :return: either 0 on success or -1 on failure
     :rtype: int
     """
-    if name: newname = name.encode()
-    else: return -1
-    if value: newvalue = str(value).encode()
-    else: return -1
+    if name:
+      newname = name.encode()
+    else:
+      return -1
+    if value:
+      newvalue = str(value).encode()
+    else:
+      return -1
     with ExceptionCheck(self):
       return self.lib.lammps_set_string_variable(self.lmp,newname,newvalue)
 
@@ -1685,8 +1724,10 @@ class lammps(object):
     :return: either 0 on success or -1 on failure
     :rtype: int
     """
-    if name: newname = name.encode()
-    else: return -1
+    if name:
+      newname = name.encode()
+    else:
+      return -1
     with ExceptionCheck(self):
       return self.lib.lammps_set_internal_variable(self.lmp,newname,value)
 
@@ -1707,8 +1748,10 @@ class lammps(object):
     :rtype: c_double
     """
 
-    if expr: newexpr = expr.encode()
-    else: return None
+    if expr:
+      newexpr = expr.encode()
+    else:
+      return None
 
     with ExceptionCheck(self):
       return self.lib.lammps_eval(self.lmp, newexpr)
@@ -1725,8 +1768,10 @@ class lammps(object):
   #   e.g. for Python list or NumPy or ctypes
 
   def gather_atoms(self,name,dtype,count):
-    if name: newname = name.encode()
-    else: newname = None
+    if name:
+      newname = name.encode()
+    else:
+      newname = None
     natoms = self.get_natoms()
     with ExceptionCheck(self):
       if dtype == 0:
@@ -1742,8 +1787,10 @@ class lammps(object):
   # -------------------------------------------------------------------------
 
   def gather_atoms_concat(self,name,dtype,count):
-    if name: newname = name.encode()
-    else: newname = None
+    if name:
+      newname = name.encode()
+    else:
+      newname = None
     natoms = self.get_natoms()
     with ExceptionCheck(self):
       if dtype == 0:
@@ -1753,12 +1800,14 @@ class lammps(object):
         data = ((count*natoms)*c_double)()
         self.lib.lammps_gather_atoms_concat(self.lmp,newname,dtype,count,data)
       else:
-          return None
+        return None
     return data
 
   def gather_atoms_subset(self,name,dtype,count,ndata,ids):
-    if name: newname = name.encode()
-    else: newname = None
+    if name:
+      newname = name.encode()
+    else:
+      newname = None
     with ExceptionCheck(self):
       if dtype == 0:
         data = ((count*ndata)*c_int)()
@@ -1782,16 +1831,20 @@ class lammps(object):
   #   e.g. for Python list or NumPy or ctypes
 
   def scatter_atoms(self,name,dtype,count,data):
-    if name: newname = name.encode()
-    else: newname = None
+    if name:
+      newname = name.encode()
+    else:
+      newname = None
     with ExceptionCheck(self):
       self.lib.lammps_scatter_atoms(self.lmp,newname,dtype,count,data)
 
   # -------------------------------------------------------------------------
 
   def scatter_atoms_subset(self,name,dtype,count,ndata,ids,data):
-    if name: newname = name.encode()
-    else: newname = None
+    if name:
+      newname = name.encode()
+    else:
+      newname = None
     with ExceptionCheck(self):
       self.lib.lammps_scatter_atoms_subset(self.lmp,newname,dtype,count,ndata,ids,data)
 
@@ -1815,9 +1868,9 @@ class lammps(object):
     """
     nbonds = self.extract_global("nbonds")
     with ExceptionCheck(self):
-        data = ((3*nbonds)*self.c_tagint)()
-        self.lib.lammps_gather_bonds(self.lmp,data)
-        return nbonds,data
+      data = ((3*nbonds)*self.c_tagint)()
+      self.lib.lammps_gather_bonds(self.lmp,data)
+      return nbonds,data
 
   # -------------------------------------------------------------------------
 
@@ -1838,9 +1891,9 @@ class lammps(object):
     """
     nangles = self.extract_global("nangles")
     with ExceptionCheck(self):
-        data = ((4*nangles)*self.c_tagint)()
-        self.lib.lammps_gather_angles(self.lmp,data)
-        return nangles,data
+      data = ((4*nangles)*self.c_tagint)()
+      self.lib.lammps_gather_angles(self.lmp,data)
+      return nangles,data
 
   # -------------------------------------------------------------------------
 
@@ -1861,9 +1914,9 @@ class lammps(object):
     """
     ndihedrals = self.extract_global("ndihedrals")
     with ExceptionCheck(self):
-        data = ((5*ndihedrals)*self.c_tagint)()
-        self.lib.lammps_gather_dihedrals(self.lmp,data)
-        return ndihedrals,data
+      data = ((5*ndihedrals)*self.c_tagint)()
+      self.lib.lammps_gather_dihedrals(self.lmp,data)
+      return ndihedrals,data
 
   # -------------------------------------------------------------------------
 
@@ -1884,9 +1937,9 @@ class lammps(object):
     """
     nimpropers = self.extract_global("nimpropers")
     with ExceptionCheck(self):
-        data = ((5*nimpropers)*self.c_tagint)()
-        self.lib.lammps_gather_impropers(self.lmp,data)
-        return nimpropers,data
+      data = ((5*nimpropers)*self.c_tagint)()
+      self.lib.lammps_gather_impropers(self.lmp,data)
+      return nimpropers,data
 
   # -------------------------------------------------------------------------
 
@@ -1899,8 +1952,10 @@ class lammps(object):
   # NOTE: need to ensure are converting to/from correct Python type
   #   e.g. for Python list or NumPy or ctypes
   def gather(self,name,dtype,count):
-    if name: newname = name.encode()
-    else: newname = None
+    if name:
+      newname = name.encode()
+    else:
+      newname = None
     natoms = self.get_natoms()
     with ExceptionCheck(self):
       if dtype == 0:
@@ -1914,8 +1969,10 @@ class lammps(object):
     return data
 
   def gather_concat(self,name,dtype,count):
-    if name: newname = name.encode()
-    else: newname = None
+    if name:
+      newname = name.encode()
+    else:
+      newname = None
     natoms = self.get_natoms()
     with ExceptionCheck(self):
       if dtype == 0:
@@ -1929,8 +1986,10 @@ class lammps(object):
     return data
 
   def gather_subset(self,name,dtype,count,ndata,ids):
-    if name: newname = name.encode()
-    else: newname = None
+    if name:
+      newname = name.encode()
+    else:
+      newname = None
     with ExceptionCheck(self):
       if dtype == 0:
         data = ((count*ndata)*c_int)()
@@ -1952,14 +2011,18 @@ class lammps(object):
   #   e.g. for Python list or NumPy or ctypes
 
   def scatter(self,name,dtype,count,data):
-    if name: newname = name.encode()
-    else: newname = None
+    if name:
+      newname = name.encode()
+    else:
+      newname = None
     with ExceptionCheck(self):
       self.lib.lammps_scatter(self.lmp,newname,dtype,count,data)
 
   def scatter_subset(self,name,dtype,count,ndata,ids,data):
-    if name: newname = name.encode()
-    else: newname = None
+    if name:
+      newname = name.encode()
+    else:
+      newname = None
     with ExceptionCheck(self):
       self.lib.lammps_scatter_subset(self.lmp,newname,dtype,count,ndata,ids,data)
 
@@ -2006,15 +2069,15 @@ class lammps(object):
 
   # create N atoms on all procs
   # N = global number of atoms
-  # id = ID of each atom (optional, can be None)
-  # type = type of each atom (1 to Ntypes) (required)
+  # atomid = ID of each atom (optional, can be None)
+  # atype = type of each atom (1 to Ntypes) (required)
   # x = coords of each atom as (N,3) array (required)
   # v = velocity of each atom as (N,3) array (optional, can be None)
   # NOTE: how could we ensure are passing correct type to LAMMPS
   #   e.g. for Python list or NumPy, etc
   #   ditto for gather_atoms() above
 
-  def create_atoms(self,n,id,type,x,v=None,image=None,shrinkexceed=False):
+  def create_atoms(self,n,atomid,atype,x,v=None,image=None,shrinkexceed=False):
     """
     Create N atoms from list of coordinates and properties
 
@@ -2034,10 +2097,10 @@ class lammps(object):
 
     :param n: number of atoms for which data is provided
     :type n: int
-    :param id: list of atom IDs with at least n elements or None
-    :type id: list of lammps.tagint
-    :param type: list of atom types
-    :type type: list of int
+    :param atomid: list of atom IDs with at least n elements or None
+    :type atomid: list of lammps.tagint
+    :param atype: list of atom types
+    :type atype: list of int
     :param x: list of coordinates for x-, y-, and z (flat list of 3n entries)
     :type x: list of float
     :param v: list of velocities for x-, y-, and z (flat list of 3n entries) or None (optional)
@@ -2049,10 +2112,10 @@ class lammps(object):
     :return: number of atoms created. 0 if insufficient or invalid data
     :rtype: int
     """
-    if id is not None:
+    if atomid is not None:
       id_lmp = (self.c_tagint*n)()
       try:
-        id_lmp[:] = id[0:n]
+        id_lmp[:] = atomid[0:n]
       except ValueError:
         return 0
     else:
@@ -2060,7 +2123,7 @@ class lammps(object):
 
     type_lmp = (c_int*n)()
     try:
-      type_lmp[:] = type[0:n]
+      type_lmp[:] = atype[0:n]
     except ValueError:
       return 0
 
@@ -2103,7 +2166,7 @@ class lammps(object):
 
   # -------------------------------------------------------------------------
 
-  def create_molecule(self, id, jsonstr):
+  def create_molecule(self, molid, jsonstr):
     """ Create new molecule template from string with JSON data
 
     .. versionadded:: TBD
@@ -2111,15 +2174,19 @@ class lammps(object):
     This is a wrapper around the :cpp:func:`lammps_create_molecule` function
     of the library interface.
 
-    :param id: molecule-id of the new molecule template
+    :param molid: molecule-id of the new molecule template
     :type name: string
     :param jsonstr: JSON data defining a new molecule template
     :type jsonstr: string
     """
-    if id: newid = id.encode()
-    else: newid = None
-    if id: newjsonstr = jsonstr.encode()
-    else: newjsonstr = None
+    if molid:
+      newid = molid.encode()
+    else:
+      newid = None
+    if jsonstr:
+      newjsonstr = jsonstr.encode()
+    else:
+      newjsonstr = None
     with ExceptionCheck(self):
       self.lib.lammps_create_molecule(self.lmp, newid, newjsonstr)
 
@@ -2476,7 +2543,7 @@ class lammps(object):
 
   # -------------------------------------------------------------------------
 
-  def available_plugins(self, category):
+  def available_plugins(self, category=None):
     """Returns a list of plugins available for a given category
 
     .. versionadded:: 10Mar2021
@@ -2494,7 +2561,8 @@ class lammps(object):
     nam = create_string_buffer(LMP_BUFSIZE)
     for idx in range(num):
       self.lib.lammps_plugin_name(idx, sty, nam, LMP_BUFSIZE)
-      available_plugins.append([sty.value.decode(), nam.value.decode()])
+      if not category or (category == sty.value):
+        available_plugins.append([sty.value.decode(), nam.value.decode()])
     return available_plugins
 
   # -------------------------------------------------------------------------
@@ -2618,7 +2686,7 @@ class lammps(object):
 
     nlocal = self.extract_setting('nlocal')
     if len(eatom) < nlocal:
-      raise Exception('per-atom energy list length must be at least nlocal')
+      raise ValueError('per-atom energy list length must be at least nlocal')
     ceatom = (nlocal*c_double)(*eatom)
     with ExceptionCheck(self):
       return self.lib.lammps_fix_external_set_energy_peratom(self.lmp, fix_id.encode(), ceatom)
@@ -2642,16 +2710,16 @@ class lammps(object):
     # copy virial data to C compatible buffer
     nlocal = self.extract_setting('nlocal')
     if len(vatom) < nlocal:
-      raise Exception('per-atom virial first dimension must be at least nlocal')
+      raise ValueError('per-atom virial first dimension must be at least nlocal')
     if len(vatom[0]) != 6:
-      raise Exception('per-atom virial second dimension must be 6')
-    vbuf = (c_double * 6)
+      raise ValueError('per-atom virial second dimension must be 6')
+    vbuf = c_double * 6
     vptr = POINTER(c_double)
     c_virial = (vptr * nlocal)()
     for i in range(nlocal):
-        c_virial[i] = vbuf()
-        for j in range(6):
-          c_virial[i][j] = vatom[i][j]
+      c_virial[i] = vbuf()
+      for j in range(6):
+        c_virial[i][j] = vatom[i][j]
 
     with ExceptionCheck(self):
       return self.lib.lammps_fix_external_set_virial_peratom(self.lmp, fix_id.encode(), c_virial)
@@ -2708,7 +2776,7 @@ class lammps(object):
     :rtype:  NeighList
     """
     if idx < 0:
-        return None
+      return None
     return NeighList(self, idx)
 
   # -------------------------------------------------------------------------

--- a/python/lammps/core.py
+++ b/python/lammps/core.py
@@ -37,6 +37,7 @@ from lammps.data import NeighList
 # -------------------------------------------------------------------------
 
 class MPIAbortException(Exception):
+  """Exception to use when LAMMPS wants to call MPI_Abort()"""
   def __init__(self, message):
     self.message = message
 
@@ -60,6 +61,7 @@ class ExceptionCheck:
 # -------------------------------------------------------------------------
 
 class command_wrapper:
+  """Wrapper class to enable using 'lmp.xxx("args")' instead of 'lmp.command("xxx args")'"""
   def __init__(self, lmp):
     self.lmp = lmp
     self.auto_flush = False
@@ -1625,12 +1627,14 @@ class lammps:
   # -------------------------------------------------------------------------
 
   def clearstep_compute(self):
+    """Call 'lammps_clearstep_compute()' from Python"""
     with ExceptionCheck(self):
       return self.lib.lammps_clearstep_compute(self.lmp)
 
   # -------------------------------------------------------------------------
 
   def addstep_compute(self, nextstep):
+    """Call 'lammps_addstep_compute()' from Python"""
     with ExceptionCheck(self):
       nextstep = self.c_bigint(nextstep)
       return self.lib.lammps_addstep_compute(self.lmp, byref(nextstep))
@@ -1638,6 +1642,7 @@ class lammps:
   # -------------------------------------------------------------------------
 
   def addstep_compute_all(self, nextstep):
+    """Call 'lammps_addstep_compute_all()' from Python"""
     with ExceptionCheck(self):
       nextstep = self.c_bigint(nextstep)
       return self.lib.lammps_addstep_compute_all(self.lmp, byref(nextstep))
@@ -2894,5 +2899,6 @@ class lammps:
     return idx
 
 # Local Variables:
-# fill-column: 80
+# fill-column: 100
+# python-indent-offset: 2
 # End:

--- a/python/lammps/core.py
+++ b/python/lammps/core.py
@@ -10,7 +10,9 @@
 #
 #   See the README file in the top-level LAMMPS directory.
 # -------------------------------------------------------------------------
-# Python wrapper for the LAMMPS library via ctypes
+"""
+Python module wrapping the LAMMPS library via ctypes
+"""
 
 # avoid pylint warnings about naming conventions
 # pylint: disable=C0103

--- a/python/lammps/data.py
+++ b/python/lammps/data.py
@@ -91,3 +91,8 @@ class NeighList:
         return numneigh, neighbors
 
     return -1, None
+
+# Local Variables:
+# fill-column: 100
+# python-indent-offset: 2
+# End:

--- a/python/lammps/data.py
+++ b/python/lammps/data.py
@@ -13,7 +13,7 @@
 
 """
 Data structures for LAMMPS Python module
-Written by Richard Berger <richard.berger@temple.edu>
+Written by Richard Berger <richard.berger@outlook.com>
 """
 
 class NeighList:

--- a/python/lammps/data.py
+++ b/python/lammps/data.py
@@ -11,82 +11,83 @@
 #   See the README file in the top-level LAMMPS directory.
 # -------------------------------------------------------------------------
 
-################################################################################
-# LAMMPS data structures
-# Written by Richard Berger <richard.berger@temple.edu>
-################################################################################
+"""
+Data structures for LAMMPS Python module
+Written by Richard Berger <richard.berger@temple.edu>
+"""
 
-class NeighList(object):
-    """This is a wrapper class that exposes the contents of a neighbor list.
+class NeighList:
+  """This is a wrapper class that exposes the contents of a neighbor list.
 
-    It can be used like a regular Python list. Each element is a tuple of:
+  It can be used like a regular Python list. Each element is a tuple of:
 
-    * the atom local index
-    * its number of neighbors
-    * and a pointer to an c_int array containing local atom indices of its
-      neighbors
+  * the atom local index
+  * its number of neighbors
+  * and a pointer to an c_int array containing local atom indices of its
+    neighbors
 
-    Internally it uses the lower-level LAMMPS C-library interface.
+  Internally it uses the lower-level LAMMPS C-library interface.
 
-    :param lmp: reference to instance of :py:class:`lammps`
-    :type  lmp: lammps
-    :param idx: neighbor list index
-    :type  idx: int
+  :param lmp: reference to instance of :py:class:`lammps`
+  :type  lmp: lammps
+  :param idx: neighbor list index
+  :type  idx: int
+  """
+  def __init__(self, lmp, idx):
+    self.lmp = lmp
+    self.idx = idx
+
+  def __str__(self):
+    # pylint: disable=C0209
+    return "Neighbor List ({} atoms)".format(self.size)
+
+  def __repr__(self):
+    return self.__str__()
+
+  @property
+  def size(self):
     """
-    def __init__(self, lmp, idx):
-        self.lmp = lmp
-        self.idx = idx
+    :return: number of elements in neighbor list
+    """
+    return self.lmp.get_neighlist_size(self.idx)
 
-    def __str__(self):
-        return "Neighbor List ({} atoms)".format(self.size)
+  def get(self, element):
+    """
+    Access a specific neighbor list entry. "element" must be a number from 0 to the size-1 of the list
 
-    def __repr__(self):
-        return self.__str__()
+    :return: tuple with atom local index, number of neighbors and ctypes pointer to neighbor's local atom indices
+    :rtype:  (int, int, ctypes.POINTER(c_int))
+    """
+    iatom, numneigh, neighbors = self.lmp.get_neighlist_element_neighbors(self.idx, element)
+    return iatom, numneigh, neighbors
 
-    @property
-    def size(self):
-        """
-        :return: number of elements in neighbor list
-        """
-        return self.lmp.get_neighlist_size(self.idx)
+  # the methods below implement the iterator interface, so NeighList can be used like a regular Python list
 
-    def get(self, element):
-        """
-        Access a specific neighbor list entry. "element" must be a number from 0 to the size-1 of the list
+  def __getitem__(self, element):
+    return self.get(element)
 
-        :return: tuple with atom local index, number of neighbors and ctypes pointer to neighbor's local atom indices
-        :rtype:  (int, int, ctypes.POINTER(c_int))
-        """
-        iatom, numneigh, neighbors = self.lmp.get_neighlist_element_neighbors(self.idx, element)
-        return iatom, numneigh, neighbors
+  def __len__(self):
+    return self.size
 
-    # the methods below implement the iterator interface, so NeighList can be used like a regular Python list
+  def __iter__(self):
+    inum = self.size
 
-    def __getitem__(self, element):
-        return self.get(element)
+    for ii in range(inum):
+      yield self.get(ii)
 
-    def __len__(self):
-        return self.size
+  def find(self, iatom):
+    """
+    Find the neighbor list for a specific (local) atom iatom.
+    If there is no list for iatom, (-1, None) is returned.
 
-    def __iter__(self):
-        inum = self.size
+    :return: tuple with number of neighbors and ctypes pointer to neighbor's local atom indices
+    :rtype:  (int, ctypes.POINTER(c_int))
+    """
 
-        for ii in range(inum):
-            yield self.get(ii)
+    inum = self.size
+    for ii in range(inum):
+      idx, numneigh, neighbors = self.get(ii)
+      if idx == iatom:
+        return numneigh, neighbors
 
-    def find(self, iatom):
-        """
-        Find the neighbor list for a specific (local) atom iatom.
-        If there is no list for iatom, (-1, None) is returned.
-
-        :return: tuple with number of neighbors and ctypes pointer to neighbor's local atom indices
-        :rtype:  (int, ctypes.POINTER(c_int))
-        """
-
-        inum = self.size
-        for ii in range(inum):
-            idx, numneigh, neighbors = self.get(ii)
-            if idx == iatom:
-                return numneigh, neighbors
-
-        return -1, None
+    return -1, None

--- a/python/lammps/formats.py
+++ b/python/lammps/formats.py
@@ -231,3 +231,8 @@ class AvgChunkFile:
 
           self.timesteps.append(timestep)
           self.total_count.append(total_count)
+
+# Local Variables:
+# fill-column: 100
+# python-indent-offset: 2
+# End:

--- a/python/lammps/formats.py
+++ b/python/lammps/formats.py
@@ -13,7 +13,7 @@
 
 """
 Output formats for LAMMPS python module
-Written by Richard Berger <richard.berger@temple.edu>
+Written by Richard Berger <richard.berger@outlook.com>
 and Axel Kohlmeyer <akohlmey@gmail.com>
 """
 

--- a/python/lammps/formats.py
+++ b/python/lammps/formats.py
@@ -11,14 +11,15 @@
 #   See the README file in the top-level LAMMPS directory.
 # -------------------------------------------------------------------------
 
-################################################################################
-# LAMMPS output formats
-# Written by Richard Berger <richard.berger@temple.edu>
-# and Axel Kohlmeyer <akohlmey@gmail.com>
-################################################################################
+"""
+Output formats for LAMMPS python module
+Written by Richard Berger <richard.berger@temple.edu>
+and Axel Kohlmeyer <akohlmey@gmail.com>
+"""
 
 import re
 
+# pylint: disable=C0103
 has_yaml = False
 try:
   import yaml
@@ -32,6 +33,7 @@ except ImportError:
   pass
 
 class LogFile:
+  # pylint: disable=R0903
   """Reads LAMMPS log files and extracts the thermo information
 
   It supports the line, multi, and yaml thermo output styles.
@@ -55,73 +57,73 @@ class LogFile:
     yamllog = ""
     self.runs = []
     self.errors = []
-    with open(filename, 'rt') as f:
-        in_thermo = False
-        in_data_section = False
-        for line in f:
-            if "ERROR" in line or "exited on signal" in line:
-                self.errors.append(line)
+    with open(filename, 'rt', encoding='utf-8') as f:
+      in_thermo = False
+      in_data_section = False
+      for line in f:
+        if "ERROR" in line or "exited on signal" in line:
+          self.errors.append(line)
 
-            elif re.match(r'^ *Step ', line):
-                in_thermo = True
-                in_data_section = True
-                keys = line.split()
-                current_run = {}
-                for k in keys:
-                    current_run[k] = []
+        elif re.match(r'^ *Step ', line):
+          in_thermo = True
+          in_data_section = True
+          keys = line.split()
+          current_run = {}
+          for k in keys:
+            current_run[k] = []
 
-            elif re.match(r'^(keywords:.*$|data:$|---$|  - \[.*\]$)', line):
-                if not has_yaml:
-                  raise Exception('Cannot process YAML format logs without the PyYAML Python module')
-                style = LogFile.STYLE_YAML
-                yamllog += line;
-                current_run = {}
+        elif re.match(r'^(keywords:.*$|data:$|---$|  - \[.*\]$)', line):
+          if not has_yaml:
+            raise RuntimeError('Cannot process YAML format logs without the PyYAML Python module')
+          style = LogFile.STYLE_YAML
+          yamllog += line
+          current_run = {}
 
-            elif re.match(r'^\.\.\.$', line):
-                thermo = yaml.load(yamllog, Loader=Loader)
-                for k in thermo['keywords']:
-                    current_run[k] = []
-                for step in thermo['data']:
-                    icol = 0
-                    for k in thermo['keywords']:
-                        current_run[k].append(step[icol])
-                        icol += 1
-                self.runs.append(current_run)
-                yamllog = ""
+        elif re.match(r'^\.\.\.$', line):
+          thermo = yaml.load(yamllog, Loader=Loader)
+          for k in thermo['keywords']:
+            current_run[k] = []
+          for step in thermo['data']:
+            icol = 0
+            for k in thermo['keywords']:
+              current_run[k].append(step[icol])
+              icol += 1
+          self.runs.append(current_run)
+          yamllog = ""
 
-            elif re.match(r'^------* Step ', line):
-                if not in_thermo:
-                   current_run = {'Step': [], 'CPU': []}
-                in_thermo = True
-                in_data_section = True
-                style = LogFile.STYLE_MULTI
-                str_step, str_cpu = line.strip('-\n').split('-----')
-                step = float(str_step.split()[1])
-                cpu  = float(str_cpu.split('=')[1].split()[0])
-                current_run["Step"].append(step)
-                current_run["CPU"].append(cpu)
+        elif re.match(r'^------* Step ', line):
+          if not in_thermo:
+            current_run = {'Step': [], 'CPU': []}
+          in_thermo = True
+          in_data_section = True
+          style = LogFile.STYLE_MULTI
+          str_step, str_cpu = line.strip('-\n').split('-----')
+          step = float(str_step.split()[1])
+          cpu  = float(str_cpu.split('=')[1].split()[0])
+          current_run["Step"].append(step)
+          current_run["CPU"].append(cpu)
 
-            elif line.startswith('Loop time of'):
-                in_thermo = False
-                if style != LogFile.STYLE_YAML:
-                    self.runs.append(current_run)
+        elif line.startswith('Loop time of'):
+          in_thermo = False
+          if style != LogFile.STYLE_YAML:
+            self.runs.append(current_run)
 
-            elif in_thermo and in_data_section:
-                if style == LogFile.STYLE_DEFAULT:
-                    if alpha.search(line):
-                        continue
-                    for k, v in zip(keys, map(float, line.split())):
-                        current_run[k].append(v)
+        elif in_thermo and in_data_section:
+          if style == LogFile.STYLE_DEFAULT:
+            if alpha.search(line):
+              continue
+            for k, v in zip(keys, map(float, line.split())):
+              current_run[k].append(v)
 
-                elif style == LogFile.STYLE_MULTI:
-                    if '=' not in line:
-                        in_data_section = False
-                        continue
-                    for k,v in kvpairs.findall(line):
-                        if k not in current_run:
-                            current_run[k] = [float(v)]
-                        else:
-                            current_run[k].append(float(v))
+          elif style == LogFile.STYLE_MULTI:
+            if '=' not in line:
+              in_data_section = False
+              continue
+            for k,v in kvpairs.findall(line):
+              if k not in current_run:
+                current_run[k] = [float(v)]
+              else:
+                current_run[k].append(float(v))
 
 class AvgChunkFile:
   """Reads files generated by fix ave/chunk
@@ -134,9 +136,13 @@ class AvgChunkFile:
   :ivar chunks: List of chunks. Each chunk is a dictionary containing its ID, the coordinates, and the averaged quantities
   """
   def __init__(self, filename):
-    with open(filename, 'rt') as f:
+    with open(filename, 'rt', encoding='utf-8') as f:
       timestep = None
       chunks_read = 0
+      compress = False
+      coord_start = None
+      coord_end = None
+      data_start = None
 
       self.timesteps = []
       self.total_count = []
@@ -145,24 +151,24 @@ class AvgChunkFile:
       for lineno, line in enumerate(f):
         if lineno == 0:
           if not line.startswith("# Chunk-averaged data for fix"):
-            raise Exception("Chunk data reader only supports default avg/chunk headers!")
+            raise RuntimeError("Chunk data reader only supports default avg/chunk headers!")
           parts = line.split()
           self.fix_name = parts[5]
           self.group_name = parts[8]
           continue
-        elif lineno == 1:
+        if lineno == 1:
           if not line.startswith("# Timestep Number-of-chunks Total-count"):
-            raise Exception("Chunk data reader only supports default avg/chunk headers!")
+            raise RuntimeError("Chunk data reader only supports default avg/chunk headers!")
           continue
-        elif lineno == 2:
+        if lineno == 2:
           if not line.startswith("#"):
-            raise Exception("Chunk data reader only supports default avg/chunk headers!")
+            raise RuntimeError("Chunk data reader only supports default avg/chunk headers!")
           columns = line.split()[1:]
           ndim = line.count("Coord")
           compress = 'OrigID' in line
           if ndim > 0:
             coord_start = columns.index("Coord1")
-            coord_end   = columns.index("Coord%d" % ndim)
+            coord_end   = columns.index(f"Coord{ndim}")
             ncount_start = coord_end + 1
             data_start = ncount_start + 1
           else:
@@ -216,8 +222,8 @@ class AvgChunkFile:
           assert chunk == chunks_read
         else:
           # do not support changing number of chunks
-          if not (num_chunks == int(parts[1])):
-            raise Exception("Currently, changing numbers of chunks are not supported.")
+          if not num_chunks == int(parts[1]):
+            raise RuntimeError("Currently, changing numbers of chunks are not supported.")
 
           timestep = int(parts[0])
           total_count = float(parts[2])

--- a/python/lammps/numpy_wrapper.py
+++ b/python/lammps/numpy_wrapper.py
@@ -13,7 +13,7 @@
 
 """
 NumPy additions to the LAMMPS Python module
-Written by Richard Berger <richard.berger@temple.edu>
+Written by Richard Berger <richard.berger@outlook.com>
 """
 
 from ctypes import POINTER, c_void_p, c_char_p, c_double, c_int, c_int32, c_int64, cast

--- a/python/lammps/numpy_wrapper.py
+++ b/python/lammps/numpy_wrapper.py
@@ -526,3 +526,8 @@ class NumPyNeighList(NeighList):
       if idx == iatom:
         return neighbors
     return None
+
+# Local Variables:
+# fill-column: 100
+# python-indent-offset: 2
+# End:

--- a/python/lammps/numpy_wrapper.py
+++ b/python/lammps/numpy_wrapper.py
@@ -414,7 +414,22 @@ class numpy_wrapper:
   # -------------------------------------------------------------------------
 
   def iarray(self, c_int_type, raw_ptr, nelem, dim=1):
-    # pylint: disable=C0116
+    """Convert ctypes pointer to an array of integers into a corresponding numpy array
+
+    This will cast the raw pointer into a 1-d or 2-d numpy array and set its shape
+
+    :param c_int_type: type of integer (c_int32 or c_int64)
+    :type: ctypes type
+    :param raw_ptr: ctypes pointer to the array data
+    :type: POINTER(c_int_type)
+    :param nelem: length of the leading dimension
+    :type: integer
+    :param dim: length of the second dimension
+    :type: integer, optional
+    :return: ctypes array converted to numpy style array with proper shape
+    :rtype: numpy.array
+    """
+
     if raw_ptr and nelem >= 0 and dim >= 0:
       np_int_type = self._ctype_to_numpy_int(c_int_type)
       ptr = None
@@ -430,16 +445,27 @@ class numpy_wrapper:
         a = np.empty(0, dtype=np_int_type)
 
       if dim > 1:
-        a.shape = (nelem, dim)
-      else:
-        a.shape = nelem
-      return a
+        return np.reshape(a, (nelem, dim))
+
+      return np.reshape(a, nelem)
     return None
 
   # -------------------------------------------------------------------------
 
   def darray(self, raw_ptr, nelem, dim=1):
-    # pylint: disable=C0116
+    """Convert ctypes pointer to an array of doubles into a corresponding numpy array
+
+    This will cast the raw pointer into a 1-d or 2-d numpy array and set its shape
+
+    :param raw_ptr: ctypes pointer to the array data
+    :type: POINTER(c_double)
+    :param nelem: length of the leading dimension
+    :type: integer
+    :param dim: length of the second dimension
+    :type: integer, optional
+    :return: ctypes array converted to numpy style array with proper shape
+    :rtype: numpy.array
+    """
     if raw_ptr and nelem >= 0 and dim >= 0:
       ptr = None
 
@@ -454,10 +480,9 @@ class numpy_wrapper:
         a = np.empty(0, c_double)
 
       if dim > 1:
-        a.shape = (nelem, dim)
-      else:
-        a.shape = nelem
-      return a
+        return np.reshape(a, (nelem, dim))
+
+      return np.reshape(a, nelem)
     return None
 
 # -------------------------------------------------------------------------

--- a/python/lammps/numpy_wrapper.py
+++ b/python/lammps/numpy_wrapper.py
@@ -11,12 +11,13 @@
 #   See the README file in the top-level LAMMPS directory.
 # -------------------------------------------------------------------------
 
-################################################################################
-# NumPy additions
-# Written by Richard Berger <richard.berger@temple.edu>
-################################################################################
+"""
+NumPy additions to the LAMMPS Python module
+Written by Richard Berger <richard.berger@temple.edu>
+"""
 
 from ctypes import POINTER, c_void_p, c_char_p, c_double, c_int, c_int32, c_int64, cast
+import numpy as np
 
 from .constants import  LAMMPS_AUTODETECT, LAMMPS_INT, LAMMPS_INT_2D, LAMMPS_DOUBLE, \
   LAMMPS_DOUBLE_2D, LAMMPS_INT64, LAMMPS_INT64_2D, LMP_STYLE_GLOBAL, LMP_STYLE_ATOM, \
@@ -26,6 +27,7 @@ from .constants import  LAMMPS_AUTODETECT, LAMMPS_INT, LAMMPS_INT_2D, LAMMPS_DOU
 from .data import NeighList
 
 class numpy_wrapper:
+  # pylint: disable=C0103
   """lammps API NumPy Wrapper
 
   This is a wrapper class that provides additional methods on top of an
@@ -46,10 +48,9 @@ class numpy_wrapper:
   # -------------------------------------------------------------------------
 
   def _ctype_to_numpy_int(self, ctype_int):
-    import numpy as np
     if ctype_int == c_int32:
       return np.int32
-    elif ctype_int == c_int64:
+    if ctype_int == c_int64:
       return np.int64
     return np.intc
 
@@ -102,9 +103,9 @@ class numpy_wrapper:
 
     if dtype in (LAMMPS_DOUBLE, LAMMPS_DOUBLE_2D):
       return self.darray(raw_ptr, nelem, dim)
-    elif dtype in (LAMMPS_INT, LAMMPS_INT_2D):
+    if dtype in (LAMMPS_INT, LAMMPS_INT_2D):
       return self.iarray(c_int32, raw_ptr, nelem, dim)
-    elif dtype in (LAMMPS_INT64, LAMMPS_INT64_2D):
+    if dtype in (LAMMPS_INT64, LAMMPS_INT64_2D):
       return self.iarray(c_int64, raw_ptr, nelem, dim)
     return raw_ptr
 
@@ -133,7 +134,7 @@ class numpy_wrapper:
       if ctype == LMP_TYPE_VECTOR:
         nrows = self.lmp.extract_compute(cid, cstyle, LMP_SIZE_VECTOR)
         return self.darray(value, nrows)
-      elif ctype == LMP_TYPE_ARRAY:
+      if ctype == LMP_TYPE_ARRAY:
         nrows = self.lmp.extract_compute(cid, cstyle, LMP_SIZE_ROWS)
         ncols = self.lmp.extract_compute(cid, cstyle, LMP_SIZE_COLS)
         return self.darray(value, nrows, ncols)
@@ -142,13 +143,12 @@ class numpy_wrapper:
       ncols = self.lmp.extract_compute(cid, cstyle, LMP_SIZE_COLS)
       if ncols == 0:
         return self.darray(value, nrows)
-      else:
-        return self.darray(value, nrows, ncols)
+      return self.darray(value, nrows, ncols)
     elif cstyle == LMP_STYLE_ATOM:
       if ctype == LMP_TYPE_VECTOR:
         nlocal = self.lmp.extract_global("nlocal")
         return self.darray(value, nlocal)
-      elif ctype == LMP_TYPE_ARRAY:
+      if ctype == LMP_TYPE_ARRAY:
         nlocal = self.lmp.extract_global("nlocal")
         ncols = self.lmp.extract_compute(cid, cstyle, LMP_SIZE_COLS)
         return self.darray(value, nlocal, ncols)
@@ -189,7 +189,7 @@ class numpy_wrapper:
       if ftype == LMP_TYPE_VECTOR:
         nlocal = self.lmp.extract_global("nlocal")
         return self.darray(value, nlocal)
-      elif ftype == LMP_TYPE_ARRAY:
+      if ftype == LMP_TYPE_ARRAY:
         nlocal = self.lmp.extract_global("nlocal")
         ncols = self.lmp.extract_fix(fid, fstyle, LMP_SIZE_COLS, 0, 0)
         return self.darray(value, nlocal, ncols)
@@ -197,7 +197,7 @@ class numpy_wrapper:
       if ftype == LMP_TYPE_VECTOR:
         nrows = self.lmp.extract_fix(fid, fstyle, LMP_SIZE_ROWS, 0, 0)
         return self.darray(value, nrows)
-      elif ftype == LMP_TYPE_ARRAY:
+      if ftype == LMP_TYPE_ARRAY:
         nrows = self.lmp.extract_fix(fid, fstyle, LMP_SIZE_ROWS, 0, 0)
         ncols = self.lmp.extract_fix(fid, fstyle, LMP_SIZE_COLS, 0, 0)
         return self.darray(value, nrows, ncols)
@@ -222,7 +222,6 @@ class numpy_wrapper:
     :return: the requested data or None
     :rtype: c_double, numpy.array, or NoneType
     """
-    import numpy as np
     value = self.lmp.extract_variable(name, group, vartype)
     if vartype == LMP_VAR_ATOM:
       return np.ctypeslib.as_array(value)
@@ -242,7 +241,6 @@ class numpy_wrapper:
     :return: the requested data as a 2d-integer numpy array
     :rtype: numpy.array(nbonds,3)
     """
-    import numpy as np
     nbonds, value = self.lmp.gather_bonds()
     return np.ctypeslib.as_array(value).reshape(nbonds,3)
 
@@ -260,7 +258,6 @@ class numpy_wrapper:
     :return: the requested data as a 2d-integer numpy array
     :rtype: numpy.array(nangles,4)
     """
-    import numpy as np
     nangles, value = self.lmp.gather_angles()
     return np.ctypeslib.as_array(value).reshape(nangles,4)
 
@@ -278,7 +275,6 @@ class numpy_wrapper:
     :return: the requested data as a 2d-integer numpy array
     :rtype: numpy.array(ndihedrals,5)
     """
-    import numpy as np
     ndihedrals, value = self.lmp.gather_dihedrals()
     return np.ctypeslib.as_array(value).reshape(ndihedrals,5)
 
@@ -296,7 +292,6 @@ class numpy_wrapper:
     :return: the requested data as a 2d-integer numpy array
     :rtype: numpy.array(nimpropers,5)
     """
-    import numpy as np
     nimpropers, value = self.lmp.gather_impropers()
     return np.ctypeslib.as_array(value).reshape(nimpropers,5)
 
@@ -317,7 +312,6 @@ class numpy_wrapper:
     :return: requested data
     :rtype: numpy.array
     """
-    import numpy as np
     nlocal = self.lmp.extract_setting('nlocal')
     value = self.lmp.fix_external_get_force(fix_id)
     return self.darray(value,nlocal,3)
@@ -339,10 +333,9 @@ class numpy_wrapper:
     :param eatom:   per-atom potential energy
     :type: numpy.array
     """
-    import numpy as np
     nlocal = self.lmp.extract_setting('nlocal')
     if len(eatom) < nlocal:
-      raise Exception('per-atom energy dimension must be at least nlocal')
+      raise RuntimeError('per-atom energy dimension must be at least nlocal')
 
     c_double_p = POINTER(c_double)
     value = eatom.astype(np.double)
@@ -366,12 +359,11 @@ class numpy_wrapper:
     :param eatom:   per-atom potential energy
     :type: numpy.array
     """
-    import numpy as np
     nlocal = self.lmp.extract_setting('nlocal')
     if len(vatom) < nlocal:
-      raise Exception('per-atom virial first dimension must be at least nlocal')
+      raise RuntimeError('per-atom virial first dimension must be at least nlocal')
     if len(vatom[0]) != 6:
-      raise Exception('per-atom virial second dimension must be 6')
+      raise RuntimeError('per-atom virial second dimension must be 6')
 
     c_double_pp = np.ctypeslib.ndpointer(dtype=np.uintp, ndim=1, flags='C')
 
@@ -395,7 +387,7 @@ class numpy_wrapper:
     :rtype:  NumPyNeighList
     """
     if idx < 0:
-        return None
+      return None
     return NumPyNeighList(self.lmp, idx)
 
   # -------------------------------------------------------------------------
@@ -422,8 +414,8 @@ class numpy_wrapper:
   # -------------------------------------------------------------------------
 
   def iarray(self, c_int_type, raw_ptr, nelem, dim=1):
+    # pylint: disable=C0116
     if raw_ptr and nelem >= 0 and dim >= 0:
-      import numpy as np
       np_int_type = self._ctype_to_numpy_int(c_int_type)
       ptr = None
 
@@ -440,15 +432,15 @@ class numpy_wrapper:
       if dim > 1:
         a.shape = (nelem, dim)
       else:
-        a.shape = (nelem)
+        a.shape = nelem
       return a
     return None
 
   # -------------------------------------------------------------------------
 
   def darray(self, raw_ptr, nelem, dim=1):
+    # pylint: disable=C0116
     if raw_ptr and nelem >= 0 and dim >= 0:
-      import numpy as np
       ptr = None
 
       if dim == 1:
@@ -464,51 +456,48 @@ class numpy_wrapper:
       if dim > 1:
         a.shape = (nelem, dim)
       else:
-        a.shape = (nelem)
+        a.shape = nelem
       return a
     return None
 
 # -------------------------------------------------------------------------
 
 class NumPyNeighList(NeighList):
-    """This is a wrapper class that exposes the contents of a neighbor list.
+  """This is a wrapper class that exposes the contents of a neighbor list.
 
-    It can be used like a regular Python list. Each element is a tuple of:
+  It can be used like a regular Python list. Each element is a tuple of:
 
-    * the atom local index
-    * a NumPy array containing the local atom indices of its neighbors
+  * the atom local index
+  * a NumPy array containing the local atom indices of its neighbors
 
-    Internally it uses the lower-level LAMMPS C-library interface.
+  Internally it uses the lower-level LAMMPS C-library interface.
 
-    :param lmp: reference to instance of :py:class:`lammps`
-    :type  lmp: lammps
-    :param idx: neighbor list index
-    :type  idx: int
+  :param lmp: reference to instance of :py:class:`lammps`
+  :type  lmp: lammps
+  :param idx: neighbor list index
+  :type  idx: int
+  """
+  def get(self, element):
     """
-    def __init__(self, lmp, idx):
-      super(NumPyNeighList, self).__init__(lmp, idx)
+    Access a specific neighbor list entry. "element" must be a number from 0 to the size-1 of the list
 
-    def get(self, element):
-        """
-        Access a specific neighbor list entry. "element" must be a number from 0 to the size-1 of the list
+    :return: tuple with atom local index, numpy array of neighbor local atom indices
+    :rtype:  (int, numpy.array)
+    """
+    iatom, neighbors = self.lmp.numpy.get_neighlist_element_neighbors(self.idx, element)
+    return iatom, neighbors
 
-        :return: tuple with atom local index, numpy array of neighbor local atom indices
-        :rtype:  (int, numpy.array)
-        """
-        iatom, neighbors = self.lmp.numpy.get_neighlist_element_neighbors(self.idx, element)
-        return iatom, neighbors
+  def find(self, iatom):
+    """
+    Find the neighbor list for a specific (local) atom iatom.
+    If there is no list for iatom, None is returned.
 
-    def find(self, iatom):
-        """
-        Find the neighbor list for a specific (local) atom iatom.
-        If there is no list for iatom, None is returned.
-
-        :return: numpy array of neighbor local atom indices
-        :rtype:  numpy.array or None
-        """
-        inum = self.size
-        for ii in range(inum):
-          idx, neighbors = self.get(ii)
-          if idx == iatom:
-            return neighbors
-        return None
+    :return: numpy array of neighbor local atom indices
+    :rtype:  numpy.array or None
+    """
+    inum = self.size
+    for ii in range(inum):
+      idx, neighbors = self.get(ii)
+      if idx == iatom:
+        return neighbors
+    return None

--- a/python/lammps/pylammps.py
+++ b/python/lammps/pylammps.py
@@ -16,10 +16,6 @@
 # Written by Richard Berger <richard.berger@outlook.com>
 ################################################################################
 
-# for python2/3 compatibility
-
-from __future__ import print_function
-
 import io
 import os
 import re
@@ -130,10 +126,10 @@ class AtomList(object):
     :rtype: Atom or Atom2D
     """
     if index not in self._loaded:
-        if self.dimensions == 2:
-            atom = Atom2D(self._pylmp, index)
-        else:
-            atom = Atom(self._pylmp, index)
+      if self.dimensions == 2:
+        atom = Atom2D(self._pylmp, index)
+      else:
+        atom = Atom(self._pylmp, index)
         self._loaded[index] = atom
     return self._loaded[index]
 
@@ -762,7 +758,7 @@ class PyLammps(object):
     if self.comm_me > 0:
       raise Exception("PyLammps.eval() may only be used on MPI rank 0")
 
-    value = self.lmp_print('"$(%s)"' % expr).strip()
+    value = print('"$(%s)"' % expr).strip()
     try:
       return float(value)
     except ValueError:
@@ -846,10 +842,6 @@ class PyLammps(object):
         element[key] = value
       elements.append(element)
     return elements
-
-  def lmp_print(self, s):
-    """ needed for Python2 compatibility, since print is a reserved keyword """
-    return self.__getattr__("print")(s)
 
   def __dir__(self):
     return sorted(set(['angle_coeff', 'angle_style', 'atom_modify', 'atom_style', 'atom_style',

--- a/python/lammps/pylammps.py
+++ b/python/lammps/pylammps.py
@@ -1015,3 +1015,8 @@ class IPyLammps(PyLammps):
     """
     from IPython.display import HTML
     return HTML("<video controls><source src=\"" + filename + "\"></video>")
+
+# Local Variables:
+# fill-column: 100
+# python-indent-offset: 2
+# End:

--- a/python/lammps/pylammps.py
+++ b/python/lammps/pylammps.py
@@ -16,6 +16,10 @@
 # Written by Richard Berger <richard.berger@outlook.com>
 ################################################################################
 
+# for python2/3 compatibility
+
+from __future__ import print_function
+
 import io
 import os
 import re
@@ -758,7 +762,7 @@ class PyLammps(object):
     if self.comm_me > 0:
       raise Exception("PyLammps.eval() may only be used on MPI rank 0")
 
-    value = print('"$(%s)"' % expr).strip()
+    value = self.lmp_print('"$(%s)"' % expr).strip()
     try:
       return float(value)
     except ValueError:
@@ -842,6 +846,10 @@ class PyLammps(object):
         element[key] = value
       elements.append(element)
     return elements
+
+  def lmp_print(self, s):
+    """ needed for Python2 compatibility, since print is a reserved keyword """
+    return self.__getattr__("print")(s)
 
   def __dir__(self):
     return sorted(set(['angle_coeff', 'angle_style', 'atom_modify', 'atom_style', 'atom_style',

--- a/src/AMOEBA/amoeba_file.cpp
+++ b/src/AMOEBA/amoeba_file.cpp
@@ -518,32 +518,32 @@ void PairAmoeba::read_keyfile(char *filename)
 
     } else if (keyword == "pme-order") {
       if (nwords != 2) error->all(FLERR, "AMOEBA keyfile line is invalid");
-      bseorder = utils::numeric(FLERR, words[1], false, lmp);
+      bseorder = utils::inumeric(FLERR, words[1], false, lmp);
     } else if (keyword == "ppme-order") {
       if (nwords != 2) error->all(FLERR, "AMOEBA keyfile line is invalid");
-      bsporder = utils::numeric(FLERR, words[1], false, lmp);
+      bsporder = utils::inumeric(FLERR, words[1], false, lmp);
     } else if (keyword == "dpme-order") {
       if (nwords != 2) error->all(FLERR, "AMOEBA keyfile line is invalid");
-      bsdorder = utils::numeric(FLERR, words[1], false, lmp);
+      bsdorder = utils::inumeric(FLERR, words[1], false, lmp);
 
     } else if (keyword == "pme-grid") {
       if (nwords != 2 && nwords != 4) error->all(FLERR, "AMOEBA keyfile line is invalid");
       if (nwords == 2)
-        nefft1 = nefft2 = nefft3 = utils::numeric(FLERR, words[1], false, lmp);
+        nefft1 = nefft2 = nefft3 = utils::inumeric(FLERR, words[1], false, lmp);
       else {
-        nefft1 = utils::numeric(FLERR, words[1], false, lmp);
-        nefft2 = utils::numeric(FLERR, words[2], false, lmp);
-        nefft3 = utils::numeric(FLERR, words[3], false, lmp);
+        nefft1 = utils::inumeric(FLERR, words[1], false, lmp);
+        nefft2 = utils::inumeric(FLERR, words[2], false, lmp);
+        nefft3 = utils::inumeric(FLERR, words[3], false, lmp);
       }
       pmegrid_key = 1;
     } else if (keyword == "dpme-grid") {
       if (nwords != 2 && nwords != 4) error->all(FLERR, "AMOEBA keyfile line is invalid");
       if (nwords == 2)
-        ndfft1 = ndfft2 = ndfft3 = utils::numeric(FLERR, words[1], false, lmp);
+        ndfft1 = ndfft2 = ndfft3 = utils::inumeric(FLERR, words[1], false, lmp);
       else {
-        ndfft1 = utils::numeric(FLERR, words[1], false, lmp);
-        ndfft2 = utils::numeric(FLERR, words[2], false, lmp);
-        ndfft3 = utils::numeric(FLERR, words[3], false, lmp);
+        ndfft1 = utils::inumeric(FLERR, words[1], false, lmp);
+        ndfft2 = utils::inumeric(FLERR, words[2], false, lmp);
+        ndfft3 = utils::inumeric(FLERR, words[3], false, lmp);
       }
       dpmegrid_key = 1;
 
@@ -635,7 +635,7 @@ void PairAmoeba::read_keyfile(char *filename)
 
   // close key file
 
-  if (me == 0) fclose(fptr);
+  if (me == 0) (void) fclose(fptr);
 
   // cutoff resets for long-range interactions
 

--- a/src/AMOEBA/amoeba_multipole.cpp
+++ b/src/AMOEBA/amoeba_multipole.cpp
@@ -905,28 +905,16 @@ void PairAmoeba::damppole(double r, int rorder, double alphai, double alphak,
   dmpi[6] = 1.0 - (1.0 + dampi + 0.5*dampi2 + dampi3/6.0 + dampi4/30.0)*expi;
   dmpi[8] = 1.0 - (1.0 + dampi + 0.5*dampi2 + dampi3/6.0 +
                    4.0*dampi4/105.0 + dampi5/210.0)*expi;
+
+  // valence-valence charge penetration damping for Gordon f1
+
   if (diff < eps) {
     dmpk[0] = dmpi[0];
     dmpk[2] = dmpi[2];
     dmpk[4] = dmpi[4];
     dmpk[6] = dmpi[6];
     dmpk[8] = dmpi[8];
-  } else {
-    dampk2 = dampk * dampk;
-    dampk3 = dampk * dampk2;
-    dampk4 = dampk2 * dampk2;
-    dampk5 = dampk2 * dampk3;
-    dmpk[0] = 1.0 - (1.0 + 0.5*dampk)*expk;
-    dmpk[2] = 1.0 - (1.0 + dampk + 0.5*dampk2)*expk;
-    dmpk[4] = 1.0 - (1.0 + dampk + 0.5*dampk2 + dampk3/6.0)*expk;
-    dmpk[6] = 1.0 - (1.0 + dampk + 0.5*dampk2 + dampk3/6.0 + dampk4/30.0)*expk;
-    dmpk[8] = 1.0 - (1.0 + dampk + 0.5*dampk2 + dampk3/6.0 +
-                     4.0*dampk4/105.0 + dampk5/210.0)*expk;
-  }
 
-  // valence-valence charge penetration damping for Gordon f1
-
-  if (diff < eps) {
     dampi6 = dampi3 * dampi3;
     dampi7 = dampi3 * dampi4;
     dmpik[0] = 1.0 - (1.0 + 11.0*dampi/16.0 + 3.0*dampi2/16.0 +
@@ -948,12 +936,23 @@ void PairAmoeba::damppole(double r, int rorder, double alphai, double alphak,
     }
 
   } else {
+    dampk2 = dampk * dampk;
+    dampk3 = dampk * dampk2;
+    dampk4 = dampk2 * dampk2;
+    dampk5 = dampk2 * dampk3;
+    dmpk[0] = 1.0 - (1.0 + 0.5*dampk)*expk;
+    dmpk[2] = 1.0 - (1.0 + dampk + 0.5*dampk2)*expk;
+    dmpk[4] = 1.0 - (1.0 + dampk + 0.5*dampk2 + dampk3/6.0)*expk;
+    dmpk[6] = 1.0 - (1.0 + dampk + 0.5*dampk2 + dampk3/6.0 + dampk4/30.0)*expk;
+    dmpk[8] = 1.0 - (1.0 + dampk + 0.5*dampk2 + dampk3/6.0 +
+                     4.0*dampk4/105.0 + dampk5/210.0)*expk;
     alphai2 = alphai * alphai;
     alphak2 = alphak * alphak;
     termi = alphak2 / (alphak2-alphai2);
     termk = alphai2 / (alphai2-alphak2);
     termi2 = termi * termi;
     termk2 = termk * termk;
+
     dmpik[0] = 1.0 - termi2*(1.0 + 2.0*termk + 0.5*dampi)*expi -
       termk2*(1.0 + 2.0*termi + 0.5*dampk)*expk;
     dmpik[2] = 1.0 - termi2*(1.0+dampi+0.5*dampi2)*expi -

--- a/src/AMOEBA/amoeba_polar.cpp
+++ b/src/AMOEBA/amoeba_polar.cpp
@@ -1376,10 +1376,10 @@ void PairAmoeba::polar_kspace()
           expterm = 0.0;
           if (term > -50.0 && hsq != 0.0) {
             denom = volterm*hsq*bsmod1[i]*bsmod2[j]*bsmod3[k];
-            if (hsq) expterm = exp(term) / denom;
+            if (denom != 0.0) expterm = exp(term) / denom;
             struc2 = gridfft[n]*gridfft[n] + gridfft[n+1]*gridfft[n+1];
             eterm = 0.5 * felec * expterm * struc2;
-            vterm = (2.0/hsq) * (1.0-term) * eterm;
+            vterm = (hsq != 0) ? (2.0/hsq) * (1.0-term) * eterm : 0.0;
             vxx -= h1*h1*vterm - eterm;
             vyy -= h2*h2*vterm - eterm;
             vzz -= h3*h3*vterm - eterm;

--- a/src/AMOEBA/fix_amoeba_bitorsion.cpp
+++ b/src/AMOEBA/fix_amoeba_bitorsion.cpp
@@ -112,7 +112,7 @@ FixAmoebaBiTorsion::FixAmoebaBiTorsion(LAMMPS *lmp, int narg, char **arg) :
   // register with Atom class
 
   nmax_previous = 0;
-  grow_arrays(atom->nmax);
+  FixAmoebaBiTorsion::grow_arrays(atom->nmax);
   atom->add_callback(Atom::GROW);
   atom->add_callback(Atom::RESTART);
 
@@ -730,22 +730,22 @@ void FixAmoebaBiTorsion::read_grid_data(char *bitorsion_file)
 
   FILE *fp = nullptr;
   if (me == 0) {
-    fp = utils::open_potential(bitorsion_file,lmp,nullptr);
+    fp = utils::open_potential(bitorsion_file, lmp, nullptr);
     if (fp == nullptr)
-      error->one(FLERR,"Cannot open fix amoeba/bitorsion file {}: {}",
+      error->one(FLERR, Error::NOLASTLINE, "Cannot open fix amoeba/bitorsion file {}: {}",
                  bitorsion_file, utils::getsyserror());
 
-    eof = fgets(line,MAXLINE,fp);
-    eof = fgets(line,MAXLINE,fp);
+    (void) fgets(line,MAXLINE,fp);
+    (void) fgets(line,MAXLINE,fp);
     eof = fgets(line,MAXLINE,fp);
     if (eof == nullptr)
-      error->one(FLERR,"Unexpected end of fix amoeba/bitorsion file");
+      error->one(FLERR, Error::NOLASTLINE, "Unexpected end of fix amoeba/bitorsion file");
 
     sscanf(line,"%d",&nbitypes);
   }
 
   MPI_Bcast(&nbitypes,1,MPI_INT,0,world);
-  if (nbitypes == 0) error->all(FLERR,"Fix amoeba/bitorsion file has no types");
+  if (nbitypes == 0) error->all(FLERR, Error::NOLASTLINE, "Fix amoeba/bitorsion file has no types");
 
   // allocate data structs
   // type index ranges from 1 to Nbitypes, so allocate one larger
@@ -763,10 +763,10 @@ void FixAmoebaBiTorsion::read_grid_data(char *bitorsion_file)
 
   for (int itype = 1; itype <= nbitypes; itype++) {
     if (me == 0) {
-      eof = fgets(line,MAXLINE,fp);
+      (void) fgets(line,MAXLINE,fp);
       eof = fgets(line,MAXLINE,fp);
       if (eof == nullptr)
-        error->one(FLERR,"Unexpected end of fix amoeba/bitorsion file");
+        error->one(FLERR, Error::NOLASTLINE, "Unexpected end of fix amoeba/bitorsion file");
       sscanf(line,"%d %d %d",&tmp,&nx,&ny);
     }
 

--- a/src/APIP/atom_vec_apip.cpp
+++ b/src/APIP/atom_vec_apip.cpp
@@ -25,9 +25,6 @@ AtomVecApip::AtomVecApip(LAMMPS *lmp) : AtomVec(lmp)
   mass_type = PER_TYPE;
   forceclearflag = 1;
 
-  double *apip_lambda, *apip_lambda_input, *apip_lambda_input_ta, *apip_lambda_const, *apip_e_fast,
-      *apip_e_precise, **apip_f_const_lambda, **apip_f_dyn_lambda;
-  int *apip_lambda_required;
   atom->apip_lambda_flag = 1;
   atom->apip_lambda_input_flag = 1;
   atom->apip_lambda_input_ta_flag = 1;

--- a/src/APIP/atom_vec_apip.h
+++ b/src/APIP/atom_vec_apip.h
@@ -28,7 +28,7 @@ class AtomVecApip : public AtomVec {
  public:
   AtomVecApip(class LAMMPS *);
 
-  void grow_pointers();
+  void grow_pointers() override;
 
   void force_clear(int, size_t) override;
   void data_atom_post(int) override;

--- a/src/APIP/fix_atom_weight_apip.cpp
+++ b/src/APIP/fix_atom_weight_apip.cpp
@@ -32,10 +32,9 @@ using namespace LAMMPS_NS;
 using namespace FixConst;
 
 FixAtomWeightAPIP::FixAtomWeightAPIP(LAMMPS *lmp, int narg, char **arg) :
-    Fix(lmp, narg, arg), fixstore(nullptr), time_simple_extract_name(nullptr),
-    time_complex_extract_name(nullptr), time_lambda_extract_name(nullptr),
-    time_group_extract_name(nullptr), time_group_name(nullptr), fix_lambda(nullptr),
-    ap_timer(nullptr)
+    Fix(lmp, narg, arg), time_simple_extract_name(nullptr), time_complex_extract_name(nullptr),
+    time_group_extract_name(nullptr), time_lambda_extract_name(nullptr), time_group_name(nullptr),
+    fixstore(nullptr), ap_timer(nullptr), fix_lambda(nullptr)
 {
   if (narg < 9) error->all(FLERR, "Illegal fix balance command");
 
@@ -119,8 +118,6 @@ FixAtomWeightAPIP::FixAtomWeightAPIP(LAMMPS *lmp, int narg, char **arg) :
   }
 
   int useless_dim = -1;
-  void *extracted_ptr = nullptr;
-
   if (time_simple_extract_name) {
     if (force->pair->extract(time_simple_extract_name, useless_dim) == nullptr)
       error->all(FLERR, "atom_weight/apip: simple time cannot be extracted with {} from {}",

--- a/src/APIP/fix_lambda_apip.cpp
+++ b/src/APIP/fix_lambda_apip.cpp
@@ -46,9 +46,9 @@ static const char cite_fix_lambda_c[] =
 /* ---------------------------------------------------------------------- */
 
 FixLambdaAPIP::FixLambdaAPIP(LAMMPS *lmp, int narg, char **arg) :
-    Fix(lmp, narg, arg), peratom_stats(nullptr), group_name_simple(nullptr),
-    group_name_complex(nullptr), group_name_ignore_lambda_input(nullptr), fixstore(nullptr),
-    fixstore2(nullptr), pair_lambda_input(nullptr), pair_lambda_zone(nullptr)
+    Fix(lmp, narg, arg), pair_lambda_input(nullptr), pair_lambda_zone(nullptr), fixstore(nullptr),
+    fixstore2(nullptr), group_name_simple(nullptr), group_name_complex(nullptr),
+    group_name_ignore_lambda_input(nullptr), peratom_stats(nullptr)
 {
   if (lmp->citeme) lmp->citeme->add(cite_fix_lambda_c);
 
@@ -190,12 +190,14 @@ FixLambdaAPIP::FixLambdaAPIP(LAMMPS *lmp, int narg, char **arg) :
 
 int FixLambdaAPIP::modify_param(int narg, char **arg)
 {
+  if (narg < 2) utils::missing_cmd_args(FLERR, "fix_modify lambda/apip", error);
+
   cut_lo = utils::numeric(FLERR, arg[0], false, lmp);
   cut_hi = utils::numeric(FLERR, arg[1], false, lmp);
   cut_hi_sq = cut_hi * cut_hi;
   cut_width = cut_hi - cut_lo;
 
-  if (cut_lo < 0 || cut_hi < cut_lo) error->all(FLERR, "fix lambda: Illegal cutoff values");
+  if (cut_lo < 0 || cut_hi < cut_lo) error->all(FLERR, "fix lambda/apip: Illegal cutoff values");
 
   if (force->pair->cutforce < cut_hi)
     error->all(FLERR, "fix lambda: cutoff of potential smaller than cutoff of switching region");
@@ -538,21 +540,20 @@ void FixLambdaAPIP::update_lambda_history()
   if (invoked_history2_update == update->ntimestep) return;
   invoked_history2_update = update->ntimestep;
 
-  double *lambda_input_ta, **lambda_history, **lambda_input_history;
+  double *lambda_input_ta, **lambda_history;
   int *mask;
   int nlocal;
 
   lambda_input_ta = atom->apip_lambda_input_ta;
   mask = atom->mask;
   lambda_history = fixstore2->astore;
-  lambda_input_history = fixstore->astore;
   nlocal = atom->nlocal;
 
   // update stats about written values
+
   history2_last = (history2_last + 1) % history2_length;
   history2_used = std::min(history2_used + 1, history2_length);
 
-  int tmp = 0;
   for (int i = 0; i < nlocal; i++) {
     if (!(mask[i] & groupbit)) continue;
 
@@ -617,15 +618,13 @@ void FixLambdaAPIP::get_lambda_average()
 void FixLambdaAPIP::calculate_lambda_input_ta()
 {
   int i, nlocal;
-  int *mask;
   double *lambda_input_ta = atom->apip_lambda_input_ta;
 
   nlocal = atom->nlocal;
-  mask = atom->mask;
 
   // store time averaged lambda_input for own atoms
   double **lambda_input_history = fixstore->astore;
-  for (i = 0; i < nlocal; i++) { lambda_input_ta[i] = lambda_input_history[i][history_length + 1]; }
+  for (i = 0; i < nlocal; i++) lambda_input_ta[i] = lambda_input_history[i][history_length + 1];
 }
 
 /* ----------------------------------------------------------------------
@@ -740,9 +739,7 @@ void FixLambdaAPIP::write_restart(FILE *fp)
 
 void FixLambdaAPIP::restart(char *buf)
 {
-  int timesteps_since_invoked_history_update, history_length_br,
-      timesteps_since_invoked_history2_update, history2_length_br;
-  bigint next_file_write_calculated;
+  int history_length_br, history2_length_br;
 
   int n = 0;
   auto list = (double *) buf;

--- a/src/APIP/fix_lambda_apip.cpp
+++ b/src/APIP/fix_lambda_apip.cpp
@@ -26,6 +26,8 @@
 #include "memory.h"
 #include "modify.h"
 #include "pair.h"
+#include "pair_lambda_input_apip.h"
+#include "pair_lambda_zone_apip.h"
 #include "update.h"
 
 using namespace LAMMPS_NS;

--- a/src/APIP/fix_lambda_apip.h
+++ b/src/APIP/fix_lambda_apip.h
@@ -24,8 +24,6 @@ FixStyle(lambda/apip,FixLambdaAPIP);
 #define LMP_FIX_LAMBDA_APIP_H
 
 #include "fix.h"
-#include "pair_lambda_input_apip.h"
-#include "pair_lambda_zone_apip.h"
 
 namespace LAMMPS_NS {
 

--- a/src/APIP/fix_lambda_thermostat_apip.cpp
+++ b/src/APIP/fix_lambda_thermostat_apip.cpp
@@ -405,14 +405,10 @@ void FixLambdaThermostatAPIP::calculate_energy_change()
 
 void FixLambdaThermostatAPIP::apply_thermostat()
 {
-  double xtmp, ytmp, ztmp, delx, dely, delz, delvx, delvy, delvz, r, dotvu, masstmp, massj, muij,
-      delv, delv_m, epsilon, epsilonsq, deltaK, rinv;
+  double xtmp, ytmp, ztmp, masstmp, massj;
   double m_cm, v_cm[3], beta_rescaling, k_rel, v_rel[3], radicand;
   int i, ii, inum, *ilist;
   int j, jj, jnum, *jlist;
-
-  int nlocal = atom->nlocal;
-  if (igroup == atom->firstgroup) nlocal = atom->nfirst;
 
   double **x = atom->x;
   double **v = atom->v;
@@ -421,8 +417,6 @@ void FixLambdaThermostatAPIP::apply_thermostat()
   int *type = atom->type;
   int *mask = atom->mask;
 
-  double *e_simple = atom->apip_e_fast;
-  double *e_complex = atom->apip_e_precise;
   double *lambda_const = atom->apip_lambda_const;
   double *lambda = atom->apip_lambda;
 
@@ -465,7 +459,6 @@ void FixLambdaThermostatAPIP::apply_thermostat()
                  "particles in neighbour list particle: {} {} {} groupbit {}\n",
                  xtmp, ytmp, ztmp, mask[i] & groupbit);
 
-    int i_collisions = 0;
     double e_remain = energy_change_atom[i];
 
     // copy ngh list

--- a/src/APIP/pair_eam_apip.cpp
+++ b/src/APIP/pair_eam_apip.cpp
@@ -143,7 +143,7 @@ void PairEAMAPIP::compute(int eflag, int vflag)
   int n_non_complex = 0;
 
   int i, j, ii, jj, m, inum, jnum, itype, jtype;
-  double xtmp, ytmp, ztmp, delx, dely, delz, evdwl, fpair, lambda_ij, fpair_cl;
+  double xtmp, ytmp, ztmp, delx, dely, delz, evdwl, fpair, fpair_cl;
   double rsq, r, p, rhoip, rhojp, z2, z2p, recip, phip, psip, phi, psip_cl;
   double *coeff;
   int *ilist, *jlist, *numneigh, **firstneigh;
@@ -181,7 +181,6 @@ void PairEAMAPIP::compute(int eflag, int vflag)
   }
   int *type = atom->type;
   int nlocal = atom->nlocal;
-  int nall = nlocal + atom->nghost;
   int newton_pair = force->newton_pair;
 
   inum = list->inum;

--- a/src/APIP/pair_eam_apip.cpp
+++ b/src/APIP/pair_eam_apip.cpp
@@ -30,6 +30,8 @@
 #include "potential_file_reader.h"
 #include "update.h"
 
+#include <cmath>
+
 using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
@@ -686,10 +688,9 @@ void PairEAMAPIP::file2array()
   }
 
   // set nr,nrho from cutoff and spacings
-  // 0.5 is for round-off in divide
 
-  nr = static_cast<int>(rmax / dr + 0.5);
-  nrho = static_cast<int>(rhomax / drho + 0.5);
+  nr = std::lround(rmax / dr);
+  nrho = std::lround(rhomax / drho);
 
   // ------------------------------------------------------------------
   // setup frho arrays

--- a/src/APIP/pair_lambda_input_csp_apip.cpp
+++ b/src/APIP/pair_lambda_input_csp_apip.cpp
@@ -265,7 +265,7 @@ void PairLambdaInputCSPAPIP::select(int k, int n, double *arr)
 
 void PairLambdaInputCSPAPIP::select2(int k, int n, double *arr, int *iarr)
 {
-  int i, ir, j, l, mid, ia, itmp;
+  int i, ir, j, l, mid, ia;
   double a;
 
   arr--;

--- a/src/APIP/pair_lambda_zone_apip.cpp
+++ b/src/APIP/pair_lambda_zone_apip.cpp
@@ -28,8 +28,7 @@ using namespace LAMMPS_NS;
 
 /* ---------------------------------------------------------------------- */
 
-PairLambdaZoneAPIP::PairLambdaZoneAPIP(LAMMPS *lmp) :
-    Pair(lmp), lambda_ta(nullptr), cut(nullptr)
+PairLambdaZoneAPIP::PairLambdaZoneAPIP(LAMMPS *lmp) : Pair(lmp), cut(nullptr), lambda_ta(nullptr)
 {
   // set defaults
 
@@ -140,7 +139,7 @@ void PairLambdaZoneAPIP::init_style()
     error->all(FLERR, "pair_lambda_zone requires an atom style with lambda_input_ta");
 
   // find fix lambda/apip
-  class Fix * fix_lambda = nullptr;
+  class Fix *fix_lambda = nullptr;
   int count = 0;
   for (int i = 0; i < modify->nfix; i++) {
     if (strcmp(modify->fix[i]->style, "lambda/apip") == 0) {
@@ -186,7 +185,7 @@ void PairLambdaZoneAPIP::calculate_lambda()
 
   double xtmp, ytmp, ztmp, delx, dely, delz, lambda_tmp, rsq, lambda_new;
   double **x, *lambda_input_ta;
-  int allnum, ii, i, nlocal, nall, jnum, j, jj, loop_iterations;
+  int allnum, ii, i, nlocal, jnum, j, jj, loop_iterations;
   int *ilist, *mask, *jlist, *numneigh, **firstneigh;
 
   mask = atom->mask;
@@ -194,7 +193,6 @@ void PairLambdaZoneAPIP::calculate_lambda()
   lambda_input_ta = atom->apip_lambda_input_ta;
 
   nlocal = atom->nlocal;
-  nall = nlocal + atom->nghost;
 
   if (nlocal > nmax_ta) {
     memory->destroy(lambda_ta);

--- a/src/BODY/body_nparticle.cpp
+++ b/src/BODY/body_nparticle.cpp
@@ -110,15 +110,12 @@ void BodyNparticle::data_body(int ibonus, int ninteger, int ndouble,
   // set ninteger, ndouble in bonus and allocate 2 vectors of ints, doubles
 
   if (ninteger != 1)
-    error->one(FLERR,"Incorrect # of integer values in "
-               "Bodies section of data file");
+    error->one(FLERR,"Incorrect # of integer values in Bodies section of data file");
   int nsub = ifile[0];
   if (nsub < 1)
-    error->one(FLERR,"Incorrect integer value in "
-               "Bodies section of data file");
+    error->one(FLERR,"Incorrect integer value in Bodies section of data file");
   if (ndouble != 6 + 3*nsub)
-    error->one(FLERR,"Incorrect # of floating-point values in "
-               "Bodies section of data file");
+    error->one(FLERR,"Incorrect # of floating-point values in Bodies section of data file");
 
   bonus->ninteger = 1;
   bonus->ivalue = icp->get(bonus->iindex);
@@ -139,8 +136,8 @@ void BodyNparticle::data_body(int ibonus, int ninteger, int ndouble,
   double *inertia = bonus->inertia;
   double evectors[3][3];
   int ierror = MathEigen::jacobi3(tensor,inertia,evectors);
-  if (ierror) error->one(FLERR,
-                         "Insufficient Jacobi rotations for body nparticle");
+  if (ierror)
+    error->one(FLERR, Error::NOLASTLINE, "Insufficient Jacobi rotations for body nparticle");
 
   // if any principal moment < scaled EPSILON, set to 0.0
 
@@ -187,8 +184,7 @@ void BodyNparticle::data_body(int ibonus, int ninteger, int ndouble,
     delta[0] = dfile[j];
     delta[1] = dfile[j+1];
     delta[2] = dfile[j+2];
-    MathExtra::transpose_matvec(ex_space,ey_space,ez_space,
-                                delta,&bonus->dvalue[k]);
+    MathExtra::transpose_matvec(ex_space,ey_space,ez_space,delta,&bonus->dvalue[k]);
     j += 3;
     k += 3;
   }
@@ -289,16 +285,13 @@ int BodyNparticle::write_data_body(FILE *fp, double *buf)
    called by Molecule class which needs single body size
 ------------------------------------------------------------------------- */
 
-double BodyNparticle::radius_body(int /*ninteger*/, int ndouble,
-                                  int *ifile, double *dfile)
+double BodyNparticle::radius_body(int /*ninteger*/, int ndouble, int *ifile, double *dfile)
 {
   int nsub = ifile[0];
   if (nsub < 1)
-    error->one(FLERR,"Incorrect integer value in "
-               "Bodies section of data file");
+    error->one(FLERR,"Incorrect integer value in Bodies section of data file");
   if (ndouble != 6 + 3*nsub)
-    error->one(FLERR,"Incorrect # of floating-point values in "
-               "Bodies section of data file");
+    error->one(FLERR,"Incorrect # of floating-point values in Bodies section of data file");
 
   // sub-particle coords are relative to body center at (0,0,0)
   // offset = 6 for sub-particle coords

--- a/src/COLVARS/colvarproxy_lammps.h
+++ b/src/COLVARS/colvarproxy_lammps.h
@@ -50,6 +50,9 @@ class colvarproxy_lammps : public colvarproxy {
 
   colvarproxy_lammps(LAMMPS_NS::LAMMPS *lmp);
   ~colvarproxy_lammps() override;
+  // disable default and copy constructor
+  colvarproxy_lammps() = delete;
+  colvarproxy_lammps(const colvarproxy_lammps &) = delete;
 
   void init();
 
@@ -57,11 +60,6 @@ class colvarproxy_lammps : public colvarproxy {
   void set_random_seed(int seed);
 
   int setup() override;
-
-  // disable default and copy constructor
- private:
-  colvarproxy_lammps() {};
-  colvarproxy_lammps(const colvarproxy_lammps &) {};
 
   // methods for lammps to move data or trigger actions in the proxy
  public:

--- a/src/GRANULAR/fix_pour.cpp
+++ b/src/GRANULAR/fix_pour.cpp
@@ -702,6 +702,8 @@ void FixPour::pre_exchange()
       atom->nangles += (bigint) onemols[imol]->nangles * ninserted_mols;
       atom->ndihedrals += (bigint) onemols[imol]->ndihedrals * ninserted_mols;
       atom->nimpropers += (bigint) onemols[imol]->nimpropers * ninserted_mols;
+      // body particle molecule template must contain only one atom
+      atom->nbodies += (bigint) onemols[imol]->bodyflag * ninserted_mols;
     }
     if (maxtag_all >= MAXTAGINT) error->all(FLERR, "New atom IDs exceed maximum allowed ID");
   }

--- a/src/GRANULAR/fix_pour.cpp
+++ b/src/GRANULAR/fix_pour.cpp
@@ -250,7 +250,7 @@ void FixPour::init()
       delta = yhi - ylo;
     }
     double t = (-v_relative - sqrt(v_relative * v_relative - 2.0 * grav * delta)) /   grav;
-    nfreq = static_cast<int>(t / update->dt + 0.5);
+    nfreq = std::lround(t / update->dt);
 
     // 1st insertion on next timestep
 

--- a/src/GRANULAR/fix_pour.cpp
+++ b/src/GRANULAR/fix_pour.cpp
@@ -684,7 +684,7 @@ void FixPour::pre_exchange()
   // warn if not successful with all insertions b/c too many attempts
 
   int ninserted_atoms = nnear - nprevious;
-  int ninserted_mols = ninserted_atoms / natom;  // clang_sa_ignore [core.DivideZero]
+  int ninserted_mols = ninserted_atoms / natom;
   ninserted += ninserted_mols;
   if (ninserted_mols < nnew && me == 0) error->warning(FLERR, "Fewer insertions than requested");
 

--- a/src/GRANULAR/fix_pour.cpp
+++ b/src/GRANULAR/fix_pour.cpp
@@ -684,7 +684,7 @@ void FixPour::pre_exchange()
   // warn if not successful with all insertions b/c too many attempts
 
   int ninserted_atoms = nnear - nprevious;
-  int ninserted_mols = ninserted_atoms / natom;
+  int ninserted_mols = ninserted_atoms / natom;  // clang_sa_ignore [core.DivideZero]
   ninserted += ninserted_mols;
   if (ninserted_mols < nnew && me == 0) error->warning(FLERR, "Fewer insertions than requested");
 

--- a/src/GRANULAR/gran_sub_mod_normal.cpp
+++ b/src/GRANULAR/gran_sub_mod_normal.cpp
@@ -572,7 +572,6 @@ double GranSubModNormalMDR::calculate_forces()
   double *sigmaxx = atom->dvector[index_sigmaxx];
   double *sigmayy = atom->dvector[index_sigmayy];
   double *sigmazz = atom->dvector[index_sigmazz];
-  double *dRavg = atom->dvector[index_dRavg];
 
   const int itag_true = atom->tag[gm->i]; // true i particle tag
   const int jtag_true = atom->tag[gm->j]; // true j particle tag

--- a/src/KOKKOS/fix_reaxff_species_kokkos.cpp
+++ b/src/KOKKOS/fix_reaxff_species_kokkos.cpp
@@ -53,7 +53,8 @@ void FixReaxFFSpeciesKokkos::init()
 {
   Pair* pair_kk = force->pair_match("^reax../kk",0);
   if (pair_kk == nullptr)
-    error->all(FLERR,"Cannot use fix reaxff/species/kk without pair_style reaxff/kk");
+    error->all(FLERR, Error::NOLASTLINE,
+               "Cannot use fix reaxff/species/kk without pair_style reaxff/kk");
 
   FixReaxFFSpecies::init();
 }

--- a/src/KOKKOS/pair_mliap_kokkos.cpp
+++ b/src/KOKKOS/pair_mliap_kokkos.cpp
@@ -416,8 +416,8 @@ int PairMLIAPKokkos<DeviceType>::pack_forward_comm_kokkos(
 template <class DeviceType>
 template <typename CommType>
 int PairMLIAPKokkos<DeviceType>::pack_forward_comm_kokkos(
-    int nv, DAT::tdual_int_1d idx_v, DAT::tdual_xfloat_1d &fill, int int2,
-    int *intp, CommType *copy_to) {
+  int nv, DAT::tdual_int_1d idx_v, DAT::tdual_xfloat_1d &fill, int /*int2*/,
+  int */*intp*/, CommType *copy_to) {
   auto idx=idx_v.view<DeviceType>();
   auto val=fill.view<DeviceType>();
   int nf=vec_len;
@@ -457,7 +457,7 @@ int PairMLIAPKokkos<DeviceType>::pack_forward_comm(int nv, int* idx_v, double *f
 template<class DeviceType>
 template <typename CommType>
 int PairMLIAPKokkos<DeviceType>::pack_forward_comm(int nv, int* idx_v, double *fill,
-                                                   int int2, int *intp, CommType *copy_to)
+                                                   int /*int2*/, int */*intp*/, CommType *copy_to)
 {
   for (int i=0;i<nv;++i) {
     int gstart=idx_v[i]*vec_len;

--- a/src/LATBOLTZ/fix_lb_fluid.cpp
+++ b/src/LATBOLTZ/fix_lb_fluid.cpp
@@ -438,9 +438,9 @@ FixLbFluid::FixLbFluid(LAMMPS *lmp, int narg, char **arg) :
   //--------------------------------------------------------------------------
   // Set the total number of grid points in each direction.
   //--------------------------------------------------------------------------
-  Nbx = (int) (domain->xprd / dx_lb + 0.5);
-  Nby = (int) (domain->yprd / dx_lb + 0.5);
-  Nbz = (int) (domain->zprd / dx_lb + 0.5);
+  Nbx = std::lround(domain->xprd / dx_lb);
+  Nby = std::lround(domain->yprd / dx_lb);
+  Nbz = std::lround(domain->zprd / dx_lb);
 
   //--------------------------------------------------------------------------
   // Set the number of grid points in each dimension for the local subgrids.
@@ -739,9 +739,9 @@ void FixLbFluid::init()
   // between runs.
   //--------------------------------------------------------------------------
   int Nbx_now, Nby_now, Nbz_now;
-  Nbx_now = (int) (domain->xprd / dx_lb + 0.5);
-  Nby_now = (int) (domain->yprd / dx_lb + 0.5);
-  Nbz_now = (int) (domain->zprd / dx_lb + 0.5);
+  Nbx_now = std::lround(domain->xprd / dx_lb);
+  Nby_now = std::lround(domain->yprd / dx_lb);
+  Nbz_now = std::lround(domain->zprd / dx_lb);
   // If there are walls in the z-direction add an extra grid point.
   if (domain->periodicity[2] == 0) { Nbz_now += 1; }
 

--- a/src/MANYBODY/pair_eam.cpp
+++ b/src/MANYBODY/pair_eam.cpp
@@ -206,7 +206,7 @@ void PairEAM::compute(int eflag, int vflag)
       if (rsq < cutforcesq) {
         jtype = type[j];
         p = sqrt(rsq)*rdr + 1.0;
-        m = static_cast<int> (p);
+        m = static_cast<int>(p);
         m = MIN(m,nr-1);
         p -= m;
         p = MIN(p,1.0);
@@ -232,7 +232,7 @@ void PairEAM::compute(int eflag, int vflag)
   for (ii = 0; ii < inum; ii++) {
     i = ilist[ii];
     p = rho[i]*rdrho + 1.0;
-    m = static_cast<int> (p);
+    m = static_cast<int>(p);
     m = MAX(1,MIN(m,nrho-1));
     p -= m;
     p = MIN(p,1.0);
@@ -283,7 +283,7 @@ void PairEAM::compute(int eflag, int vflag)
         jtype = type[j];
         r = sqrt(rsq);
         p = r*rdr + 1.0;
-        m = static_cast<int> (p);
+        m = static_cast<int>(p);
         m = MIN(m,nr-1);
         p -= m;
         p = MIN(p,1.0);
@@ -636,10 +636,9 @@ void PairEAM::file2array()
   }
 
   // set nr,nrho from cutoff and spacings
-  // 0.5 is for round-off in divide
 
-  nr = static_cast<int> (rmax/dr + 0.5);
-  nrho = static_cast<int> (rhomax/drho + 0.5);
+  nr = std::lround(rmax/dr);
+  nrho = std::lround(rhomax/drho);
 
   // ------------------------------------------------------------------
   // setup frho arrays
@@ -662,7 +661,7 @@ void PairEAM::file2array()
     for (m = 1; m <= nrho; m++) {
       r = (m-1)*drho;
       p = r/file->drho + 1.0;
-      k = static_cast<int> (p);
+      k = static_cast<int>(p);
       k = MIN(k,file->nrho-2);
       k = MAX(k,2);
       p -= k;
@@ -709,7 +708,7 @@ void PairEAM::file2array()
     for (m = 1; m <= nr; m++) {
       r = (m-1)*dr;
       p = r/file->dr + 1.0;
-      k = static_cast<int> (p);
+      k = static_cast<int>(p);
       k = MIN(k,file->nr-2);
       k = MAX(k,2);
       p -= k;
@@ -759,7 +758,7 @@ void PairEAM::file2array()
         r = (m-1)*dr;
 
         p = r/ifile->dr + 1.0;
-        k = static_cast<int> (p);
+        k = static_cast<int>(p);
         k = MIN(k,ifile->nr-2);
         k = MAX(k,2);
         p -= k;
@@ -772,7 +771,7 @@ void PairEAM::file2array()
           cof3*ifile->zr[k+1] + cof4*ifile->zr[k+2];
 
         p = r/jfile->dr + 1.0;
-        k = static_cast<int> (p);
+        k = static_cast<int>(p);
         k = MIN(k,jfile->nr-2);
         k = MAX(k,2);
         p -= k;
@@ -896,7 +895,7 @@ double PairEAM::single(int i, int j, int itype, int jtype,
 
   if (numforce[i] > 0) {
     p = rho[i]*rdrho + 1.0;
-    m = static_cast<int> (p);
+    m = static_cast<int>(p);
     m = MAX(1,MIN(m,nrho-1));
     p -= m;
     p = MIN(p,1.0);
@@ -908,7 +907,7 @@ double PairEAM::single(int i, int j, int itype, int jtype,
 
   r = sqrt(rsq);
   p = r*rdr + 1.0;
-  m = static_cast<int> (p);
+  m = static_cast<int>(p);
   m = MIN(m,nr-1);
   p -= m;
   p = MIN(p,1.0);

--- a/src/MC/fix_charge_regulation.cpp
+++ b/src/MC/fix_charge_regulation.cpp
@@ -1087,11 +1087,11 @@ int FixChargeRegulation::get_random_particle(int ptype, double charge, double rd
     double dx, dy, dz, distance_check;
     for (int i = 0; i < nlocal; i++) {
       dx = fabs(atom->x[i][0] - target[0]);
-      dx -= static_cast<int>(1.0 * dx / (xhi - xlo) + 0.5) * (xhi - xlo);
+      dx -= std::lround(1.0 * dx / (xhi - xlo)) * (xhi - xlo);
       dy = fabs(atom->x[i][1] - target[1]);
-      dy -= static_cast<int>(1.0 * dy / (yhi - ylo) + 0.5) * (yhi - ylo);
+      dy -= std::lround(1.0 * dy / (yhi - ylo)) * (yhi - ylo);
       dz = fabs(atom->x[i][2] - target[2]);
-      dz -= static_cast<int>(1.0 * dz / (zhi - zlo) + 0.5) * (zhi - zlo);
+      dz -= std::lround(1.0 * dz / (zhi - zlo)) * (zhi - zlo);
       distance_check = dx * dx + dy * dy + dz * dz;
       if ((distance_check < rd * rd) && atom->type[i] == ptype &&
           fabs(atom->q[i] - charge) < SMALL && atom->mask[i] != exclusion_group_bit) {
@@ -1193,11 +1193,11 @@ int FixChargeRegulation::particle_number_xrd(int ptype, double charge, double rd
     double dx, dy, dz, distance_check;
     for (int i = 0; i < atom->nlocal; i++) {
       dx = fabs(atom->x[i][0] - target[0]);
-      dx -= static_cast<int>(1.0 * dx / (xhi - xlo) + 0.5) * (xhi - xlo);
+      dx -= std::lround(1.0 * dx / (xhi - xlo)) * (xhi - xlo);
       dy = fabs(atom->x[i][1] - target[1]);
-      dy -= static_cast<int>(1.0 * dy / (yhi - ylo) + 0.5) * (yhi - ylo);
+      dy -= std::lround(1.0 * dy / (yhi - ylo)) * (yhi - ylo);
       dz = fabs(atom->x[i][2] - target[2]);
-      dz -= static_cast<int>(1.0 * dz / (zhi - zlo) + 0.5) * (zhi - zlo);
+      dz -= std::lround(1.0 * dz / (zhi - zlo)) * (zhi - zlo);
       distance_check = dx * dx + dy * dy + dz * dz;
       if ((distance_check < rd * rd) && atom->type[i] == ptype &&
           fabs(atom->q[i] - charge) < SMALL && atom->mask[i] != exclusion_group_bit) {
@@ -1283,10 +1283,10 @@ void FixChargeRegulation::restart(char *buf)
   int n = 0;
   auto list = (double *) buf;
 
-  seed = static_cast<int> (list[n++]);
+  seed = static_cast<int>(list[n++]);
   random_equal->reset(seed);
 
-  seed = static_cast<int> (list[n++]);
+  seed = static_cast<int>(list[n++]);
   random_unequal->reset(seed);
 
   nacid_attempts  = list[n++];

--- a/src/ML-UF3/pair_uf3.cpp
+++ b/src/ML-UF3/pair_uf3.cpp
@@ -286,8 +286,7 @@ void PairUF3::uf3_read_unified_pot_file(char *potf_name)
       if (nbody_on_file == "2B") {
         //2B block
         if (fp2nd_line.count() != 6)
-          error->all(FLERR,
-                     "UF3: Expected 6 words on line {} of {} file but found {} word/s",
+          error->all(FLERR, "UF3: Expected 6 words on line {} of {} file but found {} word/s",
                      line_counter, potf_name, fp2nd_line.count());
 
         //get the elements
@@ -604,7 +603,7 @@ void PairUF3::uf3_read_unified_pot_file(char *potf_name)
           temp_line = txtfilereader.next_line(num_knots_2b);
           ValueTokenizer fp4th_line(temp_line);
 
-          if (fp4th_line.count() != num_knots_2b)
+          if ((int) fp4th_line.count() != num_knots_2b)
             error->all(FLERR,
                        "UF3: Error reading the 2B potential block for {}-{}\n"
                        "Expected {} numbers on 4th line of the block but found {} numbers",
@@ -627,7 +626,7 @@ void PairUF3::uf3_read_unified_pot_file(char *potf_name)
           temp_line = txtfilereader.next_line(num_of_coeff_2b);
           ValueTokenizer fp6th_line(temp_line);
 
-          if (fp6th_line.count() != num_of_coeff_2b)
+          if ((int) fp6th_line.count() != num_of_coeff_2b)
             error->all(FLERR,
                        "UF3: Error reading the 2B potential block for {}-{}\n"
                        "Expected {} numbers on 6th line of the block but found {} numbers",
@@ -703,7 +702,7 @@ void PairUF3::uf3_read_unified_pot_file(char *potf_name)
 
           temp_line = txtfilereader.next_line(num_knots_3b_jk);
           ValueTokenizer fp4th_line(temp_line);
-          if (fp4th_line.count() != num_knots_3b_jk)
+          if ((int) fp4th_line.count() != num_knots_3b_jk)
             error->all(FLERR,
                        "UF3: Error reading the 3B potential block for {}-{}-{}\n"
                        "Expected {} numbers on 4th line of the block but found {} "
@@ -726,7 +725,7 @@ void PairUF3::uf3_read_unified_pot_file(char *potf_name)
 
           temp_line = txtfilereader.next_line(num_knots_3b_ik);
           ValueTokenizer fp5th_line(temp_line);
-          if (fp5th_line.count() != num_knots_3b_ik)
+          if ((int) fp5th_line.count() != num_knots_3b_ik)
             error->all(FLERR,
                        "UF3: Error reading the 3B potential block for {}-{}-{}\n"
                        "Expected {} numbers on 5th line of the block but found {} "
@@ -749,7 +748,7 @@ void PairUF3::uf3_read_unified_pot_file(char *potf_name)
 
           temp_line = txtfilereader.next_line(num_knots_3b_ij);
           ValueTokenizer fp6th_line(temp_line);
-          if (fp6th_line.count() != num_knots_3b_ij)
+          if ((int) fp6th_line.count() != num_knots_3b_ij)
             error->all(FLERR,
                        "UF3: Error reading the 3B potential block for {}-{}-{}\n"
                        "Expected {} numbers on 6th line of the block but found {} "
@@ -807,7 +806,7 @@ void PairUF3::uf3_read_unified_pot_file(char *potf_name)
             for (int j = 0; j < coeff_matrix_dim2; j++) {
               temp_line = txtfilereader.next_line(coeff_matrix_elements_len);
               ValueTokenizer coeff_line(temp_line);
-              if (coeff_line.count() != coeff_matrix_elements_len)
+              if ((int) coeff_line.count() != coeff_matrix_elements_len)
                 error->all(FLERR,
                            "UF3: Error reading 3B potential block for {}-{}-{}\n"
                            "Expected {} numbers on {}th line of the block but found {} "
@@ -835,7 +834,7 @@ void PairUF3::uf3_read_unified_pot_file(char *potf_name)
         }
       }
     }    // if #UF3 POT
-  }      //while
+  }    //while
   fclose(fp);
 
   //Set interaction of atom types of the same elements

--- a/src/PTM/ptm_initialize_data.cpp
+++ b/src/PTM/ptm_initialize_data.cpp
@@ -31,7 +31,7 @@ static int initialize_graphs(const ptm::refdata_t* s, int8_t* colours)
         {
                 int8_t code[2 * PTM_MAX_EDGES];
                 int8_t degree[PTM_MAX_NBRS];
-                int _max_degree = ptm::graph_degree(s->num_facets, s->graphs[i].facets, s->num_nbrs, degree);
+                ptm::graph_degree(s->num_facets, s->graphs[i].facets, s->num_nbrs, degree);
                 assert(_max_degree <= s->max_degree);
 
                 make_facets_clockwise(s->num_facets, s->graphs[i].facets, &s->points[1]);

--- a/src/PTM/ptm_initialize_data.cpp
+++ b/src/PTM/ptm_initialize_data.cpp
@@ -31,7 +31,7 @@ static int initialize_graphs(const ptm::refdata_t* s, int8_t* colours)
         {
                 int8_t code[2 * PTM_MAX_EDGES];
                 int8_t degree[PTM_MAX_NBRS];
-                ptm::graph_degree(s->num_facets, s->graphs[i].facets, s->num_nbrs, degree);
+                int _max_degree = ptm::graph_degree(s->num_facets, s->graphs[i].facets, s->num_nbrs, degree);
                 assert(_max_degree <= s->max_degree);
 
                 make_facets_clockwise(s->num_facets, s->graphs[i].facets, &s->points[1]);

--- a/src/REAXFF/fix_qtpie_reaxff.cpp
+++ b/src/REAXFF/fix_qtpie_reaxff.cpp
@@ -493,7 +493,7 @@ void FixQtpieReaxFF::init()
       error->all(FLERR,"Atom-style external electric field requires atom-style "
                        "potential variable when used with fix {}", style);
   } else {
-    if (utils::strmatch(style,"^qeqr/reax") && comm->me == 0)
+    if (utils::strmatch(style,"^qeq/rel/reax") && comm->me == 0)
       error->warning(FLERR, "Use fix qeq/reaxff instead of fix {} when not using fix efield\n",
                      style);
   }

--- a/src/REAXFF/fix_reaxff_bonds.cpp
+++ b/src/REAXFF/fix_reaxff_bonds.cpp
@@ -29,6 +29,8 @@
 #include "pair_reaxff.h"
 #include "reaxff_api.h"
 
+#include <cmath>
+
 using namespace LAMMPS_NS;
 using namespace FixConst;
 using namespace ReaxFF;
@@ -205,7 +207,7 @@ void FixReaxFFBonds::PassBuffer(double *buf, int &nbuf_local)
     buf[j+2] = reaxff->api->workspace->nlp[i];
     buf[j+3] = atom->q[i];
     buf[j+4] = numneigh[i];
-    numbonds = nint(buf[j+4]);
+    numbonds = std::lround(buf[j+4]);
 
     for (k = 5; k < 5+numbonds; k++) {
       buf[j+k] = neighid[i][k-5];
@@ -273,16 +275,16 @@ void FixReaxFFBonds::RecvBuffer(double *buf, int nbuf, int nbuf_local,
       } else {
         MPI_Irecv(&buf[0],nbuf,MPI_DOUBLE,inode,0,world,&irequest);
         MPI_Wait(&irequest,MPI_STATUS_IGNORE);
-        nlocal_tmp = nint(buf[0]);
+        nlocal_tmp = std::lround(buf[0]);
       }
       j = 2;
       for (i = 0; i < nlocal_tmp; i ++) {
         itag = static_cast<tagint> (buf[j-1]);
-        itype = nint(buf[j+0]);
+        itype = std::lround(buf[j+0]);
         sbotmp = buf[j+1];
         nlptmp = buf[j+2];
         avqtmp = buf[j+3];
-        numbonds = nint(buf[j+4]);
+        numbonds = std::lround(buf[j+4]);
 
         auto mesg = fmt::format(" {} {} {}",itag,itype,numbonds);
         for (k = 5; k < 5+numbonds; k++)
@@ -307,16 +309,6 @@ void FixReaxFFBonds::RecvBuffer(double *buf, int nbuf, int nbuf_local,
     fputs("# \n",fp);
     fflush(fp);
   }
-}
-
-/* ---------------------------------------------------------------------- */
-
-int FixReaxFFBonds::nint(const double &r)
-{
-  int i = 0;
-  if (r>0.0) i = static_cast<int>(r+0.5);
-  else if (r<0.0) i = static_cast<int>(r-0.5);
-  return i;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/REAXFF/fix_reaxff_bonds.cpp
+++ b/src/REAXFF/fix_reaxff_bonds.cpp
@@ -85,6 +85,9 @@ int FixReaxFFBonds::setmask()
 
 void FixReaxFFBonds::setup(int /*vflag*/)
 {
+  if (atom->natoms > MAXSMALLINT)
+    error->all(FLERR, Error::NOLASTLINE, "Too many atoms for fix {}", style);
+
   // only print output during setup() at the very beginning
   // to avoid duplicate outputs when using multiple run statements
   if (first_flag) end_of_step();
@@ -96,8 +99,9 @@ void FixReaxFFBonds::setup(int /*vflag*/)
 void FixReaxFFBonds::init()
 {
   reaxff = dynamic_cast<PairReaxFF *>(force->pair_match("^reax..",0));
-  if (reaxff == nullptr) error->all(FLERR,"Cannot use fix reaxff/bonds without "
-                                "pair_style reaxff, reaxff/kk, or reaxff/omp");
+  if (reaxff == nullptr)
+    error->all(FLERR, Error::NOLASTLINE, "Cannot use fix reaxff/bonds without "
+               "pair_style reaxff, reaxff/kk, or reaxff/omp");
 }
 
 /* ---------------------------------------------------------------------- */
@@ -118,7 +122,7 @@ void FixReaxFFBonds::Output_ReaxFF_Bonds()
   double *buf;
 
   int nlocal = atom->nlocal;
-  int nlocal_tot = static_cast<int> (atom->natoms);
+  int nlocal_tot = static_cast<int>(atom->natoms);
 
   if (atom->nmax > nmax) {
     destroy();

--- a/src/REAXFF/fix_reaxff_bonds.h
+++ b/src/REAXFF/fix_reaxff_bonds.h
@@ -48,7 +48,6 @@ class FixReaxFFBonds : public Fix {
   int FindBond();
   void PassBuffer(double *, int &);
   void RecvBuffer(double *, int, int, int, int);
-  int nint(const double &);
   int modify_param(int, char **) override;
   double memory_usage() override;
 

--- a/src/REAXFF/fix_reaxff_species.cpp
+++ b/src/REAXFF/fix_reaxff_species.cpp
@@ -344,7 +344,7 @@ void FixReaxFFSpecies::setup(int /*vflag*/)
 {
   if (atom->natoms > MAXSMALLINT)
     error->all(FLERR, Error::NOLASTLINE, "Too many atoms for fix {}", style);
-    
+
   ntotal = static_cast<int>(atom->natoms);
 
   if (!eleflag) {
@@ -589,8 +589,8 @@ void FixReaxFFSpecies::SortMolecule(int &Nmole)
   for (n = 0; n < nlocal; n++) {
     if (!(mask[n] & groupbit)) continue;
     if (clusterID[n] == 0.0) flag = 1;
-    lo = MIN(lo, nint(clusterID[n]));
-    hi = MAX(hi, nint(clusterID[n]));
+    lo = MIN(lo, std::lround(clusterID[n]));
+    hi = MAX(hi, std::lround(clusterID[n]));
   }
   int flagall;
   MPI_Allreduce(&lo, &idlo, 1, MPI_INT, MPI_MIN, world);
@@ -615,7 +615,7 @@ void FixReaxFFSpecies::SortMolecule(int &Nmole)
 
   for (n = 0; n < nlocal; n++) {
     if (!(mask[n] & groupbit)) continue;
-    molmap[nint(clusterID[n]) - idlo] = 1;
+    molmap[std::lround(clusterID[n]) - idlo] = 1;
   }
 
   int *molmapall;
@@ -634,8 +634,8 @@ void FixReaxFFSpecies::SortMolecule(int &Nmole)
   flag = 0;
   for (n = 0; n < nlocal; n++) {
     if (mask[n] & groupbit) continue;
-    if (nint(clusterID[n]) < idlo || nint(clusterID[n]) > idhi) continue;
-    if (molmap[nint(clusterID[n]) - idlo] >= 0) flag = 1;
+    if (std::lround(clusterID[n]) < idlo || std::lround(clusterID[n]) > idhi) continue;
+    if (molmap[std::lround(clusterID[n]) - idlo] >= 0) flag = 1;
   }
 
   MPI_Allreduce(&flag, &flagall, 1, MPI_INT, MPI_SUM, world);
@@ -643,7 +643,7 @@ void FixReaxFFSpecies::SortMolecule(int &Nmole)
 
   for (n = 0; n < nlocal; n++) {
     if (!(mask[n] & groupbit)) continue;
-    clusterID[n] = molmap[nint(clusterID[n]) - idlo] + 1;
+    clusterID[n] = molmap[std::lround(clusterID[n]) - idlo] + 1;
   }
 
   memory->destroy(molmap);
@@ -681,7 +681,7 @@ void FixReaxFFSpecies::FindSpecies(int Nmole, int &Nspec)
     for (n = 0; n < nutypes; n++) Name[n] = 0;
     for (n = 0, flag_mol = 0; n < nlocal; n++) {
       if (!(mask[n] & groupbit)) continue;
-      cid = nint(clusterID[n]);
+      cid = std::lround(clusterID[n]);
       if (cid == m) {
         itype = ele2uele[atom->type[n] - 1];
         Name[itype]++;
@@ -878,7 +878,7 @@ void FixReaxFFSpecies::WritePos(int Nmole, int Nspec)
 
     for (i = 0; i < nlocal; i++) {
       if (!(mask[i] & groupbit)) continue;
-      cid = nint(clusterID[i]);
+      cid = std::lround(clusterID[i]);
       if (cid == m) {
         itype = ele2uele[atom->type[i] - 1];
         Name[itype]++;
@@ -1017,7 +1017,7 @@ void FixReaxFFSpecies::DeleteSpecies(int Nmole, int Nspec)
 
     for (i = 0; i < nlocal; i++) {
       if (!(mask[i] & groupbit)) continue;
-      cid = nint(clusterID[i]);
+      cid = std::lround(clusterID[i]);
       if (cid == m) {
         itype = ele2uele[type[i] - 1];
         Name[itype]++;
@@ -1156,18 +1156,6 @@ double FixReaxFFSpecies::compute_vector(int n)
   if (n == 0) return vector_nmole;
   if (n == 1) return vector_nspec;
   return 0.0;
-}
-
-/* ---------------------------------------------------------------------- */
-
-int FixReaxFFSpecies::nint(const double &r)
-{
-  int i = 0;
-  if (r > 0.0)
-    i = static_cast<int>(r + 0.5);
-  else if (r < 0.0)
-    i = static_cast<int>(r - 0.5);
-  return i;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/REAXFF/fix_reaxff_species.h
+++ b/src/REAXFF/fix_reaxff_species.h
@@ -77,7 +77,6 @@ class FixReaxFFSpecies : public Fix {
   int CheckExistence(int, int);
   void GetUniqueElements();
 
-  int nint(const double &);
   int pack_forward_comm(int, int *, double *, int, int *) override;
   void unpack_forward_comm(int, int, double *) override;
   void OpenPos();

--- a/src/SRD/fix_srd.cpp
+++ b/src/SRD/fix_srd.cpp
@@ -3113,9 +3113,9 @@ void FixSRD::setup_velocity_bins()
 {
   // require integer # of bins across global domain
 
-  nbin1x = static_cast<int>(domain->xprd / gridsrd + 0.5);
-  nbin1y = static_cast<int>(domain->yprd / gridsrd + 0.5);
-  nbin1z = static_cast<int>(domain->zprd / gridsrd + 0.5);
+  nbin1x = std::lround(domain->xprd / gridsrd);
+  nbin1y = std::lround(domain->yprd / gridsrd);
+  nbin1z = std::lround(domain->zprd / gridsrd);
   if (dimension == 2) nbin1z = 1;
 
   if (nbin1x == 0) nbin1x = 1;

--- a/src/angle.cpp
+++ b/src/angle.cpp
@@ -185,7 +185,6 @@ void Angle::ev_setup(int eflag, int vflag, int alloc)
       cvatom[i][6] = 0.0;
       cvatom[i][7] = 0.0;
       cvatom[i][8] = 0.0;
-      cvatom[i][9] = 0.0;
     }
   }
 }

--- a/src/atom_vec_body.cpp
+++ b/src/atom_vec_body.cpp
@@ -555,7 +555,7 @@ void AtomVecBody::data_atom_post(int ilocal)
 
 void AtomVecBody::data_body(int m, int ninteger, int ndouble, int *ivalues, double *dvalues)
 {
-  if (body[m]) error->one(FLERR, "Assigning body parameters to non-body atom");
+  if (body[m]) error->one(FLERR, "Assigning body parameters to an atom that already has them");
   if (nlocal_bonus == nmax_bonus) grow_bonus();
   bonus[nlocal_bonus].ilocal = m;
   bptr->data_body(nlocal_bonus, ninteger, ndouble, ivalues, dvalues);

--- a/src/atom_vec_body.cpp
+++ b/src/atom_vec_body.cpp
@@ -555,7 +555,8 @@ void AtomVecBody::data_atom_post(int ilocal)
 
 void AtomVecBody::data_body(int m, int ninteger, int ndouble, int *ivalues, double *dvalues)
 {
-  if (body[m]) error->one(FLERR, "Assigning body parameters to an atom that already has them");
+  if (body[m])
+    error->one(FLERR, "Assigning body parameters to atom {} that already has them", tag[m]);
   if (nlocal_bonus == nmax_bonus) grow_bonus();
   bonus[nlocal_bonus].ilocal = m;
   bptr->data_body(nlocal_bonus, ninteger, ndouble, ivalues, dvalues);

--- a/src/atom_vec_body.h
+++ b/src/atom_vec_body.h
@@ -25,6 +25,7 @@ AtomStyle(body,AtomVecBody);
 namespace LAMMPS_NS {
 
 class AtomVecBody : public AtomVec {
+ friend class CreateAtoms;
  public:
   class Body *bptr;
 
@@ -77,7 +78,7 @@ class AtomVecBody : public AtomVec {
 
   int nlocal_bonus;
 
- private:
+ protected:
   int *body;
   double *rmass, *radius;
   double **angmom;

--- a/src/compute_chunk_atom.cpp
+++ b/src/compute_chunk_atom.cpp
@@ -1268,7 +1268,7 @@ int ComputeChunkAtom::setup_xyz_bins()
     if (lo > hi) error->all(FLERR, Error::NOLASTLINE, "Invalid bin bounds in compute chunk/atom");
 
     offset[m] = lo;
-    nlayers[m] = static_cast<int>((hi - lo) * invdelta[m] + 0.5);
+    nlayers[m] = std::lround((hi - lo) * invdelta[m]);
     nbins *= nlayers[m];
   }
 

--- a/src/compute_msd.cpp
+++ b/src/compute_msd.cpp
@@ -29,7 +29,7 @@ using namespace LAMMPS_NS;
 
 ComputeMSD::ComputeMSD(LAMMPS *lmp, int narg, char **arg) : Compute(lmp, narg, arg), id_fix(nullptr)
 {
-  if (narg < 3) error->all(FLERR, "Illegal compute msd command");
+  if (narg < 3) utils::missing_cmd_args(FLERR, "compute msd", error);
 
   vector_flag = 1;
   size_vector = 4;
@@ -53,11 +53,11 @@ ComputeMSD::ComputeMSD(LAMMPS *lmp, int narg, char **arg) : Compute(lmp, narg, a
       avflag = utils::logical(FLERR, arg[iarg + 1], false, lmp);
       iarg += 2;
     } else
-      error->all(FLERR, "Unknown compute msd keyword: {}", arg[iarg]);
+      error->all(FLERR, iarg, "Unknown compute msd keyword: {}", arg[iarg]);
   }
 
   if (group->dynamic[igroup])
-    error->all(FLERR, "Compute {} is not compatible with dynamic groups", style);
+    error->all(FLERR, 1, "Compute {} is not compatible with dynamic groups", style);
 
   // create a new fix STORE style for reference positions
   // id = compute-ID + COMPUTE_STORE, fix group = compute group

--- a/src/compute_msd.cpp
+++ b/src/compute_msd.cpp
@@ -128,7 +128,8 @@ void ComputeMSD::init()
   // set fix which stores reference atom coords
 
   fix = dynamic_cast<FixStoreAtom *>(modify->get_fix_by_id(id_fix));
-  if (!fix) error->all(FLERR, "Could not find compute msd fix with ID {}", id_fix);
+  if (!fix)
+    error->all(FLERR, Error::NOLASTLINE, "Could not find compute msd fix with ID {}", id_fix);
 
   // nmsd = # of atoms in group
 
@@ -140,6 +141,12 @@ void ComputeMSD::init()
 
 void ComputeMSD::compute_vector()
 {
+  // check that nmsd is unchanged
+
+  int newnmsd = group->count(igroup);
+  if (newnmsd != nmsd)
+    error->all(FLERR, Error::NOLASTLINE, "Number of atoms in compute msd group must not change.");
+
   invoked_vector = update->ntimestep;
 
   // cm = current center of mass

--- a/src/create_atoms.cpp
+++ b/src/create_atoms.cpp
@@ -666,18 +666,6 @@ void CreateAtoms::command(int narg, char **arg)
           if (onemol->specialflag)
             for (int j = 0; j < nspecial[ilocal][2]; j++) special[ilocal][j] += offset;
         }
-
-        // create body particle
-
-        if (onemol->bodyflag) {
-          auto *avec_body = dynamic_cast<AtomVecBody *>(atom->avec);
-          if (avec_body)
-            avec_body->data_body(ilocal, onemol->nibody, onemol->ndbody, onemol->ibodyparams,
-                                 onemol->dbodyparams);
-          else
-            error->all(FLERR, Error::NOLASTLINE, "Molecule template {} requires a body atom style",
-                       onemol->id);
-        }
         ilocal++;
       }
       if (molecule_flag) {

--- a/src/dihedral.cpp
+++ b/src/dihedral.cpp
@@ -184,7 +184,6 @@ void Dihedral::ev_setup(int eflag, int vflag, int alloc)
       cvatom[i][6] = 0.0;
       cvatom[i][7] = 0.0;
       cvatom[i][8] = 0.0;
-      cvatom[i][9] = 0.0;
     }
   }
 }

--- a/src/dump_atom.cpp
+++ b/src/dump_atom.cpp
@@ -677,12 +677,12 @@ int DumpAtom::convert_image(int n, double *mybuf)
     offset += snprintf(&sbuf[offset],
                       maxsbuf - offset,
                       format,
-                      static_cast<tagint> (mybuf[m]),
-                      static_cast<int> (mybuf[m+1]),
+                      static_cast<tagint>(mybuf[m]),
+                      static_cast<int>(mybuf[m+1]),
                       mybuf[m+2],mybuf[m+3],mybuf[m+4],
-                      static_cast<int> (mybuf[m+5]),
-                      static_cast<int> (mybuf[m+6]),
-                      static_cast<int> (mybuf[m+7]));
+                      static_cast<int>(mybuf[m+5]),
+                      static_cast<int>(mybuf[m+6]),
+                      static_cast<int>(mybuf[m+7]));
     m += size_one;
   }
 
@@ -705,8 +705,8 @@ int DumpAtom::convert_noimage(int n, double *mybuf)
     offset += snprintf(&sbuf[offset],
                       maxsbuf - offset,
                       format,
-                      static_cast<tagint> (mybuf[m]),
-                      static_cast<int> (mybuf[m+1]),
+                      static_cast<tagint>(mybuf[m]),
+                      static_cast<int>(mybuf[m+1]),
                       mybuf[m+2],mybuf[m+3],mybuf[m+4]);
     m += size_one;
   }
@@ -738,9 +738,9 @@ void DumpAtom::write_lines_image(int n, double *mybuf)
   int m = 0;
   for (int i = 0; i < n; i++) {
     fprintf(fp,format,
-            static_cast<tagint> (mybuf[m]), static_cast<int> (mybuf[m+1]),
-            mybuf[m+2],mybuf[m+3],mybuf[m+4], static_cast<int> (mybuf[m+5]),
-            static_cast<int> (mybuf[m+6]), static_cast<int> (mybuf[m+7]));
+            static_cast<tagint>(mybuf[m]), static_cast<int>(mybuf[m+1]),
+            mybuf[m+2],mybuf[m+3],mybuf[m+4], static_cast<int>(mybuf[m+5]),
+            static_cast<int>(mybuf[m+6]), static_cast<int>(mybuf[m+7]));
     m += size_one;
   }
 }
@@ -752,8 +752,8 @@ void DumpAtom::write_lines_noimage(int n, double *mybuf)
   int m = 0;
   for (int i = 0; i < n; i++) {
     fprintf(fp,format,
-            static_cast<tagint> (mybuf[m]), static_cast<int> (mybuf[m+1]),
-            mybuf[m+2],mybuf[m+3],mybuf[m+4]);
+            static_cast<tagint>(mybuf[m]), static_cast<int>(mybuf[m+1]),
+            mybuf[m+2], mybuf[m+3], mybuf[m+4]);
     m += size_one;
   }
 }

--- a/src/dump_image.cpp
+++ b/src/dump_image.cpp
@@ -928,10 +928,10 @@ void DumpImage::create_image()
       j = clist[i];
 
       if (acolor == TYPE) {
-        itype = static_cast<int> (buf[m]);
+        itype = static_cast<int>(buf[m]);
         color = colortype[itype];
       } else if (acolor == ELEMENT) {
-        itype = static_cast<int> (buf[m]);
+        itype = static_cast<int>(buf[m]);
         color = colorelement[itype];
       } else if (acolor == ATTRIBUTE) {
         color = image->map_value2color(0,buf[m]);
@@ -940,10 +940,10 @@ void DumpImage::create_image()
       if (adiam == NUMERIC) {
         diameter = adiamvalue;
       } else if (adiam == TYPE) {
-        itype = static_cast<int> (buf[m+1]);
+        itype = static_cast<int>(buf[m+1]);
         diameter = diamtype[itype];
       } else if (adiam == ELEMENT) {
-        itype = static_cast<int> (buf[m+1]);
+        itype = static_cast<int>(buf[m+1]);
         diameter = diamelement[itype];
       } else if (adiam == ATTRIBUTE) {
         diameter = buf[m+1];
@@ -1108,7 +1108,7 @@ void DumpImage::create_image()
       if (body[j] < 0) continue;
 
       if (bodycolor == TYPE) {
-        itype = static_cast<int> (buf[m]);
+        itype = static_cast<int>(buf[m]);
         color = colortype[itype];
       }
 
@@ -1282,14 +1282,14 @@ void DumpImage::create_image()
         // no fix draws spheres yet
       } else if (fixvec[i] == LINE) {
         if (fixcolor == TYPE) {
-          itype = static_cast<int> (fixarray[i][0]);
+          itype = static_cast<int>(fixarray[i][0]);
           color = colortype[itype];
         }
         image->draw_cylinder(&fixarray[i][1],&fixarray[i][4],
                              color,fixflag1,3);
       } else if (fixvec[i] == TRI) {
         if (fixcolor == TYPE) {
-          itype = static_cast<int> (fixarray[i][0]);
+          itype = static_cast<int>(fixarray[i][0]);
           color = colortype[itype];
         }
         p1 = &fixarray[i][1];
@@ -1532,10 +1532,10 @@ void DumpImage::unpack_forward_comm(int n, int first, double *buf)
   last = first + n;
 
   if (comm_forward == 1)
-    for (i = first; i < last; i++) chooseghost[i] = static_cast<int> (buf[m++]);
+    for (i = first; i < last; i++) chooseghost[i] = static_cast<int>(buf[m++]);
   else {
     for (i = first; i < last; i++) {
-      chooseghost[i] = static_cast<int> (buf[m++]);
+      chooseghost[i] = static_cast<int>(buf[m++]);
       bufcopy[i][0] = buf[m++];
       bufcopy[i][1] = buf[m++];
     }
@@ -1638,9 +1638,9 @@ int DumpImage::modify_param(int narg, char **arg)
     if (narg < 2) error->all(FLERR,"Illegal dump_modify command");
     double *color = image->color2rgb(arg[1]);
     if (color == nullptr) error->all(FLERR,"Invalid color in dump_modify command");
-    image->background[0] = static_cast<int> (color[0]*255.0);
-    image->background[1] = static_cast<int> (color[1]*255.0);
-    image->background[2] = static_cast<int> (color[2]*255.0);
+    image->background[0] = static_cast<int>(color[0]*255.0);
+    image->background[1] = static_cast<int>(color[1]*255.0);
+    image->background[2] = static_cast<int>(color[2]*255.0);
     return 2;
   }
 

--- a/src/fix_deposit.cpp
+++ b/src/fix_deposit.cpp
@@ -614,6 +614,8 @@ void FixDeposit::pre_exchange()
       atom->nangles += onemols[imol]->nangles;
       atom->ndihedrals += onemols[imol]->ndihedrals;
       atom->nimpropers += onemols[imol]->nimpropers;
+      // body particle molecule template must contain only one atom
+      atom->nbodies += (bigint) onemols[imol]->bodyflag;
     }
     maxtag_all += natom;
     if (maxtag_all >= MAXTAGINT)

--- a/src/fix_pair.cpp
+++ b/src/fix_pair.cpp
@@ -111,7 +111,7 @@ FixPair::FixPair(LAMMPS *lmp, int narg, char **arg) :
 
   vector = nullptr;
   array = nullptr;
-  grow_arrays(atom->nmax);
+  FixPair::grow_arrays(atom->nmax);
   atom->add_callback(Atom::GROW);
 
   // zero the vector/array since dump may access it on timestep 0

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -272,7 +272,7 @@ void Image::view_params(double boxxlo, double boxxhi, double boxylo,
   if (ssao) {
     if (!random) random = new RanMars(lmp,seed+me);
     SSAORadius = maxdel * 0.05 * ssaoint;
-    SSAOSamples = static_cast<int> (8.0 + 32.0*ssaoint);
+    SSAOSamples = static_cast<int>(8.0 + 32.0*ssaoint);
     SSAOJitter = MY_PI / 12;
     ambientColor[0] = 0.5;
     ambientColor[1] = 0.5;
@@ -364,8 +364,8 @@ void Image::merge()
     MPI_Bcast(depthBuffer,npixels,MPI_DOUBLE,0,world);
     compute_SSAO();
 
-    int pixelstart = 3 * static_cast<int> (1.0*me/nprocs * npixels);
-    int pixelstop = 3 * static_cast<int> (1.0*(me+1)/nprocs * npixels);
+    int pixelstart = 3 * static_cast<int>(1.0*me/nprocs * npixels);
+    int pixelstop = 3 * static_cast<int>(1.0*(me+1)/nprocs * npixels);
     int mypixels = pixelstop - pixelstart;
 
     if (npixels % nprocs == 0) {
@@ -469,12 +469,12 @@ void Image::draw_sphere(double *x, double *surfaceColor, double diameter)
   double pixelWidth = (tanPerPixel > 0) ? tanPerPixel * dist :
     -tanPerPixel / zoom;
   double pixelRadiusFull = radius / pixelWidth;
-  int pixelRadius = static_cast<int> (pixelRadiusFull + 0.5) + 1;
+  int pixelRadius = std::lround(pixelRadiusFull) + 1;
 
   double xf = xmap / pixelWidth;
   double yf = ymap / pixelWidth;
-  int xc = static_cast<int> (xf);
-  int yc = static_cast<int> (yf);
+  int xc = static_cast<int>(xf);
+  int yc = static_cast<int>(yf);
   double width_error = xf - xc;
   double height_error = yf - yc;
 
@@ -531,12 +531,12 @@ void Image::draw_cube(double *x, double *surfaceColor, double diameter)
 
   double halfWidth = diameter;
   double pixelHalfWidthFull = halfWidth / pixelWidth;
-  int pixelHalfWidth = static_cast<int> (pixelHalfWidthFull + 0.5);
+  int pixelHalfWidth = std::lround(pixelHalfWidthFull);
 
   double xf = xmap / pixelWidth;
   double yf = ymap / pixelWidth;
-  int xc = static_cast<int> (xf);
-  int yc = static_cast<int> (yf);
+  int xc = static_cast<int>(xf);
+  int yc = static_cast<int>(yf);
   double width_error = xf - xc;
   double height_error = yf - yc;
 
@@ -658,8 +658,8 @@ void Image::draw_cylinder(double *x, double *y,
 
   double xf = xmap / pixelWidth;
   double yf = ymap / pixelWidth;
-  int xc = static_cast<int> (xf);
-  int yc = static_cast<int> (yf);
+  int xc = static_cast<int>(xf);
+  int yc = static_cast<int>(yf);
   double width_error = xf - xc;
   double height_error = yf - yc;
 
@@ -670,8 +670,8 @@ void Image::draw_cylinder(double *x, double *y,
 
   double pixelHalfWidthFull = (rasterWidth * 0.5) / pixelWidth;
   double pixelHalfHeightFull = (rasterHeight * 0.5) / pixelWidth;
-  int pixelHalfWidth = static_cast<int> (pixelHalfWidthFull + 0.5);
-  int pixelHalfHeight = static_cast<int> (pixelHalfHeightFull + 0.5);
+  int pixelHalfWidth = std::lround(pixelHalfWidthFull);
+  int pixelHalfHeight = std::lround(pixelHalfHeightFull);
 
   if (zaxis[0] == camDir[0] && zaxis[1] == camDir[1] && zaxis[2] == camDir[2])
     return;
@@ -804,8 +804,8 @@ void Image::draw_triangle(double *x, double *y, double *z, double *surfaceColor)
 
   double xf = xmap / pixelWidth;
   double yf = ymap / pixelWidth;
-  int xc = static_cast<int> (xf);
-  int yc = static_cast<int> (yf);
+  int xc = static_cast<int>(xf);
+  int yc = static_cast<int>(yf);
   double width_error = xf - xc;
   double height_error = yf - yc;
 
@@ -818,10 +818,10 @@ void Image::draw_triangle(double *x, double *y, double *z, double *surfaceColor)
   double pixelRightFull = rasterRight / pixelWidth;
   double pixelDownFull = rasterDown / pixelWidth;
   double pixelUpFull = rasterUp / pixelWidth;
-  int pixelLeft = static_cast<int> (pixelLeftFull + 0.5);
-  int pixelRight = static_cast<int> (pixelRightFull + 0.5);
-  int pixelDown = static_cast<int> (pixelDownFull + 0.5);
-  int pixelUp = static_cast<int> (pixelUpFull + 0.5);
+  int pixelLeft = std::lround(pixelLeftFull);
+  int pixelRight = std::lround(pixelRightFull);
+  int pixelDown = std::lround(pixelDownFull);
+  int pixelUp = std::lround(pixelUpFull);
 
   for (int iy = yc - pixelDown; iy <= yc + pixelUp; iy ++) {
     for (int ix = xc - pixelLeft; ix <= xc + pixelRight; ix ++) {
@@ -956,8 +956,8 @@ void Image::compute_SSAO()
   // x = column # from 0 to width-1
   // y = row # from 0 to height-1
 
-  int pixelstart = static_cast<int> (1.0*me/nprocs * npixels);
-  int pixelstop = static_cast<int> (1.0*(me+1)/nprocs * npixels);
+  int pixelstart = static_cast<int>(1.0*me/nprocs * npixels);
+  int pixelstop = static_cast<int>(1.0*(me+1)/nprocs * npixels);
 
   // file buffer with random numbers to avoid race conditions
   double *uniform = new double[pixelstop - pixelstart];
@@ -992,8 +992,8 @@ void Image::compute_SSAO()
 
       // Bresenham's line algorithm to march over depthBuffer
 
-      int dx = static_cast<int> (hx * pixelRadius);
-      int dy = static_cast<int> (hy * pixelRadius);
+      int dx = static_cast<int>(hx * pixelRadius);
+      int dy = static_cast<int>(hy * pixelRadius);
       int ex = x + dx;
       if (ex < 0) { ex = 0; } if (ex >= width) { ex = width - 1; }
       int ey = y + dy;
@@ -1997,7 +1997,7 @@ double *ColorMap::value2color(double value)
       if (value >= mentry[i].lvalue && value <= mentry[i].hvalue)
         return mentry[i].color;
   } else {
-    int ibin = static_cast<int> ((value-lo) * mbinsizeinv);
+    int ibin = static_cast<int>((value-lo) * mbinsizeinv);
     return mentry[ibin%nentry].color;
   }
 

--- a/src/improper.cpp
+++ b/src/improper.cpp
@@ -184,7 +184,6 @@ void Improper::ev_setup(int eflag, int vflag, int alloc)
       cvatom[i][6] = 0.0;
       cvatom[i][7] = 0.0;
       cvatom[i][8] = 0.0;
-      cvatom[i][9] = 0.0;
     }
   }
 }

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -18,7 +18,6 @@
 #define LAMMPS_LIB_MPI 1
 #include "library.h"
 #include <mpi.h>
-#include <algorithm>
 
 #include "accelerator_kokkos.h"
 #include "atom.h"
@@ -60,7 +59,10 @@
 #include "variable.h"
 #include "version.h"
 
+
+#include <algorithm>
 #include <cstring>
+#include <utility>
 
 #if defined(LMP_PYTHON)
 #include <Python.h>
@@ -125,11 +127,11 @@ static void ptr_argument_warning()
     error->set_last_error(e.what(), ERROR_NORMAL); \
   }
 
-#define STORE_ERROR_MESSAGE(handle, message)   \
-  if (handle && handle->error) {               \
-    handle->error->set_last_error(message);    \
-  } else {                                     \
-    lammps_last_global_errormessage = message; \
+#define STORE_ERROR_MESSAGE(handle, message)                \
+  if (handle && handle->error) {                            \
+    handle->error->set_last_error(message);                 \
+  } else {                                                  \
+    lammps_last_global_errormessage = std::move(message);   \
   }
 
 // ----------------------------------------------------------------------
@@ -312,7 +314,7 @@ void lammps_close(void *handle)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->comm) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -500,7 +502,7 @@ void lammps_error(void *handle, int error_type, const char *error_text)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -587,7 +589,7 @@ char *lammps_expand(void *handle, const char *line)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return nullptr;
   }
@@ -637,7 +639,7 @@ void lammps_file(void *handle, const char *filename)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->update || !lmp->input) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -679,7 +681,7 @@ char *lammps_command(void *handle, const char *cmd)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->update || !lmp->input) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return nullptr;
   }
@@ -755,7 +757,7 @@ void lammps_commands_string(void *handle, const char *str)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->update || !lmp->output || !lmp->comm || !lmp->input) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -883,7 +885,7 @@ double lammps_get_natoms(void *handle)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->atom) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return -1.0;
   }
@@ -916,7 +918,7 @@ double lammps_get_thermo(void *handle, const char *keyword)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->output || !lmp->output->thermo) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return 0.0;
   }
@@ -1017,7 +1019,7 @@ void *lammps_last_thermo(void *handle, const char *what, int index)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->update || !lmp->output || !lmp->output->thermo) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return nullptr;
   }
@@ -1108,7 +1110,7 @@ void lammps_extract_box(void *handle, double *boxlo, double *boxhi,
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->domain || !lmp->comm) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -1175,7 +1177,7 @@ void lammps_reset_box(void *handle, double *boxlo, double *boxhi,
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->domain || !lmp->comm) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -1242,7 +1244,7 @@ void lammps_memory_usage(void *handle, double *meminfo)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -1278,14 +1280,14 @@ int lammps_get_mpi_comm(void *handle)
 {
 #ifdef MPI_STUBS
   LAMMPS *lmp = nullptr;
-  const auto mesg = fmt::format("ERROR: {}(): No MPI communicator conversion possible "
+  const auto &mesg = fmt::format("ERROR: {}(): No MPI communicator conversion possible "
                                 "with MPI STUBS\n", FNERR);
   STORE_ERROR_MESSAGE(lmp, mesg);
   return -1;
 #else
   LAMMPS *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return -1;
   }
@@ -1538,7 +1540,7 @@ int lammps_extract_setting(void *handle, const char *keyword)
 
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->domain || !lmp->force || !lmp->comm || !lmp->universe || !lmp->atom) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return -1;
   }
@@ -2209,7 +2211,7 @@ void *lammps_extract_global(void *handle, const char *name)
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->update || !lmp->atom || !lmp->force || !lmp->domain || !lmp->domain->lattice
       || !lmp->update->integrate) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return nullptr;
   }
@@ -2351,7 +2353,7 @@ int lammps_extract_pair_dimension(void * handle, const char *name)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->force || !lmp->force->pair) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return -1;
   }
@@ -2385,7 +2387,7 @@ void *lammps_extract_pair(void * handle, const char *name)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->force || !lmp->force->pair) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return nullptr;
   }
@@ -2420,7 +2422,7 @@ int lammps_map_atom(void *handle, const void *id)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->atom) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return -1;
   }
@@ -2461,7 +2463,7 @@ int lammps_extract_atom_datatype(void *handle, const char *name)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->atom) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return -1;
   }
@@ -2499,7 +2501,7 @@ int lammps_extract_atom_size(void *handle, const char *name, int type)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->atom) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return -1;
   }
@@ -2540,7 +2542,7 @@ void *lammps_extract_atom(void *handle, const char *name)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->atom) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return nullptr;
   }
@@ -2663,7 +2665,7 @@ void *lammps_extract_compute(void *handle, const char *id, int style, int type)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->modify) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return nullptr;
   }
@@ -2896,7 +2898,7 @@ void *lammps_extract_fix(void *handle, const char *id, int style, int type, int 
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->modify) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return nullptr;
   }
@@ -3095,7 +3097,7 @@ void *lammps_extract_variable(void *handle, const char *name, const char *group)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->input || !lmp->input->variable || !lmp->group) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return nullptr;
   }
@@ -3161,7 +3163,7 @@ int lammps_extract_variable_datatype(void *handle, const char *name)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->input || !lmp->input->variable) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return -1;
   }
@@ -3252,7 +3254,7 @@ int lammps_set_string_variable(void *handle, const char *name, const char *str)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->input || !lmp->input->variable) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return -1;
   }
@@ -3295,7 +3297,7 @@ int lammps_set_internal_variable(void *handle, const char *name, double value)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->input || !lmp->input->variable) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return -1;
   }
@@ -3343,7 +3345,7 @@ string, otherwise 1.
 int lammps_variable_info(void *handle, int idx, char *buffer, int buf_size) {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->input || !lmp->input->variable) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return -1;
   }
@@ -3384,7 +3386,7 @@ double lammps_eval(void *handle, const char *expr)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->input || !lmp->input->variable) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return 0.0;
   }
@@ -3423,7 +3425,7 @@ double lammps_eval(void *handle, const char *expr)
 void lammps_clearstep_compute(void *handle) {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->modify) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -3455,7 +3457,7 @@ void lammps_clearstep_compute(void *handle) {
 void lammps_addstep_compute_all(void *handle, void *newstep) {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->modify) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -3486,7 +3488,7 @@ void lammps_addstep_compute_all(void *handle, void *newstep) {
 void lammps_addstep_compute(void *handle, void *newstep) {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->modify) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -3549,7 +3551,7 @@ void lammps_gather_atoms(void *handle, const char *name, int dtype, int count, v
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->atom || !lmp->memory) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -3711,7 +3713,7 @@ void lammps_gather_atoms_concat(void *handle, const char *name, int dtype,
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->atom || !lmp->comm || !lmp->memory) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -3878,7 +3880,7 @@ void lammps_gather_atoms_subset(void *handle, const char *name, int dtype,
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->atom || !lmp->memory) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -4041,7 +4043,7 @@ void lammps_scatter_atoms(void *handle, const char *name, int dtype, int count, 
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->atom || !lmp->memory) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -4195,7 +4197,7 @@ void lammps_scatter_atoms_subset(void *handle, const char *name, int dtype,
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->atom || !lmp->memory) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -4370,7 +4372,7 @@ void lammps_gather_bonds(void *handle, void *data)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->atom || !lmp->atom->avec || !lmp->comm || !lmp->memory) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -4488,7 +4490,7 @@ void lammps_gather_angles(void *handle, void *data)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->atom || !lmp->atom->avec || !lmp->comm || !lmp->memory) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -4607,7 +4609,7 @@ void lammps_gather_dihedrals(void *handle, void *data)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->atom || !lmp->atom->avec || !lmp->comm || !lmp->memory) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -4726,7 +4728,7 @@ void lammps_gather_impropers(void *handle, void *data)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->atom || !lmp->atom->avec || !lmp->comm || !lmp->memory) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -4839,7 +4841,7 @@ void lammps_gather(void *handle, const char *name, int dtype, int count, void *d
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->atom || !lmp->memory || !lmp->modify) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -5099,7 +5101,7 @@ void lammps_gather_concat(void *handle, const char *name, int dtype, int count, 
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->atom || !lmp->memory || !lmp->modify || !lmp->comm) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -5369,7 +5371,7 @@ void lammps_gather_subset(void *handle, const char *name, int dtype, int count, 
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->atom || !lmp->memory || !lmp->modify || !lmp->comm) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -5637,7 +5639,7 @@ void lammps_scatter(void *handle, const char *name, int dtype, int count, void *
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->atom || !lmp->memory || !lmp->modify || !lmp->comm) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -5880,7 +5882,7 @@ void lammps_scatter_subset(void *handle, const char *name, int dtype, int count,
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->atom || !lmp->memory || !lmp->modify || !lmp->comm) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -6118,7 +6120,7 @@ int lammps_create_atoms(void *handle, int n, const tagint *id, const int *type,
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->domain || !lmp->atom) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return -1;
   }
@@ -6225,12 +6227,12 @@ void lammps_create_molecule(void *handle, const char *id, const char *jsonstr)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->atom || !lmp->comm || !lmp->domain || !lmp->error) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
   if (!id || !jsonstr) {
-    const auto mesg = fmt::format("ERROR: {}(): Non-NULL arguments required\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Non-NULL arguments required\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -6280,7 +6282,7 @@ void lammps_create_molecule(void *handle, const char *id, const char *jsonstr)
 int lammps_find_pair_neighlist(void *handle, const char *style, int exact, int nsub, int reqid) {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->neighbor || !lmp->force) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return -1;
   }
@@ -6321,7 +6323,7 @@ int lammps_find_pair_neighlist(void *handle, const char *style, int exact, int n
 int lammps_find_fix_neighlist(void *handle, const char *id, int reqid) {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->neighbor || !lmp->modify) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return -1;
   }
@@ -6362,7 +6364,7 @@ int lammps_find_fix_neighlist(void *handle, const char *id, int reqid) {
 int lammps_find_compute_neighlist(void *handle, const char *id, int reqid) {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->neighbor || !lmp->modify) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return -1;
   }
@@ -6459,7 +6461,7 @@ int lammps_request_single_neighlist(void *handle, const char *id, int flags, dou
   auto lmp = (LAMMPS *)handle;
   int idx = -1;
   if (!lmp || !lmp->error || !lmp->neighbor) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return -1;
   }
@@ -6490,7 +6492,7 @@ int lammps_request_single_neighlist(void *handle, const char *id, int flags, dou
 int lammps_neighlist_num_elements(void *handle, int idx) {
   auto   lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->neighbor) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return 0;
   }
@@ -6521,7 +6523,7 @@ void lammps_neighlist_element_neighbors(void *handle, int idx, int element, int 
                                         int *numneigh, int **neighbors) {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->neighbor) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -6572,7 +6574,7 @@ int lammps_version(void *handle)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return 0;
   }
@@ -6922,7 +6924,7 @@ Valid categories are: *atom*\ , *integrate*\ , *minimize*\ ,
 int lammps_has_style(void *handle, const char *category, const char *name) {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return 0;
   }
@@ -6950,7 +6952,7 @@ categories.
 int lammps_style_count(void *handle, const char *category) {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return 0;
   }
@@ -6982,7 +6984,7 @@ int lammps_style_count(void *handle, const char *category) {
 int lammps_style_name(void *handle, const char *category, int idx, char *buffer, int buf_size) {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return 0;
   }
@@ -7023,7 +7025,7 @@ int lammps_has_id(void *handle, const char *category, const char *name) {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->modify || !lmp->output || !lmp->group || !lmp->atom
       || !lmp->domain || !lmp->input || !lmp->input->variable) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return 0;
   }
@@ -7070,7 +7072,7 @@ int lammps_id_count(void *handle, const char *category) {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->modify || !lmp->output || !lmp->group || !lmp->atom
       || !lmp->domain || !lmp->input || !lmp->input->variable) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return 0;
   }
@@ -7122,7 +7124,7 @@ int lammps_id_name(void *handle, const char *category, int idx, char *buffer, in
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->modify || !lmp->output || !lmp->group || !lmp->atom
       || !lmp->domain || !lmp->input || !lmp->input->variable) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return 0;
   }
@@ -7351,7 +7353,7 @@ void lammps_set_fix_external_callback(void *handle, const char *id, FixExternalF
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->modify) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -7420,7 +7422,7 @@ double **lammps_fix_external_get_force(void *handle, const char *id)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->modify) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return nullptr;
   }
@@ -7476,7 +7478,7 @@ void lammps_fix_external_set_energy_global(void *handle, const char *id, double 
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->modify) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -7531,7 +7533,7 @@ void lammps_fix_external_set_virial_global(void *handle, const char *id, double 
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->modify) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -7586,7 +7588,7 @@ void lammps_fix_external_set_energy_peratom(void *handle, const char *id, double
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->modify) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -7644,7 +7646,7 @@ void lammps_fix_external_set_virial_peratom(void *handle, const char *id, double
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->modify) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -7695,7 +7697,7 @@ void lammps_fix_external_set_vector_length(void *handle, const char *id, int len
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->modify) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -7756,7 +7758,7 @@ void lammps_fix_external_set_vector(void *handle, const char *id, int idx, doubl
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->modify) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
@@ -7826,7 +7828,7 @@ int lammps_is_running(void *handle)
 {
   auto   lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->update) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return 0;
   }
@@ -7844,7 +7846,7 @@ void lammps_force_timeout(void *handle)
 {
   auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->timer) {
-    const auto mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
+    const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }

--- a/src/math_eigen_impl.h
+++ b/src/math_eigen_impl.h
@@ -215,8 +215,8 @@ namespace MathEigen {
   public:
     // C++ boilerplate: copy and move constructor, swap, and assignment operator
     Jacobi(const Jacobi<Scalar, Vector, Matrix, ConstMatrix>& source);
-    Jacobi(Jacobi<Scalar, Vector, Matrix, ConstMatrix>&& other);
-    void swap(Jacobi<Scalar, Vector, Matrix, ConstMatrix> &other);
+    Jacobi(Jacobi<Scalar, Vector, Matrix, ConstMatrix>&& other) noexcept;
+    void swap(Jacobi<Scalar, Vector, Matrix, ConstMatrix> &other) noexcept;
     Jacobi<Scalar, Vector, Matrix, ConstMatrix>& operator = (Jacobi<Scalar, Vector, Matrix, ConstMatrix> source);
 
   }; // class Jacobi
@@ -878,7 +878,7 @@ Jacobi(const Jacobi<Scalar, Vector, Matrix, ConstMatrix>& source)
 
 template<typename Scalar,typename Vector,typename Matrix,typename ConstMatrix>
 void Jacobi<Scalar, Vector, Matrix, ConstMatrix>::
-swap(Jacobi<Scalar, Vector, Matrix, ConstMatrix> &other) {
+swap(Jacobi<Scalar, Vector, Matrix, ConstMatrix> &other) noexcept {
   std::swap(n, other.n);
   std::swap(is_preallocated, other.is_preallocated);
   std::swap(max_idx_row, other.max_idx_row);
@@ -888,7 +888,7 @@ swap(Jacobi<Scalar, Vector, Matrix, ConstMatrix> &other) {
 // Move constructor (C++11)
 template<typename Scalar,typename Vector,typename Matrix,typename ConstMatrix>
 Jacobi<Scalar, Vector, Matrix, ConstMatrix>::
-Jacobi(Jacobi<Scalar, Vector, Matrix, ConstMatrix>&& other) {
+Jacobi(Jacobi<Scalar, Vector, Matrix, ConstMatrix>&& other) noexcept {
   Init();
   this->swap(other);
 }

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -243,7 +243,8 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
                  std::string(moldata["application"]));
   } else {
     error->all(FLERR, Error::NOLASTLINE,
-               "Molecule template {}: JSON data does not contain required \"application\" field", id);
+               "Molecule template {}: JSON data does not contain required \"application\" field",
+               id);
   }
   if (moldata.contains("format")) {
     if (moldata["format"] != "molecule")
@@ -438,9 +439,10 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
       if (shakedata["flags"].contains("data")) {
         shakeflagflag = 1;
         if (shakedata["flags"]["data"].size() != natoms)
-          error->all(FLERR, Error::NOLASTLINE,
-                     "Molecule template {}: Found {} instead of {} data entries for \"shake:flags\"",
-                     id, shakedata["flags"]["data"].size(), natoms);
+          error->all(
+              FLERR, Error::NOLASTLINE,
+              "Molecule template {}: Found {} instead of {} data entries for \"shake:flags\"", id,
+              shakedata["flags"]["data"].size(), natoms);
       } else {
         error->all(FLERR, Error::NOLASTLINE,
                    "Molecule template {}: JSON molecule data does not contain required \"data\" "
@@ -464,9 +466,10 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
         shakeatomflag = 1;
         tag_require = 1;
         if (shakedata["atoms"]["data"].size() != natoms)
-          error->all(FLERR, Error::NOLASTLINE,
-                     "Molecule template {}: Found {} instead of {} data entries for \"shake:atoms\"",
-                     id, shakedata["atoms"]["data"].size(), natoms);
+          error->all(
+              FLERR, Error::NOLASTLINE,
+              "Molecule template {}: Found {} instead of {} data entries for \"shake:atoms\"", id,
+              shakedata["atoms"]["data"].size(), natoms);
       } else {
         error->all(FLERR, Error::NOLASTLINE,
                    "Molecule template {}: JSON molecule data does not contain required \"data\" "
@@ -490,9 +493,10 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
         shaketypeflag = 1;
         tag_require = 1;
         if (shakedata["types"]["data"].size() != natoms)
-          error->all(FLERR, Error::NOLASTLINE,
-                     "Molecule template {}: Found {} instead of {} data entries for \"shake:types\"",
-                     id, shakedata["types"]["data"].size(), natoms);
+          error->all(
+              FLERR, Error::NOLASTLINE,
+              "Molecule template {}: Found {} instead of {} data entries for \"shake:types\"", id,
+              shakedata["types"]["data"].size(), natoms);
       } else {
         error->all(FLERR, Error::NOLASTLINE,
                    "Molecule template {}: JSON molecule data does not contain required \"data\" "
@@ -1452,8 +1456,10 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
   }
 
   if (specialflag) {
-    const auto &specialcounts = moldata["special"]["counts"];
 
+    // process counts
+
+    const auto &specialcounts = moldata["special"]["counts"];
     secfmt.clear();
     for (int i = 0; i < 4; ++i) secfmt.push_back(specialcounts["format"][i]);
     if ((secfmt[0] == "atom-id") && (secfmt[1] == "n12") && (secfmt[2] == "n13") &&

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -356,7 +356,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
                    "field for 'special:counts'",
                    id);
       if (specialcounts.contains("data")) {
-        if ((int)specialcounts["data"].size() != natoms)
+        if ((int) specialcounts["data"].size() != natoms)
           error->all(
               FLERR, Error::NOLASTLINE,
               "Molecule template {}: Found {} instead of {} data entries for 'special:counts'", id,
@@ -394,7 +394,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
                    "field for \"special:bonds\"",
                    id);
       if (specialbonds.contains("data")) {
-        if ((int)specialbonds["data"].size() != natoms)
+        if ((int) specialbonds["data"].size() != natoms)
           error->all(
               FLERR, Error::NOLASTLINE,
               "Molecule template {}: Found {} instead of {} data entries for \"special:bonds\"", id,
@@ -404,7 +404,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
                      "Molecule template {}: \"special:bonds\" is incorrectly formatted: {}", id,
                      to_string(specialbonds["data"][0]));
         for (int i = 0; i < natoms; ++i) {
-          if ((int)specialbonds["data"][i][1].size() > maxspecial)
+          if ((int) specialbonds["data"][i][1].size() > maxspecial)
             error->all(FLERR, Error::NOLASTLINE,
                        "Molecule template {}: Number of data entries in \"special:bonds\" for atom "
                        "{} exceeds limit: {} vs {}",
@@ -438,7 +438,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
                    id);
       if (shakedata["flags"].contains("data")) {
         shakeflagflag = 1;
-        if ((int)shakedata["flags"]["data"].size() != natoms)
+        if ((int) shakedata["flags"]["data"].size() != natoms)
           error->all(
               FLERR, Error::NOLASTLINE,
               "Molecule template {}: Found {} instead of {} data entries for \"shake:flags\"", id,
@@ -465,7 +465,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
       if (shakedata["atoms"].contains("data")) {
         shakeatomflag = 1;
         tag_require = 1;
-        if ((int)shakedata["atoms"]["data"].size() != natoms)
+        if ((int) shakedata["atoms"]["data"].size() != natoms)
           error->all(
               FLERR, Error::NOLASTLINE,
               "Molecule template {}: Found {} instead of {} data entries for \"shake:atoms\"", id,
@@ -492,7 +492,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
       if (shakedata["types"].contains("data")) {
         shaketypeflag = 1;
         tag_require = 1;
-        if ((int)shakedata["types"]["data"].size() != natoms)
+        if ((int) shakedata["types"]["data"].size() != natoms)
           error->all(
               FLERR, Error::NOLASTLINE,
               "Molecule template {}: Found {} instead of {} data entries for \"shake:types\"", id,
@@ -2181,6 +2181,10 @@ void Molecule::read(int flag)
         nibody = values.next_int();
         ndbody = values.next_int();
         nwant = 3;
+      } else if (values.matches("^\\s*\\d+\\s+\\S+\\s+types\\s*$")) {
+        error->all(FLERR, fileiarg, "Found data file header keyword '{}' in molecule file", text);
+      } else if (values.matches("^\\s*\\f+\\s+\\f+\\s+[xyz]lo\\s+[xyz]hi\\s*$")) {
+        error->all(FLERR, fileiarg, "Found data file header keyword '{}' in molecule file", text);
       } else {
         // unknown header keyword
         if (values.matches("^\\s*\\f+\\s+\\S+")) {
@@ -2335,6 +2339,10 @@ void Molecule::read(int flag)
         error->all(FLERR, fileiarg, "Found Body Doubles section but no setting in header");
       dbodyflag = 1;
       body(flag, 1, line);
+    } else if ((keyword == "Atoms") || (keyword == "Velocities") || (keyword == "Pair Coeffs") ||
+               (keyword == "Bond Coeffs") || (keyword == "Angle Coeffs") ||
+               (keyword == "Dihedral Coeffs") || (keyword == "Improper Coeffs")) {
+      error->all(FLERR, fileiarg, "Found data file section '{}' in molecule file\n", keyword);
     } else {
 
       // Error: Either a too long/short section or a typo in the keyword

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -1592,21 +1592,15 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
 
   // error checks
 
-  if ((nspecialflag && !specialflag) || (!nspecialflag && specialflag))
-    error->all(FLERR, fileiarg, "Molecule file needs both Special Bond sections");
   if (specialflag && !bondflag)
     error->all(FLERR, fileiarg, "Molecule file has special flags but no bonds");
   if ((shakeflagflag || shakeatomflag || shaketypeflag) && !shakeflag)
-    error->all(FLERR, fileiarg, "Molecule file shake info is incomplete");
+    error->all(FLERR, Error::NOLASTLINE,
+               "Molecule template {}: \"shake\" info is incomplete in JSON data");
   if (bodyflag && !rmassflag)
     error->all(FLERR, Error::NOLASTLINE,
                "Molecule template {}: \"body\" JSON section requires \"masses\" section", id);
-  if (bodyflag && nibody && ibodyflag == 0)
-    error->all(FLERR, fileiarg, "Molecule file has no Body Integers section");
-  if (bodyflag && ndbody && dbodyflag == 0)
-    error->all(FLERR, fileiarg, "Molecule file has no Body Doubles section");
-  if (nfragments > 0 && !fragmentflag)
-    error->all(FLERR, fileiarg, "Molecule file has no Fragments section");
+
   // auto-generate special bonds if needed and not in file
 
   if (bondflag && specialflag == 0) {

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -1585,6 +1585,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
 #undef SET_SHAKE_TYPE
 
   // body integers and doubles
+
   if (bodyflag) {
     for (int i = 0; i < nibody; ++i) ibodyparams[i] = moldata["body"]["integers"][i];
     for (int i = 0; i < ndbody; ++i) dbodyparams[i] = moldata["body"]["doubles"][i];
@@ -1801,7 +1802,7 @@ void Molecule::compute_inertia()
       itensor[5] -= onemass * dx * dy;
     }
 
-    if (radiusflag) {
+    if (radiusflag && !bodyflag) {
       for (int i = 0; i < natoms; i++) {
         if (rmassflag)
           onemass = rmass[i];
@@ -3390,6 +3391,7 @@ void Molecule::check_attributes()
   if (muflag && !atom->mu_flag) mismatch = 1;
   if (radiusflag && !atom->radius_flag) mismatch = 1;
   if (rmassflag && !atom->rmass_flag) mismatch = 1;
+  if (bodyflag && !atom->body_flag) mismatch = 1;
 
   if (mismatch && (comm->me == 0))
     error->warning(FLERR, "Molecule attributes do not match system attributes"

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -3220,6 +3220,7 @@ void Molecule::special_read(char *line)
                      "molecule file", ival);
         special[iatom][m - 1] = ival;
       }
+      count[iatom]++;
     }
   } catch (TokenizerException &e) {
     error->all(FLERR, fileiarg, "Invalid line in Special Bonds section of molecule file: {}\n{}",

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -2803,22 +2803,16 @@ void Molecule::shakeflag_read(char *line)
 
       if (values.count() != 2) error->all(FLERR, fileiarg, "Invalid Shake Flags section in molecule file");
 
-      int iatom = values.next_int() - 1;
-      if (iatom < 0 || iatom >= natoms)
-        error->all(FLERR, fileiarg, "Invalid atom index in Shake Flags section of molecule file");
-      count[iatom]++;
-      shake_flag[iatom] = values.next_int();
+      values.next_int();
+      shake_flag[i] = values.next_int();
     }
   } catch (TokenizerException &e) {
     error->all(FLERR, fileiarg, "Invalid Shake Flags section in molecule file: {}", e.what());
   }
 
-  for (int i = 0; i < natoms; i++) {
+  for (int i = 0; i < natoms; i++)
     if (shake_flag[i] < 0 || shake_flag[i] > 4)
       error->all(FLERR, fileiarg, "Invalid shake flag in molecule file");
-    if (count[i] == 0)
-      error->all(FLERR, fileiarg, "Atom {} missing in Shake Flags section of molecule file", i + 1);
-  }
 }
 
 /* ----------------------------------------------------------------------
@@ -2834,57 +2828,54 @@ void Molecule::shakeatom_read(char *line)
 
       ValueTokenizer values(utils::trim_comment(line));
       nmatch = values.count();
-      int iatom = values.next_int() - 1;
-      if ((iatom < 0) || (iatom >= natoms))
-        throw TokenizerException(fmt::format("Invalid atom-id {} in Shake Atoms section of "
-                                             "molecule file", iatom + 1), "");
 
-      switch (shake_flag[iatom]) {
+      switch (shake_flag[i]) {
         case 1:
-          shake_atom[iatom][0] = values.next_tagint();
-          shake_atom[iatom][1] = values.next_tagint();
-          shake_atom[iatom][2] = values.next_tagint();
+          values.next_int();
+          shake_atom[i][0] = values.next_tagint();
+          shake_atom[i][1] = values.next_tagint();
+          shake_atom[i][2] = values.next_tagint();
           nwant = 4;
           break;
 
         case 2:
-          shake_atom[iatom][0] = values.next_tagint();
-          shake_atom[iatom][1] = values.next_tagint();
+          values.next_int();
+          shake_atom[i][0] = values.next_tagint();
+          shake_atom[i][1] = values.next_tagint();
           nwant = 3;
           break;
 
         case 3:
-          shake_atom[iatom][0] = values.next_tagint();
-          shake_atom[iatom][1] = values.next_tagint();
-          shake_atom[iatom][2] = values.next_tagint();
+          values.next_int();
+          shake_atom[i][0] = values.next_tagint();
+          shake_atom[i][1] = values.next_tagint();
+          shake_atom[i][2] = values.next_tagint();
           nwant = 4;
           break;
 
         case 4:
-          shake_atom[iatom][0] = values.next_tagint();
-          shake_atom[iatom][1] = values.next_tagint();
-          shake_atom[iatom][2] = values.next_tagint();
-          shake_atom[iatom][3] = values.next_tagint();
+          values.next_int();
+          shake_atom[i][0] = values.next_tagint();
+          shake_atom[i][1] = values.next_tagint();
+          shake_atom[i][2] = values.next_tagint();
+          shake_atom[i][3] = values.next_tagint();
           nwant = 5;
           break;
 
         case 0:
+          values.next_int();
           nwant = 1;
           break;
 
         default:
-        throw TokenizerException(
-          fmt::format("Unexpected Shake flag {} for atom {} in Shake flags "
-                      "section of molecule file", shake_flag[iatom], iatom + 1), "");
+          error->all(FLERR, fileiarg, "Invalid shake atom in molecule file");
       }
 
-      if (nmatch != nwant)
-        throw TokenizerException(
-          fmt::format("Unexpected number of atom-ids ({} vs {}) for atom {} in Shake Atoms "
-                      "section of molecule file", nmatch, nwant, iatom + 1), "");
+      if (nmatch != nwant) error->all(FLERR, fileiarg, "Invalid shake atom in molecule file");
     }
+
   } catch (TokenizerException &e) {
-    error->all(FLERR, fileiarg, "Invalid Shake Atoms section in molecule file: {}", e.what());
+    error->all(FLERR, fileiarg, "Invalid shake atom in molecule file: {}", e.what());
   }
 
   for (int i = 0; i < natoms; i++) {

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -356,7 +356,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
                    "field for 'special:counts'",
                    id);
       if (specialcounts.contains("data")) {
-        if (specialcounts["data"].size() != natoms)
+        if ((int)specialcounts["data"].size() != natoms)
           error->all(
               FLERR, Error::NOLASTLINE,
               "Molecule template {}: Found {} instead of {} data entries for 'special:counts'", id,
@@ -394,7 +394,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
                    "field for \"special:bonds\"",
                    id);
       if (specialbonds.contains("data")) {
-        if (specialbonds["data"].size() != natoms)
+        if ((int)specialbonds["data"].size() != natoms)
           error->all(
               FLERR, Error::NOLASTLINE,
               "Molecule template {}: Found {} instead of {} data entries for \"special:bonds\"", id,
@@ -404,7 +404,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
                      "Molecule template {}: \"special:bonds\" is incorrectly formatted: {}", id,
                      to_string(specialbonds["data"][0]));
         for (int i = 0; i < natoms; ++i) {
-          if (specialbonds["data"][i][1].size() > maxspecial)
+          if ((int)specialbonds["data"][i][1].size() > maxspecial)
             error->all(FLERR, Error::NOLASTLINE,
                        "Molecule template {}: Number of data entries in \"special:bonds\" for atom "
                        "{} exceeds limit: {} vs {}",
@@ -438,7 +438,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
                    id);
       if (shakedata["flags"].contains("data")) {
         shakeflagflag = 1;
-        if (shakedata["flags"]["data"].size() != natoms)
+        if ((int)shakedata["flags"]["data"].size() != natoms)
           error->all(
               FLERR, Error::NOLASTLINE,
               "Molecule template {}: Found {} instead of {} data entries for \"shake:flags\"", id,
@@ -465,7 +465,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
       if (shakedata["atoms"].contains("data")) {
         shakeatomflag = 1;
         tag_require = 1;
-        if (shakedata["atoms"]["data"].size() != natoms)
+        if ((int)shakedata["atoms"]["data"].size() != natoms)
           error->all(
               FLERR, Error::NOLASTLINE,
               "Molecule template {}: Found {} instead of {} data entries for \"shake:atoms\"", id,
@@ -492,7 +492,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
       if (shakedata["types"].contains("data")) {
         shaketypeflag = 1;
         tag_require = 1;
-        if (shakedata["types"]["data"].size() != natoms)
+        if ((int)shakedata["types"]["data"].size() != natoms)
           error->all(
               FLERR, Error::NOLASTLINE,
               "Molecule template {}: Found {} instead of {} data entries for \"shake:types\"", id,

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -2803,16 +2803,22 @@ void Molecule::shakeflag_read(char *line)
 
       if (values.count() != 2) error->all(FLERR, fileiarg, "Invalid Shake Flags section in molecule file");
 
-      values.next_int();
-      shake_flag[i] = values.next_int();
+      int iatom = values.next_int() - 1;
+      if (iatom < 0 || iatom >= natoms)
+        error->all(FLERR, fileiarg, "Invalid atom index in Shake Flags section of molecule file");
+      count[iatom]++;
+      shake_flag[iatom] = values.next_int();
     }
   } catch (TokenizerException &e) {
     error->all(FLERR, fileiarg, "Invalid Shake Flags section in molecule file: {}", e.what());
   }
 
-  for (int i = 0; i < natoms; i++)
+  for (int i = 0; i < natoms; i++) {
     if (shake_flag[i] < 0 || shake_flag[i] > 4)
       error->all(FLERR, fileiarg, "Invalid shake flag in molecule file");
+    if (count[i] == 0)
+      error->all(FLERR, fileiarg, "Atom {} missing in Shake Flags section of molecule file", i + 1);
+  }
 }
 
 /* ----------------------------------------------------------------------
@@ -2828,54 +2834,57 @@ void Molecule::shakeatom_read(char *line)
 
       ValueTokenizer values(utils::trim_comment(line));
       nmatch = values.count();
+      int iatom = values.next_int() - 1;
+      if ((iatom < 0) || (iatom >= natoms))
+        throw TokenizerException(fmt::format("Invalid atom-id {} in Shake Atoms section of "
+                                             "molecule file", iatom + 1), "");
 
-      switch (shake_flag[i]) {
+      switch (shake_flag[iatom]) {
         case 1:
-          values.next_int();
-          shake_atom[i][0] = values.next_tagint();
-          shake_atom[i][1] = values.next_tagint();
-          shake_atom[i][2] = values.next_tagint();
+          shake_atom[iatom][0] = values.next_tagint();
+          shake_atom[iatom][1] = values.next_tagint();
+          shake_atom[iatom][2] = values.next_tagint();
           nwant = 4;
           break;
 
         case 2:
-          values.next_int();
-          shake_atom[i][0] = values.next_tagint();
-          shake_atom[i][1] = values.next_tagint();
+          shake_atom[iatom][0] = values.next_tagint();
+          shake_atom[iatom][1] = values.next_tagint();
           nwant = 3;
           break;
 
         case 3:
-          values.next_int();
-          shake_atom[i][0] = values.next_tagint();
-          shake_atom[i][1] = values.next_tagint();
-          shake_atom[i][2] = values.next_tagint();
+          shake_atom[iatom][0] = values.next_tagint();
+          shake_atom[iatom][1] = values.next_tagint();
+          shake_atom[iatom][2] = values.next_tagint();
           nwant = 4;
           break;
 
         case 4:
-          values.next_int();
-          shake_atom[i][0] = values.next_tagint();
-          shake_atom[i][1] = values.next_tagint();
-          shake_atom[i][2] = values.next_tagint();
-          shake_atom[i][3] = values.next_tagint();
+          shake_atom[iatom][0] = values.next_tagint();
+          shake_atom[iatom][1] = values.next_tagint();
+          shake_atom[iatom][2] = values.next_tagint();
+          shake_atom[iatom][3] = values.next_tagint();
           nwant = 5;
           break;
 
         case 0:
-          values.next_int();
           nwant = 1;
           break;
 
         default:
-          error->all(FLERR, fileiarg, "Invalid shake atom in molecule file");
+        throw TokenizerException(
+          fmt::format("Unexpected Shake flag {} for atom {} in Shake flags "
+                      "section of molecule file", shake_flag[iatom], iatom + 1), "");
       }
 
-      if (nmatch != nwant) error->all(FLERR, fileiarg, "Invalid shake atom in molecule file");
+      if (nmatch != nwant)
+        throw TokenizerException(
+          fmt::format("Unexpected number of atom-ids ({} vs {}) for atom {} in Shake Atoms "
+                      "section of molecule file", nmatch, nwant, iatom + 1), "");
     }
-
   } catch (TokenizerException &e) {
-    error->all(FLERR, fileiarg, "Invalid shake atom in molecule file: {}", e.what());
+    error->all(FLERR, fileiarg, "Invalid Shake Atoms section in molecule file: {}", e.what());
   }
 
   for (int i = 0; i < natoms; i++) {

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -1539,19 +1539,16 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
             SET_SHAKE_TYPE(Atom::ANGLE, 2, 3, aoffset);
             break;
           case 2:
+            SET_SHAKE_TYPE(Atom::BOND, 0, 1, boffset);
+            break;
+          case 3:
             SET_SHAKE_TYPE(Atom::BOND, 0, 2, boffset);
             SET_SHAKE_TYPE(Atom::BOND, 1, 2, boffset);
             break;
-          case 3:
+          case 4:
             SET_SHAKE_TYPE(Atom::BOND, 0, 3, boffset);
             SET_SHAKE_TYPE(Atom::BOND, 1, 3, boffset);
             SET_SHAKE_TYPE(Atom::BOND, 2, 3, boffset);
-            break;
-          case 4:
-            SET_SHAKE_TYPE(Atom::BOND, 0, 4, boffset);
-            SET_SHAKE_TYPE(Atom::BOND, 1, 4, boffset);
-            SET_SHAKE_TYPE(Atom::BOND, 2, 4, boffset);
-            SET_SHAKE_TYPE(Atom::BOND, 3, 4, boffset);
             break;
           case 0:
             break;
@@ -3262,12 +3259,7 @@ void Molecule::shaketype_read(char *line)
         shake_type[iatom][0] = utils::inumeric(FLERR, values[1], false, lmp) + ((subst) ? 0 : boffset);
         delete[] subst;
 
-        subst = utils::expand_type(FLERR, values[2], Atom::BOND, lmp);
-        if (subst) values[2] = subst;
-        shake_type[iatom][1] = utils::inumeric(FLERR, values[2], false, lmp) + ((subst) ? 0 : boffset);
-        delete[] subst;
-
-        nwant = 3;
+        nwant = 2;
         break;
 
       case 3:
@@ -3281,12 +3273,7 @@ void Molecule::shaketype_read(char *line)
         shake_type[iatom][1] = utils::inumeric(FLERR, values[2], false, lmp) + ((subst) ? 0 : boffset);
         delete[] subst;
 
-        subst = utils::expand_type(FLERR, values[1], Atom::BOND, lmp);
-        if (subst) values[3] = subst;
-        shake_type[iatom][2] = utils::inumeric(FLERR, values[3], false, lmp) + ((subst) ? 0 : boffset);
-        delete[] subst;
-
-        nwant = 4;
+        nwant = 3;
         break;
 
       case 4:
@@ -3305,12 +3292,7 @@ void Molecule::shaketype_read(char *line)
         shake_type[iatom][2] = utils::inumeric(FLERR, values[3], false, lmp) + ((subst) ? 0 : boffset);
         delete[] subst;
 
-        subst = utils::expand_type(FLERR, values[4], Atom::BOND, lmp);
-        if (subst) values[4] = subst;
-        shake_type[iatom][3] = utils::inumeric(FLERR, values[4], false, lmp) + ((subst) ? 0 : boffset);
-        delete[] subst;
-
-        nwant = 5;
+        nwant = 4;
         break;
 
       case 0:

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -1555,7 +1555,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
           default:
             error->all(FLERR, Error::NOLASTLINE,
                        "Molecule template {}: Unsupported Shake flag {} for "
-                       " atom {} in \"shake:atoms\" section of molecule JSON data",
+                       " atom {} in \"shake:types\" section of molecule JSON data",
                        id, shake_flag[iatom], iatom + 1);
         }
         count[iatom]++;
@@ -1564,13 +1564,13 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
       for (int i = 0; i < natoms; i++) {
         if (count[i] == 0)
           error->all(FLERR, Error::NOLASTLINE,
-                     "Molecule template {}: atom {} missing in \"shake:atoms\" JSON section", id,
+                     "Molecule template {}: atom {} missing in \"shake:types\" JSON section", id,
                      i + 1);
       }
     } else {
       error->all(FLERR, Error::NOLASTLINE,
-                 "Molecule template {}: Expected \"shake:atoms\" format "
-                 "[\"atom-id\",\"atom-id-list\"] but found [\"{}\",\"{}\"]",
+                 "Molecule template {}: Expected \"shake:types\" format "
+                 "[\"atom-id\",\"type-list\"] but found [\"{}\",\"{}\"]",
                  id, secfmt[0], secfmt[1]);
     }
   }

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -243,7 +243,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
                  std::string(moldata["application"]));
   } else {
     error->all(FLERR, Error::NOLASTLINE,
-               "Molecule template {}: JSON data does not contain required 'application' field", id);
+               "Molecule template {}: JSON data does not contain required \"application\" field", id);
   }
   if (moldata.contains("format")) {
     if (moldata["format"] != "molecule")
@@ -252,7 +252,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
                  std::string(moldata["format"]));
   } else {
     error->all(FLERR, Error::NOLASTLINE,
-               "Molecule template {}: JSON data does not contain required 'format' field", id);
+               "Molecule template {}: JSON data does not contain required \"format\" field", id);
   }
   if (moldata.contains("revision")) {
     int rev = moldata["revision"];
@@ -261,13 +261,13 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
                  "Molecule template {}: JSON molecule data with unsupported revision {}", id, rev);
   } else {
     error->all(FLERR, Error::NOLASTLINE,
-               "Molecule template {}: JSON data does not contain required 'revision' field", id);
+               "Molecule template {}: JSON data does not contain required \"revision\" field", id);
   }
 
   // length of types data list determines the number of atoms in the template and is thus required
   if (!moldata.contains("types"))
     error->all(FLERR, Error::NOLASTLINE,
-               "Molecule template {}: JSON data does not contain required 'types' field", id);
+               "Molecule template {}: JSON data does not contain required \"types\" field", id);
 
   // optional fields
 
@@ -301,7 +301,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
   if (moldata.contains(#field)) {                                                                  \
     if (!moldata[#field].contains("format"))                                                       \
       error->all(FLERR, Error::NOLASTLINE,                                                         \
-                 "Molecule template {}: JSON molecule data does not contain required 'format' "    \
+                 "Molecule template {}: JSON molecule data does not contain required \"format\" "  \
                  "field for '{}'",                                                                 \
                  id, #field);                                                                      \
     if (moldata[#field].contains("data")) {                                                        \
@@ -309,7 +309,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
       sizevar = moldata[#field]["data"].size();                                                    \
     } else {                                                                                       \
       error->all(FLERR, Error::NOLASTLINE,                                                         \
-                 "Molecule template {}: JSON molecule data does not contain required 'data' "      \
+                 "Molecule template {}: JSON molecule data does not contain required \"data\" "    \
                  "field for '{}'",                                                                 \
                  id, #field);                                                                      \
     }                                                                                              \
@@ -351,7 +351,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
       const auto &specialcounts = moldata["special"]["counts"];
       if (!specialcounts.contains("format"))
         error->all(FLERR, Error::NOLASTLINE,
-                   "Molecule template {}: JSON molecule data does not contain required 'format' "
+                   "Molecule template {}: JSON molecule data does not contain required \"format\" "
                    "field for 'special:counts'",
                    id);
       if (specialcounts.contains("data")) {
@@ -373,14 +373,14 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
         }
       } else {
         error->all(FLERR, Error::NOLASTLINE,
-                   "Molecule template {}: JSON molecule data does not contain required 'data' "
+                   "Molecule template {}: JSON molecule data does not contain required \"data\" "
                    "field for 'special:counts'",
                    id);
       }
     } else {
       error->all(FLERR, Error::NOLASTLINE,
                  "Molecule template {}: JSON molecule data does not contain required 'counts' "
-                 "field for 'special'",
+                 "field for \"special\"",
                  id);
     }
 
@@ -389,25 +389,36 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
       const auto &specialbonds = moldata["special"]["bonds"];
       if (!specialbonds.contains("format"))
         error->all(FLERR, Error::NOLASTLINE,
-                   "Molecule template {}: JSON molecule data does not contain required 'format' "
-                   "field for 'special:bonds'",
+                   "Molecule template {}: JSON molecule data does not contain required \"format\" "
+                   "field for \"special:bonds\"",
                    id);
       if (specialbonds.contains("data")) {
         if (specialbonds["data"].size() != natoms)
           error->all(
               FLERR, Error::NOLASTLINE,
-              "Molecule template {}: Found {} instead of {} data entries for 'special:bonds'", id,
+              "Molecule template {}: Found {} instead of {} data entries for \"special:bonds\"", id,
               specialbonds["data"].size(), natoms);
+        if (specialbonds["data"][0] != 2)
+          error->all(FLERR, Error::NOLASTLINE,
+                     "Molecule template {}: \"special:bonds\" is incorrectly formatted: {}", id,
+                     to_string(specialbonds["data"][0]));
+        for (int i = 0; i < natoms; ++i) {
+          if (specialbonds["data"][i][1].size() > maxspecial)
+            error->all(FLERR, Error::NOLASTLINE,
+                       "Molecule template {}: Number of data entries in \"special:bonds\" for atom "
+                       "{} exceeds limit: {} vs {}",
+                       id, specialbonds["data"][i][1].size(), maxspecial);
+        }
       } else {
         error->all(FLERR, Error::NOLASTLINE,
-                   "Molecule template {}: JSON molecule data does not contain required 'data' "
-                   "field for 'special:bonds'",
+                   "Molecule template {}: JSON molecule data does not contain required \"data\" "
+                   "field for \"special:bonds\"",
                    id);
       }
     } else {
       error->all(FLERR, Error::NOLASTLINE,
-                 "Molecule template {}: JSON molecule data does not contain required 'bonds' "
-                 "field for 'special'",
+                 "Molecule template {}: JSON molecule data does not contain required \"bonds\" "
+                 "field for \"special\"",
                  id);
     }
   }
@@ -421,77 +432,77 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
     if (shakedata.contains("flags")) {
       if (!shakedata["flags"].contains("format"))
         error->all(FLERR, Error::NOLASTLINE,
-                   "Molecule template {}: JSON molecule data does not contain required 'format' "
-                   "field for 'shake:flags'",
+                   "Molecule template {}: JSON molecule data does not contain required \"format\" "
+                   "field for \"shake:flags\"",
                    id);
       if (shakedata["flags"].contains("data")) {
         shakeflagflag = 1;
         if (shakedata["flags"]["data"].size() != natoms)
           error->all(FLERR, Error::NOLASTLINE,
-                     "Molecule template {}: Found {} instead of {} data entries for 'shake:flags'",
+                     "Molecule template {}: Found {} instead of {} data entries for \"shake:flags\"",
                      id, shakedata["flags"]["data"].size(), natoms);
       } else {
         error->all(FLERR, Error::NOLASTLINE,
-                   "Molecule template {}: JSON molecule data does not contain required 'data' "
-                   "field for 'shake:flags'",
+                   "Molecule template {}: JSON molecule data does not contain required \"data\" "
+                   "field for \"shake:flags\"",
                    id);
       }
     } else {
       error->all(FLERR, Error::NOLASTLINE,
                  "Molecule template {}: JSON molecule data does not contain required 'flags' "
-                 "field for 'shake'",
+                 "field for \"shake\"",
                  id);
     }
 
     if (shakedata.contains("atoms")) {
       if (!shakedata["atoms"].contains("format"))
         error->all(FLERR, Error::NOLASTLINE,
-                   "Molecule template {}: JSON molecule data does not contain required 'format' "
-                   "field for 'shake:atoms'",
+                   "Molecule template {}: JSON molecule data does not contain required \"format\" "
+                   "field for \"shake:atoms\"",
                    id);
       if (shakedata["atoms"].contains("data")) {
         shakeatomflag = 1;
         tag_require = 1;
         if (shakedata["atoms"]["data"].size() != natoms)
           error->all(FLERR, Error::NOLASTLINE,
-                     "Molecule template {}: Found {} instead of {} data entries for 'shake:atoms'",
+                     "Molecule template {}: Found {} instead of {} data entries for \"shake:atoms\"",
                      id, shakedata["atoms"]["data"].size(), natoms);
       } else {
         error->all(FLERR, Error::NOLASTLINE,
-                   "Molecule template {}: JSON molecule data does not contain required 'data' "
-                   "field for 'shake:atoms'",
+                   "Molecule template {}: JSON molecule data does not contain required \"data\" "
+                   "field for \"shake:atoms\"",
                    id);
       }
     } else {
       error->all(FLERR, Error::NOLASTLINE,
-                 "Molecule template {}: JSON molecule data does not contain required 'atoms' "
-                 "field for 'shake'",
+                 "Molecule template {}: JSON molecule data does not contain required \"atoms\" "
+                 "field for \"shake\"",
                  id);
     }
 
     if (shakedata.contains("types")) {
       if (!shakedata["types"].contains("format"))
         error->all(FLERR, Error::NOLASTLINE,
-                   "Molecule template {}: JSON molecule data does not contain required 'format' "
-                   "field for 'shake:types'",
+                   "Molecule template {}: JSON molecule data does not contain required \"format\" "
+                   "field for \"shake:types\"",
                    id);
       if (shakedata["types"].contains("data")) {
         shaketypeflag = 1;
         tag_require = 1;
         if (shakedata["types"]["data"].size() != natoms)
           error->all(FLERR, Error::NOLASTLINE,
-                     "Molecule template {}: Found {} instead of {} data entries for 'shake:types'",
+                     "Molecule template {}: Found {} instead of {} data entries for \"shake:types\"",
                      id, shakedata["types"]["data"].size(), natoms);
       } else {
         error->all(FLERR, Error::NOLASTLINE,
-                   "Molecule template {}: JSON molecule data does not contain required 'data' "
-                   "field for 'shake:types'",
+                   "Molecule template {}: JSON molecule data does not contain required \"data\" "
+                   "field for \"shake:types\"",
                    id);
       }
     } else {
       error->all(FLERR, Error::NOLASTLINE,
-                 "Molecule template {}: JSON molecule data does not contain required 'types' "
-                 "field for 'shake'",
+                 "Molecule template {}: JSON molecule data does not contain required \"types\" "
+                 "field for \"shake\"",
                  id);
     }
     if (shakeflagflag && shakeatomflag && shaketypeflag) shakeflag = 1;
@@ -1489,25 +1500,25 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
       const auto &specialbonds = moldata["special"]["bonds"];
       if (!specialbonds.contains("format"))
         error->all(FLERR, Error::NOLASTLINE,
-                   "Molecule template {}: JSON molecule data does not contain required 'format' "
-                   "field for 'special:bonds'",
+                   "Molecule template {}: JSON molecule data does not contain required \"format\" "
+                   "field for \"special:bonds\"",
                    id);
       if (specialbonds.contains("data")) {
         if (specialbonds["data"].size() != natoms)
           error->all(
               FLERR, Error::NOLASTLINE,
-              "Molecule template {}: Found {} instead of {} data entries for 'special:bonds'", id,
+              "Molecule template {}: Found {} instead of {} data entries for \"special:bonds\"", id,
               specialbonds["data"].size(), natoms);
       } else {
         error->all(FLERR, Error::NOLASTLINE,
-                   "Molecule template {}: JSON molecule data does not contain required 'data' "
-                   "field for 'special:bonds'",
+                   "Molecule template {}: JSON molecule data does not contain required \"data\" "
+                   "field for \"special:bonds\"",
                    id);
       }
     } else {
       error->all(FLERR, Error::NOLASTLINE,
-                 "Molecule template {}: JSON molecule data does not contain required 'bonds' "
-                 "field for 'special'",
+                 "Molecule template {}: JSON molecule data does not contain required \"bonds\" "
+                 "field for \"special\"",
                  id);
     }
 #endif

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -1927,10 +1927,11 @@ void Molecule::read(int flag)
 
     readline(line);
 
-    // trim comments. if line is blank, continue
+    // trim comments. if line is blank or comment, continue
 
     auto text = utils::trim(utils::trim_comment(line));
     if (text.empty()) continue;
+    if (utils::strmatch(text, "^\\s*#")) continue;
 
     // search line for header keywords and set corresponding variable
     try {
@@ -1938,31 +1939,31 @@ void Molecule::read(int flag)
 
       int nmatch = values.count();
       int nwant = 0;
-      if (values.matches("^\\s*\\d+\\s+atoms")) {
+      if (values.matches("^\\s*\\d+\\s+atoms\\s*$")) {
         natoms = values.next_int();
         nwant = 2;
         has_atoms = true;
-      } else if (values.matches("^\\s*\\d+\\s+bonds")) {
+      } else if (values.matches("^\\s*\\d+\\s+bonds\\s*$")) {
         nbonds = values.next_int();
         nwant = 2;
-      } else if (values.matches("^\\s*\\d+\\s+angles")) {
+      } else if (values.matches("^\\s*\\d+\\s+angles\\s*$")) {
         nangles = values.next_int();
         nwant = 2;
-      } else if (values.matches("^\\s*\\d+\\s+dihedrals")) {
+      } else if (values.matches("^\\s*\\d+\\s+dihedrals\\s*$")) {
         ndihedrals = values.next_int();
         nwant = 2;
-      } else if (values.matches("^\\s*\\d+\\s+impropers")) {
+      } else if (values.matches("^\\s*\\d+\\s+impropers\\s*$")) {
         nimpropers = values.next_int();
         nwant = 2;
-      } else if (values.matches("^\\s*\\d+\\s+fragments")) {
+      } else if (values.matches("^\\s*\\d+\\s+fragments\\s*$")) {
         nfragments = values.next_int();
         nwant = 2;
-      } else if (values.matches("^\\s*\\f+\\s+mass")) {
+      } else if (values.matches("^\\s*\\f+\\s+mass\\s*$")) {
         massflag = 1;
         masstotal = values.next_double();
         nwant = 2;
         masstotal *= sizescale * sizescale * sizescale;
-      } else if (values.matches("^\\s*\\f+\\s+\\f+\\s+\\f+\\s+com")) {
+      } else if (values.matches("^\\s*\\f+\\s+\\f+\\s+\\f+\\s+com\\s*$")) {
         comflag = 1;
         com[0] = values.next_double();
         com[1] = values.next_double();
@@ -1973,7 +1974,7 @@ void Molecule::read(int flag)
         com[2] *= sizescale;
         if ((domain->dimension == 2) && (com[2] != 0.0))
           error->all(FLERR, fileiarg, "Molecule file z center-of-mass must be 0.0 for 2d systems");
-      } else if (values.matches("^\\s*\\f+\\s+\\f+\\s+\\f+\\s+\\f+\\s+\\f+\\s+\\f+\\s+inertia")) {
+      } else if (values.matches("^\\s*\\f+\\s+\\f+\\s+\\f+\\s+\\f+\\s+\\f+\\s+\\f+\\s+inertia\\s*$")) {
         inertiaflag = 1;
         itensor[0] = values.next_double();
         itensor[1] = values.next_double();
@@ -1989,7 +1990,7 @@ void Molecule::read(int flag)
         itensor[3] *= scale5;
         itensor[4] *= scale5;
         itensor[5] *= scale5;
-      } else if (values.matches("^\\s*\\d+\\s+\\d+\\s+body")) {
+      } else if (values.matches("^\\s*\\d+\\s+\\d+\\s+body\\s*$")) {
         bodyflag = 1;
         avec_body = dynamic_cast<AtomVecBody *>(atom->style_match("body"));
         if (!avec_body) error->all(FLERR, fileiarg, "Molecule file requires atom style body");
@@ -1999,15 +2000,15 @@ void Molecule::read(int flag)
       } else {
         // unknown header keyword
         if (values.matches("^\\s*\\f+\\s+\\S+")) {
-          error->one(FLERR, fileiarg, "Unknown keyword or incorrectly formatted header line: {}",
+          error->all(FLERR, fileiarg, "Unknown keyword or incorrectly formatted header line: {}",
                      line);
         } else
           break;
       }
       if (nmatch != nwant)
-        error->one(FLERR, fileiarg, "Invalid header line format in molecule file");
+        error->all(FLERR, fileiarg, "Invalid header line format in molecule file: {}", line);
     } catch (TokenizerException &e) {
-      error->one(FLERR, fileiarg, "Invalid header in molecule file: {}", e.what());
+      error->all(FLERR, fileiarg, "Invalid header in molecule file: {}", e.what());
     }
   }
 

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -980,7 +980,6 @@ void Pair::ev_setup(int eflag, int vflag, int alloc)
       cvatom[i][6] = 0.0;
       cvatom[i][7] = 0.0;
       cvatom[i][8] = 0.0;
-      cvatom[i][9] = 0.0;
     }
   }
 

--- a/src/tabular_function.h
+++ b/src/tabular_function.h
@@ -14,6 +14,8 @@
 #ifndef LMP_TABULAR_FUNCTION_H
 #define LMP_TABULAR_FUNCTION_H
 
+#include <cmath>
+
 namespace LAMMPS_NS {
 class TabularFunction {
  public:
@@ -35,7 +37,7 @@ class TabularFunction {
   void value(double x, double &y, int ny, double &y1, int ny1)
   {
     double ps = (x - xmin) * rdx;
-    int ks = ps + 0.5;
+    int ks = std::lround(ps);
     if (ks > size - 1) ks = size - 1;
     if (ks < 0) ks = 0;
     ps = ps - ks;

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -65,7 +65,7 @@ Tokenizer::Tokenizer(const Tokenizer &rhs) :
   reset();
 }
 
-Tokenizer::Tokenizer(Tokenizer &&rhs) :
+Tokenizer::Tokenizer(Tokenizer &&rhs) noexcept :
     text(std::move(rhs.text)), separators(std::move(rhs.separators)), ntokens(rhs.ntokens)
 {
   reset();
@@ -78,14 +78,14 @@ Tokenizer &Tokenizer::operator=(const Tokenizer &other)
   return *this;
 }
 
-Tokenizer &Tokenizer::operator=(Tokenizer &&other)
+Tokenizer &Tokenizer::operator=(Tokenizer &&other) noexcept
 {
   Tokenizer tmp(std::move(other));
   swap(tmp);
   return *this;
 }
 
-void Tokenizer::swap(Tokenizer &other)
+void Tokenizer::swap(Tokenizer &other) noexcept
 {
   std::swap(text, other.text);
   std::swap(separators, other.separators);
@@ -221,7 +221,7 @@ ValueTokenizer::ValueTokenizer(const std::string &str, const std::string &separa
 {
 }
 
-ValueTokenizer::ValueTokenizer(ValueTokenizer &&rhs) : tokens(std::move(rhs.tokens)) {}
+ValueTokenizer::ValueTokenizer(ValueTokenizer &&rhs) noexcept : tokens(std::move(rhs.tokens)) {}
 
 ValueTokenizer &ValueTokenizer::operator=(const ValueTokenizer &other)
 {
@@ -230,14 +230,14 @@ ValueTokenizer &ValueTokenizer::operator=(const ValueTokenizer &other)
   return *this;
 }
 
-ValueTokenizer &ValueTokenizer::operator=(ValueTokenizer &&other)
+ValueTokenizer &ValueTokenizer::operator=(ValueTokenizer &&other) noexcept
 {
   ValueTokenizer tmp(std::move(other));
   swap(tmp);
   return *this;
 }
 
-void ValueTokenizer::swap(ValueTokenizer &other)
+void ValueTokenizer::swap(ValueTokenizer &other) noexcept
 {
   std::swap(tokens, other.tokens);
 }

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -36,11 +36,11 @@ class Tokenizer {
 
  public:
   Tokenizer(std::string str, std::string separators = TOKENIZER_DEFAULT_SEPARATORS);
-  Tokenizer(Tokenizer &&);
+  Tokenizer(Tokenizer &&) noexcept;
   Tokenizer(const Tokenizer &);
   Tokenizer &operator=(const Tokenizer &);
-  Tokenizer &operator=(Tokenizer &&);
-  void swap(Tokenizer &);
+  Tokenizer &operator=(Tokenizer &&) noexcept;
+  void swap(Tokenizer &) noexcept;
 
   void reset();
   void skip(int n = 1);
@@ -111,10 +111,10 @@ class ValueTokenizer {
   ValueTokenizer(const std::string &str,
                  const std::string &separators = TOKENIZER_DEFAULT_SEPARATORS);
   ValueTokenizer(const ValueTokenizer &) = default;
-  ValueTokenizer(ValueTokenizer &&);
+  ValueTokenizer(ValueTokenizer &&) noexcept;
   ValueTokenizer &operator=(const ValueTokenizer &);
-  ValueTokenizer &operator=(ValueTokenizer &&);
-  void swap(ValueTokenizer &);
+  ValueTokenizer &operator=(ValueTokenizer &&) noexcept;
+  void swap(ValueTokenizer &) noexcept;
 
   std::string next_string();
   tagint next_tagint();

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -2976,7 +2976,7 @@ double Variable::collapse_tree(Tree *tree)
     arg3 = collapse_tree(tree->extra[0]);
     if (tree->first->type != VALUE) return 0.0;
     tree->type = VALUE;
-    if (arg1) tree->value = arg2;
+    if (arg1 != 0.0) tree->value = arg2;
     else tree->value = arg3;
     return tree->value;
   }
@@ -3400,7 +3400,7 @@ double Variable::eval_tree(Tree *tree, int i)
     double first = eval_tree(tree->first,i);
     double second = eval_tree(tree->second,i);
     double third = eval_tree(tree->extra[0],i);
-    if (first) return second;
+    if (first != 0.0) return second;
     else return third;
   }
 
@@ -3940,7 +3940,7 @@ int Variable::math_function(char *word, char *contents, Tree **tree, Tree **tree
       print_var_error(FLERR,"Invalid math function in variable formula",ivar);
     if (tree) newtree->type = TERNARY;
     else {
-      if (value1) argstack[nargstack++] = value2;
+      if (value1 != 0.0) argstack[nargstack++] = value2;
       else argstack[nargstack++] = values[0];
     }
 

--- a/src/write_coeff.cpp
+++ b/src/write_coeff.cpp
@@ -154,8 +154,8 @@ void WriteCoeff::command(int narg, char **arg)
           // parse type number and skip over it
           int type = std::stoi(str);
           char *p = str;
-          while ((*p != '\0') && (*p == ' ')) ++p;
-          while ((*p != '\0') && isdigit(*p)) ++p;
+          while (*p == ' ') ++p;
+          while (isdigit(*p)) ++p;
 
           fprintf(two, "%s %d %s %s", coeff, type, section, p);
           utils::sfgets(FLERR, str, BUF_SIZE, one, file, error);

--- a/tools/json/molecule-schema.json
+++ b/tools/json/molecule-schema.json
@@ -300,6 +300,67 @@
                 }
             },
             "required": ["format", "data"]
+        },
+        "shake": {
+            "type": "object",
+            "properties": {
+                "flags" : {
+                    "type": "object",
+                    "properties": {
+                        "format": {
+                            "type": "array",
+                            "const": ["atom-id", "flag"]
+                        },
+                        "data": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "type": "integer"
+                                },
+                                "minItems": 2,
+                                "maxItems": 2
+                            }
+                        }
+                    },
+                    "required": ["format", "data"]
+                },
+                "atoms" : {
+                    "type": "object",
+                    "properties": {
+                        "format": {
+                            "type": "array",
+                            "const": ["atom-id", "atom-id-list"]
+                        },
+                        "data": {
+                            "type": "array",
+                            "items": {
+                                "type": ["integer", "array"],
+                                "minItems": 1
+                            }
+                        }
+                    },
+                    "required": ["format", "data"]
+                },
+                "types" : {
+                    "type": "object",
+                    "properties": {
+                        "format": {
+                            "type": "array",
+                            "const": ["atom-id", "bond-type-list"]
+                        },
+                        "data": {
+                            "type": "array",
+                            "items": {
+                                "type": ["integer", "array"],
+                                "minItems": 1
+                            }
+                        }
+                    },
+                    "required": ["format", "data"]
+                }
+            },
+            "required": ["flags", "atoms", "types"]
         }
     },
     "required": ["application", "format", "revision", "types"]

--- a/tools/json/molecule-schema.json
+++ b/tools/json/molecule-schema.json
@@ -27,13 +27,8 @@
                 "items": { "type": "number"},
                 "minItems": 3,
                 "maxItems": 3
-               },
+        },
         "masstotal": {"type": "number"},
-        "body": {"type": "array",
-                 "items": { "type": "integer"},
-                "minItems": 2,
-                "maxItems": 2
-               },
         "inertia": {"type": "array",
                     "items": { "type": "number"},
                     "minItems": 6,
@@ -361,6 +356,22 @@
                 }
             },
             "required": ["flags", "atoms", "types"]
+        },
+        "body": {
+            "type": "object",
+            "properties": {
+                "integers": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                    "minItems" : 1
+                },
+                "doubles": {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "minItems" : 1
+                }
+            },
+            "required": ["integers", "doubles"]
         }
     },
     "required": ["application", "format", "revision", "types"]

--- a/tools/json/molecule-schema.json
+++ b/tools/json/molecule-schema.json
@@ -296,6 +296,51 @@
             },
             "required": ["format", "data"]
         },
+        "special": {
+            "type": "object",
+            "properties": {
+                "counts" : {
+                    "type": "object",
+                    "properties": {
+                        "format": {
+                            "type": "array",
+                            "const": ["atom-id", "n12", "n13", "n14"]
+                        },
+                        "data": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "type": "integer"
+                                },
+                                "minItems": 4,
+                                "maxItems": 4
+                            }
+                        }
+                    },
+                    "required": ["format", "data"]
+                },
+                "bonds" : {
+                    "type": "object",
+                    "properties": {
+                        "format": {
+                            "type": "array",
+                            "const": ["atom-id", "atom-id-list"]
+                        },
+                        "data": {
+                            "type": "array",
+                            "items": {
+                                "type": ["integer", "array"],
+                                "minItems": 1
+                            }
+                        }
+                    },
+                    "required": ["format", "data"]
+                }
+            },
+            "required": ["counts", "bonds"]
+        },
+
         "shake": {
             "type": "object",
             "properties": {

--- a/tools/json/molecule-schema.json
+++ b/tools/json/molecule-schema.json
@@ -347,7 +347,7 @@
                     "properties": {
                         "format": {
                             "type": "array",
-                            "const": ["atom-id", "bond-type-list"]
+                            "const": ["atom-id", "type-list"]
                         },
                         "data": {
                             "type": "array",

--- a/tools/stl_bin2txt.cpp
+++ b/tools/stl_bin2txt.cpp
@@ -82,11 +82,11 @@ int main(int argc, char **argv)
             printf("Error reading binary STL facet attributes: %s\n", strerror(errno));
             return 7;
         }
-        fprintf(out, "  facet normal %e %e %e\n", normal[0], normal[1], normal[2]);
+        fprintf(out, "  facet normal %e %e %e\n", (double) normal[0], (double) normal[1], (double) normal[2]);
         fputs("    outer loop\n", out);
-        fprintf(out, "    vertex %e %e %e\n", vert1[0], vert1[1], vert1[2]);
-        fprintf(out, "    vertex %e %e %e\n", vert2[0], vert2[1], vert2[2]);
-        fprintf(out, "    vertex %e %e %e\n", vert3[0], vert3[1], vert3[2]);
+        fprintf(out, "    vertex %e %e %e\n", (double) vert1[0], (double) vert1[1], (double) vert1[2]);
+        fprintf(out, "    vertex %e %e %e\n", (double) vert2[0], (double) vert2[1], (double) vert2[2]);
+        fprintf(out, "    vertex %e %e %e\n", (double) vert3[0], (double) vert3[1], (double) vert3[2]);
         fputs("    endloop\n  endfacet\n", out);
         if (ferror(out)) {
             printf("Error writing text STL facet: %s\n", strerror(errno));

--- a/unittest/force-styles/test_angle_style.cpp
+++ b/unittest/force-styles/test_angle_style.cpp
@@ -550,7 +550,10 @@ TEST(AngleStyle, kokkos_omp)
 {
     if (!LAMMPS::is_installed_pkg("KOKKOS")) GTEST_SKIP();
     if (test_config.skip_tests.count(test_info_->name())) GTEST_SKIP();
-    if (!Info::has_accelerator_feature("KOKKOS", "api", "openmp")) GTEST_SKIP();
+    // test either OpenMP or Serial
+    if (!Info::has_accelerator_feature("KOKKOS", "api", "serial") &&
+        !Info::has_accelerator_feature("KOKKOS", "api", "openmp"))
+        GTEST_SKIP();
     // if KOKKOS has GPU support enabled, it *must* be used. We cannot test OpenMP only.
     if (Info::has_accelerator_feature("KOKKOS", "api", "cuda") ||
         Info::has_accelerator_feature("KOKKOS", "api", "hip") ||
@@ -559,6 +562,8 @@ TEST(AngleStyle, kokkos_omp)
 
     LAMMPS::argv args = {"AngleStyle", "-log", "none", "-echo", "screen", "-nocite",
                          "-k",         "on",   "t",    "4",     "-sf",    "kk"};
+    // fall back to serial if openmp is not available
+    if (!Info::has_accelerator_feature("KOKKOS", "api", "openmp")) args[9] = "1";
 
     ::testing::internal::CaptureStdout();
     LAMMPS *lmp = nullptr;

--- a/unittest/force-styles/test_bond_style.cpp
+++ b/unittest/force-styles/test_bond_style.cpp
@@ -553,7 +553,10 @@ TEST(BondStyle, kokkos_omp)
 {
     if (!LAMMPS::is_installed_pkg("KOKKOS")) GTEST_SKIP();
     if (test_config.skip_tests.count(test_info_->name())) GTEST_SKIP();
-    if (!Info::has_accelerator_feature("KOKKOS", "api", "openmp")) GTEST_SKIP();
+    // test either OpenMP or Serial
+    if (!Info::has_accelerator_feature("KOKKOS", "api", "serial") &&
+        !Info::has_accelerator_feature("KOKKOS", "api", "openmp"))
+        GTEST_SKIP();
     // if KOKKOS has GPU support enabled, it *must* be used. We cannot test OpenMP only.
     if (Info::has_accelerator_feature("KOKKOS", "api", "cuda") ||
         Info::has_accelerator_feature("KOKKOS", "api", "hip") ||
@@ -562,6 +565,8 @@ TEST(BondStyle, kokkos_omp)
 
     LAMMPS::argv args = {"BondStyle", "-log", "none", "-echo", "screen", "-nocite",
                          "-k",        "on",   "t",    "4",     "-sf",    "kk"};
+    // fall back to serial if openmp is not available
+    if (!Info::has_accelerator_feature("KOKKOS", "api", "openmp")) args[9] = "1";
 
     ::testing::internal::CaptureStdout();
     LAMMPS *lmp = nullptr;

--- a/unittest/force-styles/test_fix_timestep.cpp
+++ b/unittest/force-styles/test_fix_timestep.cpp
@@ -894,7 +894,10 @@ TEST(FixTimestep, kokkos_omp)
 {
     if (!LAMMPS::is_installed_pkg("KOKKOS")) GTEST_SKIP();
     if (test_config.skip_tests.count(test_info_->name())) GTEST_SKIP();
-    if (!Info::has_accelerator_feature("KOKKOS", "api", "openmp")) GTEST_SKIP();
+    // test either OpenMP or Serial
+    if (!Info::has_accelerator_feature("KOKKOS", "api", "serial") &&
+        !Info::has_accelerator_feature("KOKKOS", "api", "openmp"))
+        GTEST_SKIP();
     // if KOKKOS has GPU support enabled, it *must* be used. We cannot test OpenMP only.
     if (Info::has_accelerator_feature("KOKKOS", "api", "cuda") ||
         Info::has_accelerator_feature("KOKKOS", "api", "hip") ||
@@ -903,6 +906,8 @@ TEST(FixTimestep, kokkos_omp)
     }
     LAMMPS::argv args = {"FixTimestep", "-log", "none", "-echo", "screen", "-nocite",
                          "-k",          "on",   "t",    "4",     "-sf",    "kk"};
+    // fall back to serial if openmp is not available
+    if (!Info::has_accelerator_feature("KOKKOS", "api", "openmp")) args[9] = "1";
 
     ::testing::internal::CaptureStdout();
     LAMMPS *lmp = nullptr;

--- a/unittest/force-styles/test_mliappy_unified.cpp
+++ b/unittest/force-styles/test_mliappy_unified.cpp
@@ -114,10 +114,14 @@ TEST(MliapUnified, VersusLJMeltGhost)
     lammps_close(ljmelt);
     lammps_close(mliap);
 }
+
 TEST(MliapUnified, VersusLJMeltKokkos)
 {
     if (!LAMMPS::is_installed_pkg("KOKKOS")) GTEST_SKIP();
-    if (!Info::has_accelerator_feature("KOKKOS", "api", "openmp")) GTEST_SKIP();
+    // test either OpenMP or Serial
+    if (!Info::has_accelerator_feature("KOKKOS", "api", "serial") &&
+        !Info::has_accelerator_feature("KOKKOS", "api", "openmp"))
+        GTEST_SKIP();
     // if KOKKOS has GPU support enabled, it *must* be used. We cannot test OpenMP only.
     if (Info::has_accelerator_feature("KOKKOS", "api", "cuda") ||
         Info::has_accelerator_feature("KOKKOS", "api", "hip") ||
@@ -127,7 +131,9 @@ TEST(MliapUnified, VersusLJMeltKokkos)
 
     const char *lmpargv[] = {"melt", "-log", "none", "-echo", "screen", "-nocite",
                              "-k",   "on",   "t",    "4",     "-sf",    "kk"};
-    int lmpargc           = sizeof(lmpargv) / sizeof(const char *);
+    // fall back to serial if openmp is not available
+    if (!Info::has_accelerator_feature("KOKKOS", "api", "openmp")) lmpargv[9] = "1";
+    int lmpargc = sizeof(lmpargv) / sizeof(const char *);
 
     void *ljmelt = lammps_open_no_mpi(lmpargc, (char **)lmpargv, nullptr);
     void *mliap  = lammps_open_no_mpi(lmpargc, (char **)lmpargv, nullptr);
@@ -159,10 +165,14 @@ TEST(MliapUnified, VersusLJMeltKokkos)
     lammps_close(ljmelt);
     lammps_close(mliap);
 }
+
 TEST(MliapUnified, VersusLJMeltGhostKokkos)
 {
     if (!LAMMPS::is_installed_pkg("KOKKOS")) GTEST_SKIP();
-    if (!Info::has_accelerator_feature("KOKKOS", "api", "openmp")) GTEST_SKIP();
+    // test either OpenMP or Serial
+    if (!Info::has_accelerator_feature("KOKKOS", "api", "openmp") &&
+        !Info::has_accelerator_feature("KOKKOS", "api", "serial"))
+        GTEST_SKIP();
     // if KOKKOS has GPU support enabled, it *must* be used. We cannot test OpenMP only.
     if (Info::has_accelerator_feature("KOKKOS", "api", "cuda") ||
         Info::has_accelerator_feature("KOKKOS", "api", "hip") ||
@@ -172,7 +182,10 @@ TEST(MliapUnified, VersusLJMeltGhostKokkos)
 
     const char *lmpargv[] = {"melt", "-log", "none", "-echo", "screen", "-nocite",
                              "-k",   "on",   "t",    "4",     "-sf",    "kk"};
-    int lmpargc           = sizeof(lmpargv) / sizeof(const char *);
+    // fall back to serial if openmp is not available
+    if (!Info::has_accelerator_feature("KOKKOS", "api", "openmp")) lmpargv[9] = "1";
+
+    int lmpargc = sizeof(lmpargv) / sizeof(const char *);
 
     void *ljmelt = lammps_open_no_mpi(lmpargc, (char **)lmpargv, nullptr);
     void *mliap  = lammps_open_no_mpi(lmpargc, (char **)lmpargv, nullptr);

--- a/unittest/formats/test_molecule_file.cpp
+++ b/unittest/formats/test_molecule_file.cpp
@@ -480,7 +480,7 @@ TEST_F(MoleculeFileTest, minimal)
 TEST_F(MoleculeFileTest, minjson)
 {
     BEGIN_CAPTURE_OUTPUT();
-    run_mol_cmd(
+    run_json_cmd(
         test_name, "",
         "{\"application\":\"LAMMPS\",\"format\":\"molecule\",\"revision\": 1,"
         "\"types\":{\"format\": [\"atom-id\",\"type\"],\"data\": [[1,1]]},"

--- a/unittest/formats/test_molecule_file.cpp
+++ b/unittest/formats/test_molecule_file.cpp
@@ -474,7 +474,7 @@ TEST_F(MoleculeFileTest, minimal)
     run_mol_cmd(test_name, "", "Comment\n1 atoms\n\n Coords\n\n 1 0.0 0.0 0.0\n");
     auto output = END_CAPTURE_OUTPUT();
     ASSERT_THAT(output, ContainsRegex(".*Read molecule template.*\n.*Comment.*\n.*1 molecules.*\n"
-                                      ".*0 fragments.*\n.*1 atoms.*\n.*0 bonds.*"));
+                                      ".*0 fragments.*\n.*0 bodies.*\n.*1 atoms.*\n.*0 bonds.*"));
 }
 
 TEST_F(MoleculeFileTest, minjson)
@@ -487,7 +487,7 @@ TEST_F(MoleculeFileTest, minjson)
         "\"coords\":{\"format\":[\"atom-id\",\"x\",\"y\",\"z\"],\"data\": [[1,0.0,0.0,0.0]]}}");
     auto output = END_CAPTURE_OUTPUT();
     ASSERT_THAT(output, ContainsRegex(".*Read molecule template minjson:\n.no title.*\n.*1 molecules.*\n"
-                                      ".*0 fragments.*\n.*1 atoms.*\n.*0 bonds.*"));
+                                      ".*0 fragments.*\n.*0 bodies.*\n.*1 atoms.*\n.*0 bonds.*"));
 }
 
 TEST_F(MoleculeFileTest, notype)
@@ -499,7 +499,7 @@ TEST_F(MoleculeFileTest, notype)
     run_mol_cmd(test_name, "", "Comment\n1 atoms\n\n Coords\n\n 1 0.0 0.0 0.0\n");
     auto output = END_CAPTURE_OUTPUT();
     ASSERT_THAT(output, ContainsRegex(".*Read molecule template.*\n.*Comment.*\n.*1 molecules.*\n"
-                                      ".*0 fragments.*\n.*1 atoms.*\n.*0 bonds.*"));
+                                      ".*0 fragments.*\n.*0 bodies.*\n.*1 atoms.*\n.*0 bonds.*"));
     TEST_FAILURE(".*ERROR: Create_atoms molecule must have atom types.*",
                  command("create_atoms 0 single 0.0 0.0 0.0 mol notype 542465"););
 }
@@ -528,7 +528,7 @@ TEST_F(MoleculeFileTest, twomols)
                 " Molecules\n\n 1 1\n 2 2\n\n Types\n\n 1 1\n 2 2\n\n");
     auto output = END_CAPTURE_OUTPUT();
     ASSERT_THAT(output, ContainsRegex(".*Read molecule template.*\n.*Comment.*\n.*2 molecules.*\n"
-                                      ".*0 fragments.*\n.*2 atoms with max type 2.*\n.*0 bonds.*"));
+                                      ".*0 fragments.*\n.*0 bodies.*\n.*2 atoms with max type 2.*\n.*0 bonds.*"));
     ASSERT_EQ(lmp->atom->nmolecule, 1);
     auto mols = lmp->atom->get_molecule_by_id(test_name);
     ASSERT_EQ(mols.size(), 1);
@@ -575,7 +575,7 @@ TEST_F(MoleculeFileTest, tenmols)
     auto output = END_CAPTURE_OUTPUT();
     ASSERT_THAT(output,
                 ContainsRegex(".*Read molecule template.*\n.*Comment.*\n.*10 molecules.*\n"
-                              ".*0 fragments.*\n.*10 atoms with max type 2.*\n.*0 bonds.*"));
+                              ".*0 fragments.*\n.*0 bodies.*\n.*10 atoms with max type 2.*\n.*0 bonds.*"));
     ASSERT_EQ(lmp->atom->nmolecule, 1);
     auto mols = lmp->atom->get_molecule_by_id(test_name);
     ASSERT_EQ(mols.size(), 1);
@@ -595,10 +595,10 @@ TEST_F(MoleculeFileTest, twofiles)
     ASSERT_THAT(
         output,
         ContainsRegex(".*Read molecule template twomols:.*\n.*Water.*\n.*1 molecules.*\n"
-                      ".*0 fragments.*\n.*3 atoms with max type 2.*\n.*2 bonds with max type 1.*\n"
+                      ".*0 fragments.*\n.*0 bodies.*\n.*3 atoms with max type 2.*\n.*2 bonds with max type 1.*\n"
                       ".*1 angles with max type 1.*\n.*0 dihedrals.*\n.*0 impropers.*\n"
                       ".*Read molecule template twomols:.*\n.*CO2.*\n.*1 molecules.*\n"
-                      ".*0 fragments.*\n.*3 atoms with max type 4.*\n.*2 bonds with max type 2.*\n"
+                      ".*0 fragments.*\n.*0 bodies.*\n.*3 atoms with max type 4.*\n.*2 bonds with max type 2.*\n"
                       ".*1 angles with max type 2.*\n.*0 dihedrals.*"));
     BEGIN_CAPTURE_OUTPUT();
     command("molecule h2o moltest.h2o.mol");
@@ -628,7 +628,7 @@ TEST_F(MoleculeFileTest, labelmap)
     ASSERT_THAT(
         output,
         ContainsRegex(".*Read molecule template h2olabel:.*\n.*Water.*\n.*1 molecules.*\n"
-                      ".*0 fragments.*\n.*3 atoms with max type 2.*\n.*2 bonds with max type 1.*\n"
+                      ".*0 fragments.*\n.*0 bodies.*\n.*3 atoms with max type 2.*\n.*2 bonds with max type 1.*\n"
                       ".*1 angles with max type 1.*\n.*0 dihedrals.*\n.*0 impropers.*"));
     BEGIN_CAPTURE_OUTPUT();
     command("molecule co2label labelmap.co2.mol");
@@ -636,7 +636,7 @@ TEST_F(MoleculeFileTest, labelmap)
     ASSERT_THAT(
         output,
         ContainsRegex(".*Read molecule template co2label:.*\n.*CO2.*\n.*1 molecules.*\n"
-                      ".*0 fragments.*\n.*3 atoms with max type 4.*\n.*2 bonds with max type 2.*\n"
+                      ".*0 fragments.*\n.*0 bodies.*\n.*3 atoms with max type 4.*\n.*2 bonds with max type 2.*\n"
                       ".*1 angles with max type 2.*\n.*0 dihedrals.*"));
     BEGIN_CAPTURE_OUTPUT();
     command("molecule h2onum moltest.h2o.mol");
@@ -650,12 +650,12 @@ TEST_F(MoleculeFileTest, labelmap)
     ASSERT_THAT(
         first,
         ContainsRegex(".*Read molecule template h2onum:.*\n.*Water.*\n.*1 molecules.*\n"
-                      ".*0 fragments.*\n.*3 atoms with max type 2.*\n.*2 bonds with max type 1.*\n"
+                      ".*0 fragments.*\n.*0 bodies.*\n.*3 atoms with max type 2.*\n.*2 bonds with max type 1.*\n"
                       ".*1 angles with max type 1.*\n.*0 dihedrals.*\n.*0 impropers.*\n"));
     ASSERT_THAT(
         second,
         ContainsRegex(".*Read molecule template co2num:.*\n.*CO2.*\n.*1 molecules.*\n"
-                      ".*0 fragments.*\n.*3 atoms with max type 4.*\n.*2 bonds with max type 2.*\n"
+                      ".*0 fragments.*\n.*0 bodies.*\n.*3 atoms with max type 4.*\n.*2 bonds with max type 2.*\n"
                       ".*1 angles with max type 2.*\n.*0 dihedrals.*"));
     ASSERT_EQ(lmp->atom->nmolecule, 4);
     auto mols = lmp->atom->get_molecule_by_id("h2onum");
@@ -701,7 +701,7 @@ TEST_F(MoleculeFileTest, bonds)
                 " 2 2 1 3\n\n");
     auto output = END_CAPTURE_OUTPUT();
     ASSERT_THAT(output, ContainsRegex(".*Read molecule template.*\n.*Comment.*\n.*1 molecules.*\n"
-                                      ".*0 fragments.*\n.*4 atoms.*type.*2.*\n"
+                                      ".*0 fragments.*\n.*0 bodies.*\n.*4 atoms.*type.*2.*\n"
                                       ".*2 bonds.*type.*2.*\n.*0 angles.*"));
 
     BEGIN_CAPTURE_OUTPUT();
@@ -740,7 +740,7 @@ TEST_F(MoleculeFileTest, dipoles)
                 "Dipoles\n\n1 1.0 0.0 0.0\n2 1.0 1.0 0.0\n\n");
     auto output = END_CAPTURE_OUTPUT();
     ASSERT_THAT(output, ContainsRegex(".*Read molecule template.*\n.*Dumbbell.*\n.*1 molecules.*\n"
-                                      ".*0 fragments.*\n.*2 atoms.*type.*2.*\n"));
+                                      ".*0 fragments.*\n.*0 bodies.*\n.*2 atoms.*type.*2.*\n"));
 
     BEGIN_CAPTURE_OUTPUT();
     command("mass * 1.0");

--- a/unittest/python/python-cmdwrapper.py
+++ b/unittest/python/python-cmdwrapper.py
@@ -53,7 +53,7 @@ class PythonCmdWrapper(unittest.TestCase):
 
         types = [1, 1]
 
-        self.assertEqual(self.lmp.create_atoms(2, id=None, type=types, x=x), 2)
+        self.assertEqual(self.lmp.create_atoms(2, atomid=None, atype=types, x=x), 2)
         self.assertEqual(self.lmp.extract_global("natoms"), 2)
         pos = self.lmp.numpy.extract_atom("x")
         self.assertEqual(pos.shape[0], 2)

--- a/unittest/python/python-commands.py
+++ b/unittest/python/python-commands.py
@@ -122,7 +122,7 @@ create_atoms 1 single &
         x = [ 1.0, 1.0, 1.0,  1.0, 1.0, 1.5 ]
         types = [1, 1]
 
-        self.assertEqual(self.lmp.create_atoms(2, id=None, type=types, x=x), 2)
+        self.assertEqual(self.lmp.create_atoms(2, atomid=None, atype=types, x=x), 2)
         nlocal = self.lmp.extract_global("nlocal")
         self.assertEqual(nlocal, 2)
 
@@ -167,7 +167,7 @@ create_atoms 1 single &
         tags = [1, 2, 3, 4, 5, 6, 7]
         types = [1, 1, 1, 1, 1, 1, 1]
 
-        self.assertEqual(self.lmp.create_atoms(7, id=tags, type=types, x=x), 7)
+        self.assertEqual(self.lmp.create_atoms(7, atomid=tags, atype=types, x=x), 7)
         nlocal = self.lmp.extract_global("nlocal")
         self.assertEqual(nlocal, 7)
 
@@ -207,7 +207,7 @@ create_atoms 1 single &
         tags = [1, 2, 3, 4, 5, 6, 7]
         types = [1, 1, 1, 1, 1, 1, 1]
 
-        self.assertEqual(self.lmp.create_atoms(7, id=tags, type=types, x=x), 7)
+        self.assertEqual(self.lmp.create_atoms(7, atomid=tags, atype=types, x=x), 7)
         nlocal = self.lmp.extract_global("nlocal")
         self.assertEqual(nlocal, 7)
 
@@ -237,7 +237,7 @@ create_atoms 1 single &
         tags = [1, 2, 3, 4, 5, 6, 7]
         types = [1, 1, 1, 1, 1, 1, 1]
 
-        self.assertEqual(self.lmp.create_atoms(7, id=tags, type=types, x=x), 7)
+        self.assertEqual(self.lmp.create_atoms(7, atomid=tags, atype=types, x=x), 7)
         nlocal = self.lmp.extract_global("nlocal")
         self.assertEqual(nlocal, 7)
 
@@ -276,7 +276,7 @@ create_atoms 1 single &
         tags = [1, 2, 3, 4, 5, 6, 7]
         types = [1, 1, 1, 1, 1, 1, 1]
 
-        self.assertEqual(self.lmp.create_atoms(7, id=tags, type=types, x=x), 7)
+        self.assertEqual(self.lmp.create_atoms(7, atomid=tags, atype=types, x=x), 7)
         nlocal = self.lmp.extract_global("nlocal")
         self.assertEqual(nlocal, 7)
 
@@ -310,7 +310,7 @@ create_atoms 1 single &
         tags = [1, 2, 3, 4, 5, 6, 7]
         types = [1, 1, 1, 1, 2, 2, 2]
 
-        self.assertEqual(self.lmp.create_atoms(7, id=tags, type=types, x=x), 7)
+        self.assertEqual(self.lmp.create_atoms(7, atomid=tags, atype=types, x=x), 7)
         nlocal = self.lmp.extract_global("nlocal")
         self.assertEqual(nlocal, 7)
 
@@ -378,7 +378,7 @@ create_atoms 1 single &
         tags = [1, 2, 3, 4, 5, 6, 7]
         types = [1, 1, 1, 1, 1, 1, 1]
 
-        self.assertEqual(self.lmp.create_atoms(7, id=tags, type=types, x=x), 7)
+        self.assertEqual(self.lmp.create_atoms(7, atomid=tags, atype=types, x=x), 7)
         nlocal = self.lmp.extract_global("nlocal")
         self.assertEqual(nlocal, 7)
 
@@ -522,7 +522,7 @@ create_atoms 1 single &
 
         types = [1, 1]
 
-        self.assertEqual(self.lmp.create_atoms(2, id=None, type=types, x=x), 2)
+        self.assertEqual(self.lmp.create_atoms(2, atomid=None, atype=types, x=x), 2)
         self.lmp.command("variable a atom x*x+y*y+z*z")
         a = self.lmp.extract_variable("a", "all", LMP_VAR_ATOM)
         self.assertEqual(a[0], x[0]*x[0]+x[1]*x[1]+x[2]*x[2])
@@ -573,7 +573,7 @@ create_atoms 1 single &
         ]
 
         types = [1, 1]
-        self.lmp.create_atoms(2, id=None, type=types, x=x)
+        self.lmp.create_atoms(2, atomid=None, atype=types, x=x)
 
         state = {
             "step": 0,
@@ -611,7 +611,7 @@ create_atoms 1 single &
           1.5, 1.5, 1.5
         ]
         types = [1, 1]
-        self.lmp.create_atoms(2, id=None, type=types, x=x)
+        self.lmp.create_atoms(2, atomid=None, atype=types, x=x)
 
         self.assertEqual(self.lmp.last_thermo(), None)
         self.lmp.command("run 2 post no")

--- a/unittest/python/python-numpy.py
+++ b/unittest/python/python-numpy.py
@@ -165,7 +165,7 @@ class PythonNumpy(unittest.TestCase):
         x = [ 1.0, 1.0, 1.0,  1.0, 1.0, 1.5,  1.5, 1.0, 1.0 ]
         types = [1, 2, 1]
         ids = [1, 2, 3]
-        self.assertEqual(self.lmp.create_atoms(3, id=ids, type=types, x=x), 3)
+        self.assertEqual(self.lmp.create_atoms(3, atomid=ids, atype=types, x=x), 3)
         self.lmp.command("mass * 2.0")
         self.lmp.command("pair_style zero 1.1")
         self.lmp.command("pair_coeff * *")
@@ -426,7 +426,7 @@ class PythonNumpy(unittest.TestCase):
         x = [ 1.0, 1.0, 1.0,  1.0, 1.0, 1.5 ]
         types = [1, 1]
 
-        self.assertEqual(self.lmp.create_atoms(2, id=None, type=types, x=x), 2)
+        self.assertEqual(self.lmp.create_atoms(2, atomid=None, atype=types, x=x), 2)
         nlocal = self.lmp.extract_global("nlocal")
         self.assertEqual(nlocal, 2)
 
@@ -471,7 +471,7 @@ class PythonNumpy(unittest.TestCase):
         tags = [1, 2, 3, 4, 5, 6, 7]
         types = [1, 1, 1, 1, 1, 1, 1]
 
-        self.assertEqual(self.lmp.create_atoms(7, id=tags, type=types, x=x), 7)
+        self.assertEqual(self.lmp.create_atoms(7, atomid=tags, atype=types, x=x), 7)
         nlocal = self.lmp.extract_global("nlocal")
         self.assertEqual(nlocal, 7)
 
@@ -510,7 +510,7 @@ class PythonNumpy(unittest.TestCase):
         tags = [1, 2, 3, 4, 5, 6, 7]
         types = [1, 1, 1, 1, 1, 1, 1]
 
-        self.assertEqual(self.lmp.create_atoms(7, id=tags, type=types, x=x), 7)
+        self.assertEqual(self.lmp.create_atoms(7, atomid=tags, atype=types, x=x), 7)
         nlocal = self.lmp.extract_global("nlocal")
         self.assertEqual(nlocal, 7)
 
@@ -544,7 +544,7 @@ class PythonNumpy(unittest.TestCase):
         tags = [1, 2, 3, 4, 5, 6, 7]
         types = [1, 1, 1, 1, 2, 2, 2]
 
-        self.assertEqual(self.lmp.create_atoms(7, id=tags, type=types, x=x), 7)
+        self.assertEqual(self.lmp.create_atoms(7, atomid=tags, atype=types, x=x), 7)
         nlocal = self.lmp.extract_global("nlocal")
         self.assertEqual(nlocal, 7)
 
@@ -609,7 +609,7 @@ class PythonNumpy(unittest.TestCase):
         tags = [1, 2, 3, 4, 5, 6, 7]
         types = [1, 1, 1, 1, 1, 1, 1]
 
-        self.assertEqual(self.lmp.create_atoms(7, id=tags, type=types, x=x), 7)
+        self.assertEqual(self.lmp.create_atoms(7, atomid=tags, atype=types, x=x), 7)
         nlocal = self.lmp.extract_global("nlocal")
         self.assertEqual(nlocal, 7)
 
@@ -647,7 +647,7 @@ class PythonNumpy(unittest.TestCase):
         tags = [1, 2, 3, 4, 5, 6, 7]
         types = [1, 1, 1, 1, 1, 1, 1]
 
-        self.assertEqual(self.lmp.create_atoms(7, id=tags, type=types, x=x), 7)
+        self.assertEqual(self.lmp.create_atoms(7, atomid=tags, atype=types, x=x), 7)
         nlocal = self.lmp.extract_global("nlocal")
         self.assertEqual(nlocal, 7)
 
@@ -680,7 +680,7 @@ class PythonNumpy(unittest.TestCase):
         tags = [1, 2, 3, 4, 5, 6, 7]
         types = [1, 1, 1, 1, 1, 1, 1]
 
-        self.assertEqual(self.lmp.create_atoms(7, id=tags, type=types, x=x), 7)
+        self.assertEqual(self.lmp.create_atoms(7, atomid=tags, atype=types, x=x), 7)
         nlocal = self.lmp.extract_global("nlocal")
         self.assertEqual(nlocal, 7)
 
@@ -733,7 +733,7 @@ class PythonNumpy(unittest.TestCase):
 
         types = [1, 1]
 
-        self.assertEqual(self.lmp.create_atoms(2, id=None, type=types, x=x), 2)
+        self.assertEqual(self.lmp.create_atoms(2, atomid=None, atype=types, x=x), 2)
         self.lmp.command("variable a atom x*x+y*y+z*z")
         a = self.lmp.numpy.extract_variable("a", "all", LMP_VAR_ATOM)
         self.assertIs(type(a), numpy.ndarray)

--- a/unittest/python/python-pylammps.py
+++ b/unittest/python/python-pylammps.py
@@ -53,7 +53,7 @@ class PythonPyLammps(unittest.TestCase):
 
         types = [1, 1]
 
-        self.assertEqual(self.pylmp.lmp.create_atoms(2, id=None, type=types, x=x), 2)
+        self.assertEqual(self.pylmp.lmp.create_atoms(2, atomid=None, atype=types, x=x), 2)
         self.assertEqual(self.pylmp.system.natoms, 2)
         self.assertEqual(len(self.pylmp.atoms), 2)
         numpy.testing.assert_array_equal(self.pylmp.atoms[0].position, tuple(x[0:3]))


### PR DESCRIPTION
**Summary**

This pull request combines multiple small changes that do not warrant a pull request on their own.

**Related Issue(s)**

Fixes #4632 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

The following individual changes are included:
- fix bug in Fortran module where reallocation of global fix callback list did not happen as expected (reported by @rbberger)
- avoid copies of strings when setting error messages in the library interface
- error out in compute msd if the number of atoms in the compute group changes by other means than a dynamic group
- fix out-of-bound access in Pair class when initializing cvatom reported in Issue #4632. Also fix the same issue `angle.cpp`, `dihedral.cpp`, and `improper.cpp`
- replace rounding with `static_cast<int>(val + 0.5)` with C++11's `std::lround()`
- remove workaround of running sphinx-build twice for linking Fortran functions in manual since it has no effect anymore. Will need to solve the problem in the package itself.
- silence compiler warnings
- run force-style unit tests with Kokkos/Serial, if it is available and Kokkos/OpenMP is not
- correct reading shake and special sections of a molecule file in native format that were ignoring the atom-id and thus contradicting the documentation.
- remove some remnants of Python 2 support from LAMMPS python module
- update LAMMPS python module to follow suggestions form pylint (or add comments to ignore them)
- small update to the LAMMPS python module wrapper for NumPy to replace discouraged code with recommended version
- parsing of JSON is only attempted for molecule files with the ".json" extension
- add support for shake, special, and body sections to JSON format molecule data.
- stricter checking of header items in native molecule file format
- correct creating of body particles from molecule files with `create_atoms`, `fix deposit`, and `fix pour`
- body particles require the Masses section to provide the total mass of the body

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
