### PR TITLE
Use qualified auto for improved readability

### DIFF
--- a/src/DPD-MESO/pair_tdpd.cpp
+++ b/src/DPD-MESO/pair_tdpd.cpp
@@ -281,9 +281,9 @@ void PairTDPD::coeff(int narg, char **arg)
   double power_one = utils::numeric(FLERR,arg[4],false,lmp);
   double cut_one   = utils::numeric(FLERR,arg[5],false,lmp);
   double cutcc_one = utils::numeric(FLERR,arg[6],false,lmp);
-  auto kappa_one = new double[cc_species];
-  auto epsilon_one = new double[cc_species];
-  auto powercc_one = new double[cc_species];
+  auto *kappa_one = new double[cc_species];
+  auto *epsilon_one = new double[cc_species];
+  auto *powercc_one = new double[cc_species];
   for (int k=0; k<cc_species; k++) {
     kappa_one[k]   = utils::numeric(FLERR,arg[7+3*k],false,lmp);
     epsilon_one[k] = utils::numeric(FLERR,arg[8+3*k],false,lmp);

--- a/src/DPD-REACT/fix_eos_table.cpp
+++ b/src/DPD-REACT/fix_eos_table.cpp
@@ -349,7 +349,7 @@ void FixEOStable::spline(double *x, double *y, int n,
 {
   int i,k;
   double p,qn,sig,un;
-  auto u = new double[n];
+  auto *u = new double[n];
 
   if (yp1 > 0.99e30) y2[0] = u[0] = 0.0;
   else {

--- a/src/DPD-REACT/fix_eos_table_rx.cpp
+++ b/src/DPD-REACT/fix_eos_table_rx.cpp
@@ -301,7 +301,7 @@ void FixEOStableRX::read_file(char *file)
 {
   int min_params_per_line = 2;
   int max_params_per_line = 5;
-  auto words = new char*[max_params_per_line+1];
+  auto *words = new char*[max_params_per_line+1];
 
   // open file on proc 0
 
@@ -640,7 +640,7 @@ void FixEOStableRX::spline(double *x, double *y, int n,
 {
   int i,k;
   double p,qn,sig,un;
-  auto u = new double[n];
+  auto *u = new double[n];
 
   if (yp1 > 0.99e30) y2[0] = u[0] = 0.0;
   else {

--- a/src/DPD-REACT/fix_rx.cpp
+++ b/src/DPD-REACT/fix_rx.cpp
@@ -232,7 +232,7 @@ void FixRX::post_constructor()
   int nUniqueSpecies = 0;
   bool match;
 
-  auto tmpspecies = new char*[maxspecies];
+  auto *tmpspecies = new char*[maxspecies];
   for (int jj=0; jj < maxspecies; jj++)
     tmpspecies[jj] = nullptr;
 
@@ -626,7 +626,7 @@ void FixRX::setup_pre_force(int /*vflag*/)
     userData.kFor = new double[nreactions];
     userData.rxnRateLaw = new double[nreactions];
 
-    auto rwork = new double[8*nspecies];
+    auto *rwork = new double[8*nspecies];
 
     if (localTempFlag) {
       int count = nlocal + (newton_pair ? nghost : 0);
@@ -696,7 +696,7 @@ void FixRX::pre_force(int /*vflag*/)
   }
 
   {
-    auto rwork = new double[8*nspecies];
+    auto *rwork = new double[8*nspecies];
 
     UserRHSData userData;
     userData.kFor = new double[nreactions];
@@ -1571,7 +1571,7 @@ int FixRX::rhs(double t, const double *y, double *dydt, void *params)
 
 int FixRX::rhs_dense(double /*t*/, const double *y, double *dydt, void *params)
 {
-  auto userData = (UserRHSData *) params;
+  auto *userData = (UserRHSData *) params;
 
   double *rxnRateLaw = userData->rxnRateLaw;
   double *kFor       = userData->kFor;
@@ -1605,7 +1605,7 @@ int FixRX::rhs_dense(double /*t*/, const double *y, double *dydt, void *params)
 
 int FixRX::rhs_sparse(double /*t*/, const double *y, double *dydt, void *v_params) const
 {
-   auto userData = (UserRHSData *) v_params;
+   auto *userData = (UserRHSData *) v_params;
 
    const double VDPD = domain->xprd * domain->yprd * domain->zprd / atom->natoms;
 

--- a/src/DPD-REACT/fix_shardlow.cpp
+++ b/src/DPD-REACT/fix_shardlow.cpp
@@ -549,7 +549,7 @@ void FixShardlow::initial_integrate(int /*vflag*/)
                     "Either reduce the number of processors requested, or change the cutoff/skin: "
                     "rcut= {} bbx= {} bby= {} bbz= {}\n", rcut, bbx, bby, bbz);
 
-  auto np_ssa = dynamic_cast<NPairHalfBinNewtonSSA*>(list->np);
+  auto *np_ssa = dynamic_cast<NPairHalfBinNewtonSSA*>(list->np);
   if (!np_ssa) error->one(FLERR, "NPair wasn't a NPairHalfBinNewtonSSA object");
   int ssa_phaseCt = np_ssa->ssa_phaseCt;
   int *ssa_phaseLen = np_ssa->ssa_phaseLen;

--- a/src/DPD-REACT/npair_half_bin_newton_ssa.cpp
+++ b/src/DPD-REACT/npair_half_bin_newton_ssa.cpp
@@ -98,12 +98,12 @@ void NPairHalfBinNewtonSSA::build(NeighList *list)
   int **firstneigh = list->firstneigh;
   MyPage<int> *ipage = list->ipage;
 
-  auto ns_ssa = dynamic_cast<NStencilSSA*>(ns);
+  auto *ns_ssa = dynamic_cast<NStencilSSA*>(ns);
   if (!ns_ssa) error->one(FLERR, Error::NOLASTLINE, "NStencil wasn't a NStencilSSA object");
   int *nstencil_ssa = &(ns_ssa->nstencil_ssa[0]);
   int nstencil_full = ns_ssa->nstencil;
 
-  auto nb_ssa = dynamic_cast<NBinSSA*>(nb);
+  auto *nb_ssa = dynamic_cast<NBinSSA*>(nb);
   if (!nb_ssa) error->one(FLERR, Error::NOLASTLINE, "NBin wasn't a NBinSSA object");
   int *bins = nb_ssa->bins;
   int *binhead = nb_ssa->binhead;

--- a/src/DPD-REACT/pair_exp6_rx.cpp
+++ b/src/DPD-REACT/pair_exp6_rx.cpp
@@ -708,7 +708,7 @@ double PairExp6rx::init_one(int i, int j)
 void PairExp6rx::read_file(char *file)
 {
   int params_per_line = 5;
-  auto words = new char*[params_per_line+1];
+  auto *words = new char*[params_per_line+1];
 
   memory->sfree(params);
   params = nullptr;
@@ -824,7 +824,7 @@ void PairExp6rx::read_file(char *file)
 void PairExp6rx::read_file2(char *file)
 {
   int params_per_line = 7;
-  auto words = new char*[params_per_line+1];
+  auto *words = new char*[params_per_line+1];
 
   // open file on proc 0
 

--- a/src/DPD-REACT/pair_multi_lucy.cpp
+++ b/src/DPD-REACT/pair_multi_lucy.cpp
@@ -626,7 +626,7 @@ void PairMultiLucy::spline(double *x, double *y, int n,
 {
   int i,k;
   double p,qn,sig,un;
-  auto u = new double[n];
+  auto *u = new double[n];
 
   if (yp1 > 0.99e30) y2[0] = u[0] = 0.0;
   else {

--- a/src/DPD-REACT/pair_multi_lucy_rx.cpp
+++ b/src/DPD-REACT/pair_multi_lucy_rx.cpp
@@ -757,7 +757,7 @@ void PairMultiLucyRX::spline(double *x, double *y, int n,
 {
   int i,k;
   double p,qn,sig,un;
-  auto u = new double[n];
+  auto *u = new double[n];
 
   if (yp1 > 0.99e30) y2[0] = u[0] = 0.0;
   else {

--- a/src/DPD-SMOOTH/fix_meso_move.cpp
+++ b/src/DPD-SMOOTH/fix_meso_move.cpp
@@ -825,7 +825,7 @@ void FixMesoMove::write_restart (FILE *fp) {
 
 void FixMesoMove::restart (char *buf) {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
 
   time_origin = static_cast<int> (list[n++]);
 }

--- a/src/DRUDE/compute_temp_drude.cpp
+++ b/src/DRUDE/compute_temp_drude.cpp
@@ -62,7 +62,7 @@ ComputeTempDrude::~ComputeTempDrude()
 void ComputeTempDrude::init()
 {
   // Fix drude already checks that there is only one fix drude instance
-  auto &fixes = modify->get_fix_by_style("^drude$");
+  const auto &fixes = modify->get_fix_by_style("^drude$");
   if (fixes.size() == 0)
     error->all(FLERR, Error::NOLASTLINE, "compute temp/drude requires fix drude");
   fix_drude = dynamic_cast<FixDrude *>(fixes[0]);

--- a/src/DRUDE/fix_drude.cpp
+++ b/src/DRUDE/fix_drude.cpp
@@ -177,7 +177,7 @@ void FixDrude::build_drudeid() {
 ------------------------------------------------------------------------- */
 void FixDrude::ring_search_drudeid(int size, char *cbuf, void *ptr) {
   // Search for the drude partner of my cores
-  auto fdptr = (FixDrude *) ptr;
+  auto *fdptr = (FixDrude *) ptr;
   Atom *atom = fdptr->atom;
   int nlocal = atom->nlocal;
   int *type = atom->type;
@@ -185,7 +185,7 @@ void FixDrude::ring_search_drudeid(int size, char *cbuf, void *ptr) {
   tagint *drudeid = fdptr->drudeid;
   int *drudetype = fdptr->drudetype;
 
-  auto first = (tagint *) cbuf;
+  auto *first = (tagint *) cbuf;
   tagint *last = first + size;
   std::set<tagint> drude_set(first, last);
   std::set<tagint>::iterator it;
@@ -207,11 +207,11 @@ void FixDrude::ring_search_drudeid(int size, char *cbuf, void *ptr) {
 ------------------------------------------------------------------------- */
 void FixDrude::ring_build_partner(int size, char *cbuf, void *ptr) {
   // Add partners from incoming list
-  auto fdptr = (FixDrude *) ptr;
+  auto *fdptr = (FixDrude *) ptr;
   Atom *atom = fdptr->atom;
   int nlocal = atom->nlocal;
   std::set<tagint> *partner_set = fdptr->partner_set;
-  auto it = (tagint *) cbuf;
+  auto *it = (tagint *) cbuf;
   tagint *last = it + size;
 
   while (it < last) {
@@ -379,13 +379,13 @@ void FixDrude::rebuild_special() {
 ------------------------------------------------------------------------- */
 void FixDrude::ring_remove_drude(int size, char *cbuf, void *ptr) {
   // Remove all drude particles from special list
-  auto fdptr = (FixDrude *) ptr;
+  auto *fdptr = (FixDrude *) ptr;
   Atom *atom = fdptr->atom;
   int nlocal = atom->nlocal;
   int **nspecial = atom->nspecial;
   tagint **special = atom->special;
   int *type = atom->type;
-  auto first = (tagint *) cbuf;
+  auto *first = (tagint *) cbuf;
   tagint *last = first + size;
   std::set<tagint> drude_set(first, last);
   int *drudetype = fdptr->drudetype;
@@ -416,7 +416,7 @@ void FixDrude::ring_remove_drude(int size, char *cbuf, void *ptr) {
 void FixDrude::ring_add_drude(int size, char *cbuf, void *ptr) {
   // Assume special array size is big enough
   // Add all particle just after their core in the special list
-  auto fdptr = (FixDrude *) ptr;
+  auto *fdptr = (FixDrude *) ptr;
   Atom *atom = fdptr->atom;
   int nlocal = atom->nlocal;
   int **nspecial = atom->nspecial;
@@ -425,7 +425,7 @@ void FixDrude::ring_add_drude(int size, char *cbuf, void *ptr) {
   tagint *drudeid = fdptr->drudeid;
   int *drudetype = fdptr->drudetype;
 
-  auto first = (tagint *) cbuf;
+  auto *first = (tagint *) cbuf;
   tagint *last = first + size;
   std::map<tagint, tagint> core_drude_map;
 
@@ -472,7 +472,7 @@ void FixDrude::ring_add_drude(int size, char *cbuf, void *ptr) {
 ------------------------------------------------------------------------- */
 void FixDrude::ring_copy_drude(int size, char *cbuf, void *ptr) {
   // Copy special list of drude from its core (except itself)
-  auto fdptr = (FixDrude *) ptr;
+  auto *fdptr = (FixDrude *) ptr;
   Atom *atom = fdptr->atom;
   int nlocal = atom->nlocal;
   int **nspecial = atom->nspecial;
@@ -481,7 +481,7 @@ void FixDrude::ring_copy_drude(int size, char *cbuf, void *ptr) {
   tagint *drudeid = fdptr->drudeid;
   int *drudetype = fdptr->drudetype;
 
-  auto first = (tagint *) cbuf;
+  auto *first = (tagint *) cbuf;
   tagint *last = first + size;
   std::map<tagint, tagint*> core_special_map;
 

--- a/src/DRUDE/fix_drude_transform.cpp
+++ b/src/DRUDE/fix_drude_transform.cpp
@@ -86,7 +86,7 @@ void FixDrudeTransform<inverse>::setup(int) {
 
   if (!rmass) {
     if (!mcoeff) mcoeff = new double[ntypes+1];
-    auto mcoeff_loc = new double[ntypes+1];
+    auto *mcoeff_loc = new double[ntypes+1];
     for (int itype=0; itype<=ntypes; itype++) mcoeff_loc[itype] = 2.; // an impossible value: mcoeff is at most 1.
     for (int i=0; i<nlocal; i++) {
       if (drudetype[type[i]] == DRUDE_TYPE) {

--- a/src/DRUDE/fix_tgnh_drude.cpp
+++ b/src/DRUDE/fix_tgnh_drude.cpp
@@ -671,7 +671,7 @@ void FixTGNHDrude::init()
   // detect if any rigid fixes exist so rigid bodies move when box is remapped
 
   rfix.clear();
-  for (auto &ifix : modify->get_fix_list())
+  for (const auto &ifix : modify->get_fix_list())
     if (ifix->rigid_flag) rfix.push_back(ifix);
 }
 
@@ -721,7 +721,7 @@ void FixTGNHDrude::setup_mol_mass_dof() {
   memory->create(v_mol_tmp, n_mol + 1, 3, "fix_tgnh_drude::v_mol_tmp");
   memory->create(mass_mol, n_mol + 1, "fix_tgnh_drude::mass_mol");
 
-  auto mass_tmp = new double[n_mol + 1];
+  auto *mass_tmp = new double[n_mol + 1];
   memset(mass_tmp, 0, sizeof(double) * (n_mol + 1));
   for (int i = 0; i < atom->nlocal; i++) {
     id_mol = molecule[i];
@@ -1348,7 +1348,7 @@ int FixTGNHDrude::pack_restart_data(double *list)
 void FixTGNHDrude::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
   int flag = static_cast<int> (list[n++]);
   if (flag) {
     int m = static_cast<int> (list[n++]);

--- a/src/EFF/fix_nvt_sllod_eff.cpp
+++ b/src/EFF/fix_nvt_sllod_eff.cpp
@@ -85,7 +85,7 @@ void FixNVTSllodEff::init()
   if (deform.size() < 1) error->all(FLERR,"Using fix {} with no fix deform defined", style);
 
   for (auto &ifix : deform) {
-    auto f = dynamic_cast<FixDeform *>(ifix);
+    auto *f = dynamic_cast<FixDeform *>(ifix);
     if (f && (f->remapflag != Domain::V_REMAP))
       error->all(FLERR,"Using fix {} with inconsistent fix deform remap option", style);
   }

--- a/src/ELECTRODE/ewald_electrode.cpp
+++ b/src/ELECTRODE/ewald_electrode.cpp
@@ -118,7 +118,7 @@ void EwaldElectrode::init()
   pair_check();
 
   int itmp;
-  double *p_cutoff = (double *) force->pair->extract("cut_coul", itmp);
+  auto *p_cutoff = (double *) force->pair->extract("cut_coul", itmp);
   if (p_cutoff == nullptr) error->all(FLERR, "KSpace style is incompatible with Pair style");
   double cutoff = *p_cutoff;
 

--- a/src/ELECTRODE/fix_electrode_conp.cpp
+++ b/src/ELECTRODE/fix_electrode_conp.cpp
@@ -421,7 +421,7 @@ void FixElectrodeConp::init()
   int *mask = atom->mask;
   if (matrix_algo) {
     std::vector<Fix *> integrate_fixes;
-    for (auto fix : modify->get_fix_list()) {
+    for (auto *fix : modify->get_fix_list()) {
       if (fix->time_integrate == 0) continue;
       int electrode_mover = 0;
       int fix_groupbit = fix->groupbit;
@@ -431,7 +431,7 @@ void FixElectrodeConp::init()
       if (electrode_mover && comm->me == 0) integrate_fixes.push_back(fix);
     }
     if (comm->me == 0)
-      for (const auto fix : integrate_fixes)
+      for (auto *const fix : integrate_fixes)
         error->warning(FLERR,
                        "Electrode atoms are integrated by fix {} {}, but fix electrode is using a "
                        "matrix method. For mobile electrodes use the conjugate gradient algorithm "
@@ -443,7 +443,7 @@ void FixElectrodeConp::init()
   if (etypes_neighlists)
     request_etypes_neighlists();
   else {
-    auto Req = neighbor->add_request(this);
+    auto *Req = neighbor->add_request(this);
     if (intelflag) Req->enable_intel();
   }
 }
@@ -578,7 +578,7 @@ void FixElectrodeConp::setup_post_neighbor()
       array_compute->compute_array(elastance, timer_flag);
     }    // write_mat before proceeding
     if (comm->me == 0 && write_mat) {
-      auto f_mat = fopen(output_file_mat.c_str(), "w");
+      auto *f_mat = fopen(output_file_mat.c_str(), "w");
       if (f_mat == nullptr)
         error->one(FLERR, "Cannot open elastance matrix file {}: {}", output_file_mat,
                    utils::getsyserror());
@@ -618,7 +618,7 @@ void FixElectrodeConp::setup_post_neighbor()
     if (force->newton_pair) comm->reverse_comm(this);
     buffer_and_gather(potential_i, potential_iele);
     if (comm->me == 0) {
-      auto f_vec = fopen(output_file_vec.c_str(), "w");
+      auto *f_vec = fopen(output_file_vec.c_str(), "w");
       if (f_vec == nullptr)
         error->one(FLERR, "Cannot open vector file {}: {}", output_file_vec, utils::getsyserror());
       std::vector<std::vector<double>> vec(ngroup, std::vector<double>(1));
@@ -630,7 +630,7 @@ void FixElectrodeConp::setup_post_neighbor()
 
   if (write_inv) {
     if (comm->me == 0) {
-      auto f_inv = fopen(output_file_inv.c_str(), "w");
+      auto *f_inv = fopen(output_file_inv.c_str(), "w");
       if (f_inv == nullptr)
         error->one(FLERR, "Cannot open capacitance matrix file {}: {}", output_file_inv,
                    utils::getsyserror());
@@ -1468,12 +1468,12 @@ void FixElectrodeConp::request_etypes_neighlists()
   }
 
   if (need_array_compute) {
-    auto matReq = neighbor->add_request(this, NeighConst::REQ_OCCASIONAL);
+    auto *matReq = neighbor->add_request(this, NeighConst::REQ_OCCASIONAL);
     matReq->set_skip(iskip_mat, ijskip_mat);
     matReq->set_id(1);
     if (intelflag) matReq->enable_intel();
   } else if (need_elec_vector) {
-    auto matReq = neighbor->add_request(this);
+    auto *matReq = neighbor->add_request(this);
     matReq->set_skip(iskip_mat, ijskip_mat);
     matReq->set_id(1);
     if (intelflag) matReq->enable_intel();
@@ -1482,7 +1482,7 @@ void FixElectrodeConp::request_etypes_neighlists()
     memory->destroy(ijskip_mat);
   }
 
-  auto vecReq = neighbor->add_request(this);
+  auto *vecReq = neighbor->add_request(this);
   vecReq->set_skip(iskip_vec, ijskip_vec);
   vecReq->set_id(2);
   if (intelflag) vecReq->enable_intel();

--- a/src/ELECTRODE/pppm_electrode.cpp
+++ b/src/ELECTRODE/pppm_electrode.cpp
@@ -136,7 +136,7 @@ void PPPMElectrode::init()
   pair_check();
 
   int itmp = 0;
-  double *p_cutoff = (double *) force->pair->extract("cut_coul", itmp);
+  auto *p_cutoff = (double *) force->pair->extract("cut_coul", itmp);
   if (p_cutoff == nullptr) error->all(FLERR, "KSpace style is incompatible with Pair style");
   cutoff = *p_cutoff;
 
@@ -148,7 +148,7 @@ void PPPMElectrode::init()
   if (tip4pflag) {
     if (me == 0) utils::logmesg(lmp, "  extracting TIP4P info from pair style\n");
 
-    double *p_qdist = (double *) force->pair->extract("qdist", itmp);
+    auto *p_qdist = (double *) force->pair->extract("qdist", itmp);
     int *p_typeO = (int *) force->pair->extract("typeO", itmp);
     int *p_typeH = (int *) force->pair->extract("typeH", itmp);
     int *p_typeA = (int *) force->pair->extract("typeA", itmp);

--- a/src/EXTRA-COMMAND/ndx2group.cpp
+++ b/src/EXTRA-COMMAND/ndx2group.cpp
@@ -140,7 +140,7 @@ void Ndx2Group::command(int narg, char **arg)
           char *buf = new char[len];
           MPI_Bcast(buf, len, MPI_CHAR, 0, world);
           MPI_Bcast(&num, 1, MPI_LMP_BIGINT, 0, world);
-          tagint *tbuf = new tagint[num];
+          auto *tbuf = new tagint[num];
           MPI_Bcast(tbuf, num, MPI_LMP_TAGINT, 0, world);
           create(buf, std::vector<tagint>(tbuf, tbuf + num));
           delete[] buf;
@@ -186,7 +186,7 @@ void Ndx2Group::command(int narg, char **arg)
           char *buf = new char[len];
           MPI_Bcast(buf, len, MPI_CHAR, 0, world);
           MPI_Bcast(&num, 1, MPI_LMP_BIGINT, 0, world);
-          tagint *tbuf = new tagint[num];
+          auto *tbuf = new tagint[num];
           MPI_Bcast(tbuf, num, MPI_LMP_TAGINT, 0, world);
           create(buf, std::vector<tagint>(tbuf, tbuf + num));
           delete[] buf;

--- a/src/EXTRA-COMMAND/region2vmd.cpp
+++ b/src/EXTRA-COMMAND/region2vmd.cpp
@@ -284,7 +284,7 @@ void Region2VMD::write_region(FILE *fp, Region *region)
 
   const std::string regstyle = region->style;
   if (regstyle == "block") {
-    const auto block = dynamic_cast<RegBlock *>(region);
+    auto *const block = dynamic_cast<RegBlock *>(region);
     if (!block) {
       error->one(FLERR, Error::NOLASTLINE, "Region {} is not of style 'block'", region->id);
     } else {
@@ -311,7 +311,7 @@ void Region2VMD::write_region(FILE *fp, Region *region)
     }
 
   } else if (regstyle == "cone") {
-    const auto cone = dynamic_cast<RegCone *>(region);
+    auto *const cone = dynamic_cast<RegCone *>(region);
     if (!cone) {
       error->one(FLERR, Error::NOLASTLINE, "Region {} is not of style 'cone'", region->id);
     } else {
@@ -676,7 +676,7 @@ void Region2VMD::write_region(FILE *fp, Region *region)
     }
 
   } else if (regstyle == "cylinder") {
-    const auto cyl = dynamic_cast<RegCylinder *>(region);
+    auto *const cyl = dynamic_cast<RegCylinder *>(region);
     if (!cyl) {
       error->one(FLERR, Error::NOLASTLINE, "Region {} is not of style 'cylinder'", region->id);
     } else {
@@ -755,7 +755,7 @@ void Region2VMD::write_region(FILE *fp, Region *region)
     }
 
   } else if (regstyle == "ellipsoid") {
-    const auto ellipsoid = dynamic_cast<RegEllipsoid *>(region);
+    auto *const ellipsoid = dynamic_cast<RegEllipsoid *>(region);
     if (!ellipsoid) {
       error->one(FLERR, Error::NOLASTLINE, "Region {} is not of style 'ellipsoid'", region->id);
     } else {
@@ -766,7 +766,7 @@ void Region2VMD::write_region(FILE *fp, Region *region)
     }
 
   } else if (regstyle == "prism") {
-    const auto prism = dynamic_cast<RegPrism *>(region);
+    auto *const prism = dynamic_cast<RegPrism *>(region);
     if (!prism) {
       error->one(FLERR, Error::NOLASTLINE, "Region {} is not of style 'prism'", region->id);
     } else {
@@ -796,7 +796,7 @@ void Region2VMD::write_region(FILE *fp, Region *region)
     }
 
   } else if (regstyle == "sphere") {
-    const auto sphere = dynamic_cast<RegSphere *>(region);
+    auto *const sphere = dynamic_cast<RegSphere *>(region);
     if (!sphere) {
       error->one(FLERR, Error::NOLASTLINE, "Region {} is not of style 'sphere'", region->id);
     } else {

--- a/src/EXTRA-COMPUTE/compute_adf.cpp
+++ b/src/EXTRA-COMPUTE/compute_adf.cpp
@@ -324,7 +324,7 @@ void ComputeADF::init()
   //   (until next reneighbor), so it needs to contain atoms further
   //   than maxouter apart, just like a normal neighbor list does
 
-  auto req = neighbor->add_request(this, NeighConst::REQ_FULL | NeighConst::REQ_OCCASIONAL);
+  auto *req = neighbor->add_request(this, NeighConst::REQ_FULL | NeighConst::REQ_OCCASIONAL);
   if (mycutneigh > 0.0) {
     if ((neighbor->style == Neighbor::MULTI) || (neighbor->style == Neighbor::MULTI_OLD))
       error->all(FLERR, "Compute adf with custom cutoffs requires neighbor style 'bin' or 'nsq'");

--- a/src/EXTRA-COMPUTE/compute_ave_sphere_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_ave_sphere_atom.cpp
@@ -113,7 +113,7 @@ void ComputeAveSphereAtom::init()
 
   // need an occasional full neighbor list
 
-  auto req = neighbor->add_request(this, NeighConst::REQ_FULL | NeighConst::REQ_OCCASIONAL);
+  auto *req = neighbor->add_request(this, NeighConst::REQ_FULL | NeighConst::REQ_OCCASIONAL);
   if (cutflag) req->set_cutoff(cutoff);
 }
 

--- a/src/EXTRA-COMPUTE/compute_basal_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_basal_atom.cpp
@@ -195,9 +195,9 @@ void ComputeBasalAtom::compute_peratom()
       chi[0] = chi[1] = chi[2] = chi[3] = chi[4] = chi[5] = chi[6] = chi[7] = 0;
       double x_ij, y_ij, z_ij, x_ik, y_ik, z_ik, xmean5, ymean5, zmean5, xmean6, ymean6, zmean6,
           xmean7, ymean7, zmean7;
-      auto x3 = new double[n0];
-      auto y3 = new double[n0];
-      auto z3 = new double[n0];
+      auto *x3 = new double[n0];
+      auto *y3 = new double[n0];
+      auto *z3 = new double[n0];
       for (j = 0; j < n0; j++) {
         x_ij = x[i][0] - x[nearest_n0[j]][0];
         y_ij = x[i][1] - x[nearest_n0[j]][1];

--- a/src/EXTRA-COMPUTE/compute_composition_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_composition_atom.cpp
@@ -107,7 +107,7 @@ void ComputeCompositionAtom::init()
 
   // need an occasional full neighbor list
 
-  auto req = neighbor->add_request(this, NeighConst::REQ_FULL | NeighConst::REQ_OCCASIONAL);
+  auto *req = neighbor->add_request(this, NeighConst::REQ_FULL | NeighConst::REQ_OCCASIONAL);
   if (cutflag) req->set_cutoff(cutoff);
 }
 

--- a/src/EXTRA-COMPUTE/compute_dipole_tip4p.cpp
+++ b/src/EXTRA-COMPUTE/compute_dipole_tip4p.cpp
@@ -69,7 +69,7 @@ void ComputeDipoleTIP4P::init()
   if (!force->pair) error->all(FLERR, "Pair style must be defined for compute dipole/ti4p");
 
   int itmp;
-  double *p_qdist = (double *) force->pair->extract("qdist", itmp);
+  auto *p_qdist = (double *) force->pair->extract("qdist", itmp);
   int *p_typeO = (int *) force->pair->extract("typeO", itmp);
   int *p_typeH = (int *) force->pair->extract("typeH", itmp);
   int *p_typeA = (int *) force->pair->extract("typeA", itmp);
@@ -98,14 +98,14 @@ void ComputeDipoleTIP4P::compute_vector()
 {
   invoked_vector = update->ntimestep;
 
-  const auto x = atom->x;
-  const auto mask = atom->mask;
-  const auto type = atom->type;
-  const auto image = atom->image;
-  const auto mass = atom->mass;
-  const auto rmass = atom->rmass;
-  const auto q = atom->q;
-  const auto mu = atom->mu;
+  auto *const x = atom->x;
+  auto *const mask = atom->mask;
+  auto *const type = atom->type;
+  auto *const image = atom->image;
+  auto *const mass = atom->mass;
+  auto *const rmass = atom->rmass;
+  auto *const q = atom->q;
+  auto *const mu = atom->mu;
   const auto nlocal = atom->nlocal;
 
   double dipole[3] = {0.0, 0.0, 0.0};

--- a/src/EXTRA-COMPUTE/compute_dipole_tip4p_chunk.cpp
+++ b/src/EXTRA-COMPUTE/compute_dipole_tip4p_chunk.cpp
@@ -85,7 +85,7 @@ void ComputeDipoleTIP4PChunk::init()
     error->all(FLERR, "A pair style must be defined for compute dipole/tip4p/chunk");
 
   int itmp;
-  double *p_qdist = (double *) force->pair->extract("qdist", itmp);
+  auto *p_qdist = (double *) force->pair->extract("qdist", itmp);
   int *p_typeO = (int *) force->pair->extract("typeO", itmp);
   int *p_typeH = (int *) force->pair->extract("typeH", itmp);
   int *p_typeA = (int *) force->pair->extract("typeA", itmp);

--- a/src/EXTRA-COMPUTE/compute_efield_wolf_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_efield_wolf_atom.cpp
@@ -97,7 +97,7 @@ void ComputeEfieldWolfAtom::init()
 
   // request an occasional full neighbor list
 
-  auto req = neighbor->add_request(this, NeighConst::REQ_FULL | NeighConst::REQ_OCCASIONAL);
+  auto *req = neighbor->add_request(this, NeighConst::REQ_FULL | NeighConst::REQ_OCCASIONAL);
   if (cutoff_flag) req->set_cutoff(cutoff);
 
   jgroup = group->find(group2);
@@ -134,9 +134,9 @@ void ComputeEfieldWolfAtom::compute_peratom()
   neighbor->build_one(list);
 
   const auto inum = list->inum;
-  const auto ilist = list->ilist;
-  const auto numneigh = list->numneigh;
-  const auto firstneigh = list->firstneigh;
+  auto *const ilist = list->ilist;
+  auto *const numneigh = list->numneigh;
+  auto *const firstneigh = list->firstneigh;
 
   // compute coulomb force according to Wolf sum approximation
   const double * const * const x = atom->x;
@@ -160,7 +160,7 @@ void ComputeEfieldWolfAtom::compute_peratom()
       const double xtmp = x[i][0];
       const double ytmp = x[i][1];
       const double ztmp = x[i][2];
-      const auto jlist = firstneigh[i];
+      auto *const jlist = firstneigh[i];
       const auto jnum = numneigh[i];
 
       for (int jj = 0; jj < jnum; jj++) {

--- a/src/EXTRA-COMPUTE/compute_entropy_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_entropy_atom.cpp
@@ -150,8 +150,8 @@ void ComputeEntropyAtom::compute_peratom()
   int i,j,ii,jj,inum,jnum;
   double xtmp,ytmp,ztmp,delx,dely,delz,rsq;
   int *ilist,*jlist,*numneigh,**firstneigh;
-  auto rbin = new double[nbin];
-  auto rbinsq = new double[nbin];
+  auto *rbin = new double[nbin];
+  auto *rbinsq = new double[nbin];
 
   invoked_peratom = update->ntimestep;
 
@@ -199,8 +199,8 @@ void ComputeEntropyAtom::compute_peratom()
 
   double **x = atom->x;
   int *mask = atom->mask;
-  auto gofr = new double[nbin];
-  auto integrand = new double[nbin];
+  auto *gofr = new double[nbin];
+  auto *integrand = new double[nbin];
 
   for (ii = 0; ii < inum; ii++) {
     i = ilist[ii];

--- a/src/EXTRA-COMPUTE/compute_hma.cpp
+++ b/src/EXTRA-COMPUTE/compute_hma.cpp
@@ -192,7 +192,7 @@ void ComputeHMA::setup()
   if (!ifix)
     error->all(FLERR, Error::NOLASTLINE, "Could not find compute hma temperature fix ID {}",
                id_temp);
-  auto  temperat = (double *) ifix->extract("t_target",dummy);
+  auto *  temperat = (double *) ifix->extract("t_target",dummy);
   if (temperat == nullptr)
     error->all(FLERR, Error::NOLASTLINE, "Fix ID {} is not a thermostat {}", id_temp);
   finaltemp = *temperat;

--- a/src/EXTRA-COMPUTE/compute_rattlers_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_rattlers_atom.cpp
@@ -88,7 +88,7 @@ void ComputeRattlersAtom::init()
   // set size to same value as request made by force->pair
   // this should enable it to always be a copy list (e.g. for granular pstyle)
 
-  auto pairrequest = neighbor->find_request(force->pair);
+  auto *pairrequest = neighbor->find_request(force->pair);
   if (pairrequest && pairrequest->get_size())
     neighbor->add_request(this, NeighConst::REQ_SIZE | NeighConst::REQ_OCCASIONAL);
   else

--- a/src/EXTRA-COMPUTE/compute_stress_cartesian.cpp
+++ b/src/EXTRA-COMPUTE/compute_stress_cartesian.cpp
@@ -136,7 +136,7 @@ ComputeStressCartesian::ComputeStressCartesian(LAMMPS *lmp, int narg, char **arg
 
   // check for variable box dimension
   int box_incompatible = 0;
-  for (auto &ifix : modify->get_fix_list()) {
+  for (const auto &ifix : modify->get_fix_list()) {
     if (((dir1 == 0) && (ifix->box_change & Fix::BOX_CHANGE_X)) ||
         ((dir1 == 1) && (ifix->box_change & Fix::BOX_CHANGE_Y)) ||
         ((dir1 == 2) && (ifix->box_change & Fix::BOX_CHANGE_Z)))

--- a/src/EXTRA-FIX/fix_ave_correlate_long.cpp
+++ b/src/EXTRA-FIX/fix_ave_correlate_long.cpp
@@ -809,7 +809,7 @@ void FixAveCorrelateLong::write_restart(FILE *fp) {
 void FixAveCorrelateLong::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
   int npairin = static_cast<int>(list[n++]);
   int numcorrelatorsin = static_cast<int> (list[n++]);
   int pin = static_cast<int>(list[n++]);

--- a/src/EXTRA-FIX/fix_deform_pressure.cpp
+++ b/src/EXTRA-FIX/fix_deform_pressure.cpp
@@ -905,7 +905,7 @@ void FixDeformPressure::restart(char *buf)
     error->all(FLERR, "Fix deform/pressure settings not consistent with restart");
 
   n += sizeof(Set);
-  SetExtra *set_extra_restart = (SetExtra *) &buf[n];
+  auto *set_extra_restart = (SetExtra *) &buf[n];
   for (int i = 0; i < 7; ++i) {
     set_extra[i].saved = set_extra_restart[i].saved;
     set_extra[i].prior_rate = set_extra_restart[i].prior_rate;
@@ -979,7 +979,7 @@ int FixDeformPressure::modify_param(int narg, char **arg)
 
     // reset id_temp of pressure to new temperature ID
 
-    auto icompute = modify->get_compute_by_id(id_press);
+    auto *icompute = modify->get_compute_by_id(id_press);
     if (!icompute)
       error->all(FLERR, "Pressure compute ID {} for fix {} does not exist", id_press, style);
     icompute->reset_extra_compute_fix(id_temp);

--- a/src/EXTRA-FIX/fix_efield_tip4p.cpp
+++ b/src/EXTRA-FIX/fix_efield_tip4p.cpp
@@ -48,7 +48,7 @@ void FixEfieldTIP4P::init()
   if (pstr) error->all(FLERR, "Fix efield/tip4p does not support the potential keyword");
 
   int itmp;
-  double *p_qdist = (double *) force->pair->extract("qdist", itmp);
+  auto *p_qdist = (double *) force->pair->extract("qdist", itmp);
   int *p_typeO = (int *) force->pair->extract("typeO", itmp);
   int *p_typeH = (int *) force->pair->extract("typeH", itmp);
   int *p_typeA = (int *) force->pair->extract("typeA", itmp);

--- a/src/EXTRA-FIX/fix_filter_corotate.cpp
+++ b/src/EXTRA-FIX/fix_filter_corotate.cpp
@@ -1274,7 +1274,7 @@ void FixFilterCorotate::find_clusters()
 
 void FixFilterCorotate::ring_bonds(int ndatum, char *cbuf, void *ptr)
 {
-  auto ffptr = (FixFilterCorotate *) ptr;
+  auto *ffptr = (FixFilterCorotate *) ptr;
   Atom *atom = ffptr->atom;
   double *rmass = atom->rmass;
   double *mass = atom->mass;
@@ -1283,7 +1283,7 @@ void FixFilterCorotate::ring_bonds(int ndatum, char *cbuf, void *ptr)
   int nlocal = atom->nlocal;
   int nmass = ffptr->nmass;
 
-  auto buf = (tagint *) cbuf;
+  auto *buf = (tagint *) cbuf;
   int m,n;
   double massone;
 
@@ -1312,13 +1312,13 @@ void FixFilterCorotate::ring_bonds(int ndatum, char *cbuf, void *ptr)
 
 void FixFilterCorotate::ring_nshake(int ndatum, char *cbuf, void *ptr)
 {
-  auto ffptr = (FixFilterCorotate *) ptr;
+  auto *ffptr = (FixFilterCorotate *) ptr;
   Atom *atom = ffptr->atom;
   int nlocal = atom->nlocal;
 
   int *nshake = ffptr->nshake;
 
-  auto buf = (tagint *) cbuf;
+  auto *buf = (tagint *) cbuf;
   int m;
 
   for (int i = 0; i < ndatum; i += 3) {
@@ -1334,7 +1334,7 @@ void FixFilterCorotate::ring_nshake(int ndatum, char *cbuf, void *ptr)
 
 void FixFilterCorotate::ring_shake(int ndatum, char *cbuf, void *ptr)
 {
-  auto ffptr = (FixFilterCorotate *) ptr;
+  auto *ffptr = (FixFilterCorotate *) ptr;
   Atom *atom = ffptr->atom;
   int nlocal = atom->nlocal;
 
@@ -1342,7 +1342,7 @@ void FixFilterCorotate::ring_shake(int ndatum, char *cbuf, void *ptr)
   tagint **shake_atom = ffptr->shake_atom;
   int **shake_type = ffptr->shake_type;
 
-  auto buf = (tagint *) cbuf;
+  auto *buf = (tagint *) cbuf;
   int m;
 
   for (int i = 0; i < ndatum; i += 11) {
@@ -1398,9 +1398,9 @@ void FixFilterCorotate::general_cluster(int index, int index_in_list)
 
   int* list_cluster = new int[N]; // contains local IDs of cluster atoms,
                                   // 0 = center
-  auto  m = new double[N];      //contains local mass
-  auto r = new double[N];      //contains r[i] = 1/||del[i]||
-  auto  del = new double*[N];  //contains del[i] = x_i-x_0
+  auto *  m = new double[N];      //contains local mass
+  auto *r = new double[N];      //contains r[i] = 1/||del[i]||
+  auto *  del = new double*[N];  //contains del[i] = x_i-x_0
   for (int i = 0; i<N; i++)
     del[i] = new double[3];
 

--- a/src/EXTRA-FIX/fix_gle.cpp
+++ b/src/EXTRA-FIX/fix_gle.cpp
@@ -55,8 +55,8 @@ namespace GLE {
 //"stabilized" cholesky decomposition. does a LDL^t decomposition, then sets to zero the negative diagonal elements and gets MM^t
 void StabCholesky(int n, const double* MMt, double* M)
 {
-  auto L = new double[n*n];
-  auto D = new double[n];
+  auto *L = new double[n*n];
+  auto *D = new double[n];
 
   int i,j,k;
   for (i=0; i<n; ++i) D[i]=0.0;
@@ -157,9 +157,9 @@ void MyPrint(int n, const double* A)
 //matrix exponential by scaling and squaring.
 void MatrixExp(int n, const double* M, double* EM, int j=8, int k=8)
 {
-  auto tc = new double[j+1];
-  auto SM = new double[n*n];
-  auto TMP = new double[n*n];
+  auto *tc = new double[j+1];
+  auto *SM = new double[n*n];
+  auto *TMP = new double[n*n];
   double onetotwok=pow(0.5,1.0*k);
 
 
@@ -367,8 +367,8 @@ void FixGLE::init_gle()
 {
   // compute Langevin terms
 
-  auto tmp1 = new double[ns1sq];
-  auto tmp2 = new double[ns1sq];
+  auto *tmp1 = new double[ns1sq];
+  auto *tmp2 = new double[ns1sq];
 
   for (int i=0; i<ns1sq; ++i) {
     tmp1[i]=-A[i]*update->dt*0.5*gle_every;
@@ -404,10 +404,10 @@ void FixGLE::init_gles()
 
   int *mask = atom->mask;
   int nlocal = atom->nlocal;
-  auto rootC  = new double[ns1sq];
-  auto rootCT = new double[ns1sq];
-  auto newg   = new double[3*(ns+1)*nlocal];
-  auto news   = new double[3*(ns+1)*nlocal];
+  auto *rootC  = new double[ns1sq];
+  auto *rootCT = new double[ns1sq];
+  auto *newg   = new double[3*(ns+1)*nlocal];
+  auto *news   = new double[3*(ns+1)*nlocal];
 
   GLE::StabCholesky(ns+1, C, rootC);
   GLE::MyTrans(ns+1,rootC,rootCT);

--- a/src/EXTRA-FIX/fix_nonaffine_displacement.cpp
+++ b/src/EXTRA-FIX/fix_nonaffine_displacement.cpp
@@ -217,7 +217,7 @@ void FixNonaffineDisplacement::init()
     if (cut_style == RADIUS) {
       neighbor->add_request(this, NeighConst::REQ_SIZE | NeighConst::REQ_OCCASIONAL);
     } else {
-      auto req = neighbor->add_request(this, NeighConst::REQ_OCCASIONAL);
+      auto *req = neighbor->add_request(this, NeighConst::REQ_OCCASIONAL);
       if (cut_style == CUSTOM) {
         if ((neighbor->style == Neighbor::MULTI) || (neighbor->style == Neighbor::MULTI_OLD))
           error->all(FLERR, "Fix nonaffine/displacement with custom cutoff requires neighbor style 'bin' or 'nsq'");

--- a/src/EXTRA-FIX/fix_npt_cauchy.cpp
+++ b/src/EXTRA-FIX/fix_npt_cauchy.cpp
@@ -640,8 +640,8 @@ void FixNPTCauchy::init()
   // ensure no conflict with fix deform
 
   if (pstat_flag)
-    for (auto &ifix : modify->get_fix_by_style("^deform")) {
-      auto deform = dynamic_cast<FixDeform *>(ifix);
+    for (const auto &ifix : modify->get_fix_by_style("^deform")) {
+      auto *deform = dynamic_cast<FixDeform *>(ifix);
       if (deform) {
         int *dimflag = deform->dimflag;
         if ((p_flag[0] && dimflag[0]) || (p_flag[1] && dimflag[1]) ||
@@ -730,7 +730,7 @@ void FixNPTCauchy::init()
   // detect if any rigid fixes exist so rigid bodies move when box is remapped
 
   rfix.clear();
-  for (auto &ifix : modify->get_fix_list())
+  for (const auto &ifix : modify->get_fix_list())
     if (ifix->rigid_flag) rfix.push_back(ifix);
 }
 
@@ -1328,7 +1328,7 @@ int FixNPTCauchy::pack_restart_data(double *list)
 void FixNPTCauchy::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
   int flag = static_cast<int> (list[n++]);
   if (flag) {
     int m = static_cast<int> (list[n++]);

--- a/src/EXTRA-FIX/fix_smd.cpp
+++ b/src/EXTRA-FIX/fix_smd.cpp
@@ -451,7 +451,7 @@ void FixSMD::write_restart(FILE *fp)
 
 void FixSMD::restart(char *buf)
 {
-  auto list = (double *)buf;
+  auto *list = (double *)buf;
   r_old = list[0];
   xn=list[1];
   yn=list[2];

--- a/src/EXTRA-FIX/fix_spring_rg.cpp
+++ b/src/EXTRA-FIX/fix_spring_rg.cpp
@@ -176,7 +176,7 @@ void FixSpringRG::write_restart(FILE *fp)
 void FixSpringRG::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
 
   rg0 = list[n++];
   rg0_flag = 0;

--- a/src/EXTRA-FIX/fix_temp_csld.cpp
+++ b/src/EXTRA-FIX/fix_temp_csld.cpp
@@ -320,7 +320,7 @@ void FixTempCSLD::write_restart(FILE *fp)
 
 void FixTempCSLD::restart(char *buf)
 {
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
 
   energy = list[0];
   int nprocs = (int) list[1];

--- a/src/EXTRA-FIX/fix_temp_csvr.cpp
+++ b/src/EXTRA-FIX/fix_temp_csvr.cpp
@@ -359,7 +359,7 @@ void FixTempCSVR::write_restart(FILE *fp)
 
 void FixTempCSVR::restart(char *buf)
 {
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
 
   energy = list[0];
   int nprocs = (int) list[1];

--- a/src/EXTRA-FIX/fix_tmd.cpp
+++ b/src/EXTRA-FIX/fix_tmd.cpp
@@ -390,7 +390,7 @@ void FixTMD::readfile(char *file)
   int *mask = atom->mask;
   int nlocal = atom->nlocal;
 
-  auto buffer = new char[CHUNK*MAXLINE];
+  auto *buffer = new char[CHUNK*MAXLINE];
   char *next,*bufptr;
   int i,m,nlines,imageflag,ix,iy,iz;
   tagint itag;

--- a/src/EXTRA-FIX/fix_ttm.cpp
+++ b/src/EXTRA-FIX/fix_ttm.cpp
@@ -591,7 +591,7 @@ void FixTTM::write_restart(FILE *fp)
 void FixTTM::restart(char *buf)
 {
   int n = 0;
-  auto rlist = (double *) buf;
+  auto *rlist = (double *) buf;
 
   // check that restart grid size is same as current grid size
 

--- a/src/EXTRA-FIX/fix_ttm_grid.cpp
+++ b/src/EXTRA-FIX/fix_ttm_grid.cpp
@@ -376,7 +376,7 @@ void FixTTMGrid::write_restart(FILE *fp)
 
 void FixTTMGrid::restart(char *buf)
 {
-  auto rlist = (double *) buf;
+  auto *rlist = (double *) buf;
 
   // check that restart grid size is same as current grid size
 
@@ -436,7 +436,7 @@ void FixTTMGrid::pack_write_grid(int /*which*/, void *vbuf)
 {
   int ix, iy, iz;
 
-  auto buf = (double *) vbuf;
+  auto *buf = (double *) vbuf;
 
   int m = 0;
   for (iz = nzlo_in; iz <= nzhi_in; iz++)
@@ -460,7 +460,7 @@ void FixTTMGrid::unpack_write_grid(int /*which*/, void *vbuf, int *bounds)
   int zlo = bounds[4];
   int zhi = bounds[5];
 
-  auto buf = (double *) vbuf;
+  auto *buf = (double *) vbuf;
   double value;
 
   int m = 0;
@@ -484,7 +484,7 @@ void FixTTMGrid::reset_grid()
 
   int tmp[12];
   double maxdist = 0.5 * neighbor->skin;
-  Grid3d *gridnew = new Grid3d(lmp, world, nxgrid, nygrid, nzgrid);
+  auto *gridnew = new Grid3d(lmp, world, nxgrid, nygrid, nzgrid);
   gridnew->set_distance(maxdist);
   gridnew->set_stencil_grid(1,1);
   gridnew->setup_grid(tmp[0],tmp[1],tmp[2],tmp[3],tmp[4],tmp[5],
@@ -554,7 +554,7 @@ void FixTTMGrid::reset_grid()
 
 void FixTTMGrid::pack_forward_grid(int /*which*/, void *vbuf, int nlist, int *list)
 {
-  auto buf = (double *) vbuf;
+  auto *buf = (double *) vbuf;
   double *src = &T_electron[nzlo_out][nylo_out][nxlo_out];
 
   for (int i = 0; i < nlist; i++) buf[i] = src[list[i]];
@@ -566,7 +566,7 @@ void FixTTMGrid::pack_forward_grid(int /*which*/, void *vbuf, int nlist, int *li
 
 void FixTTMGrid::unpack_forward_grid(int /*which*/, void *vbuf, int nlist, int *list)
 {
-  auto buf = (double *) vbuf;
+  auto *buf = (double *) vbuf;
   double *dest = &T_electron[nzlo_out][nylo_out][nxlo_out];
 
   for (int i = 0; i < nlist; i++) dest[list[i]] = buf[i];
@@ -578,7 +578,7 @@ void FixTTMGrid::unpack_forward_grid(int /*which*/, void *vbuf, int nlist, int *
 
 void FixTTMGrid::pack_reverse_grid(int /*which*/, void *vbuf, int nlist, int *list)
 {
-  auto buf = (double *) vbuf;
+  auto *buf = (double *) vbuf;
   double *src = &net_energy_transfer[nzlo_out][nylo_out][nxlo_out];
 
   for (int i = 0; i < nlist; i++) buf[i] = src[list[i]];
@@ -590,7 +590,7 @@ void FixTTMGrid::pack_reverse_grid(int /*which*/, void *vbuf, int nlist, int *li
 
 void FixTTMGrid::unpack_reverse_grid(int /*which*/, void *vbuf, int nlist, int *list)
 {
-  auto buf = (double *) vbuf;
+  auto *buf = (double *) vbuf;
   double *dest = &net_energy_transfer[nzlo_out][nylo_out][nxlo_out];
 
   for (int i = 0; i < nlist; i++) dest[list[i]] += buf[i];
@@ -602,7 +602,7 @@ void FixTTMGrid::unpack_reverse_grid(int /*which*/, void *vbuf, int nlist, int *
 
 void FixTTMGrid::pack_remap_grid(int /*which*/, void *vbuf, int nlist, int *list)
 {
-  auto buf = (double *) vbuf;
+  auto *buf = (double *) vbuf;
   double *src =
     &T_electron_previous[nzlo_out_previous][nylo_out_previous][nxlo_out_previous];
 
@@ -615,7 +615,7 @@ void FixTTMGrid::pack_remap_grid(int /*which*/, void *vbuf, int nlist, int *list
 
 void FixTTMGrid::unpack_remap_grid(int /*which*/, void *vbuf, int nlist, int *list)
 {
-  auto buf = (double *) vbuf;
+  auto *buf = (double *) vbuf;
   double *dest = &T_electron[nzlo_out][nylo_out][nxlo_out];
 
   for (int i = 0; i < nlist; i++) dest[list[i]] = buf[i];

--- a/src/EXTRA-FIX/fix_ttm_mod.cpp
+++ b/src/EXTRA-FIX/fix_ttm_mod.cpp
@@ -942,7 +942,7 @@ void FixTTMMod::write_restart(FILE *fp)
 void FixTTMMod::restart(char *buf)
 {
   int n = 0;
-  auto rlist = (double *) buf;
+  auto *rlist = (double *) buf;
 
   // check that restart grid size is same as current grid size
 

--- a/src/EXTRA-FIX/fix_wall_region_ees.cpp
+++ b/src/EXTRA-FIX/fix_wall_region_ees.cpp
@@ -124,7 +124,7 @@ void FixWallRegionEES::init()
 void FixWallRegionEES::setup(int vflag)
 {
   if (utils::strmatch(update->integrate_style, "^respa")) {
-    auto respa = dynamic_cast<Respa *>(update->integrate);
+    auto *respa = dynamic_cast<Respa *>(update->integrate);
     respa->copy_flevel_f(nlevels_respa - 1);
     post_force_respa(vflag, nlevels_respa - 1, 0);
     respa->copy_f_flevel(nlevels_respa - 1);

--- a/src/EXTRA-MOLECULE/dihedral_table_cut.cpp
+++ b/src/EXTRA-MOLECULE/dihedral_table_cut.cpp
@@ -523,9 +523,9 @@ void DihedralTableCut::coeff(int narg, char **arg)
   // We also want the angles to be sorted in increasing order.
   // This messy code fixes these problems with the user's data:
   {
-    auto phifile_tmp = new double[tb->ninput];  //temporary arrays
-    auto ffile_tmp = new double[tb->ninput];  //used for sorting
-    auto efile_tmp = new double[tb->ninput];
+    auto *phifile_tmp = new double[tb->ninput];  //temporary arrays
+    auto *ffile_tmp = new double[tb->ninput];  //used for sorting
+    auto *efile_tmp = new double[tb->ninput];
 
     // After re-imaging, does the range of angles cross the 0 or 2*PI boundary?
     // If so, find the discontinuity:

--- a/src/EXTRA-PAIR/pair_lj96_cut.cpp
+++ b/src/EXTRA-PAIR/pair_lj96_cut.cpp
@@ -488,7 +488,7 @@ void PairLJ96Cut::init_style()
   int list_style = NeighConst::REQ_DEFAULT;
 
   if (update->whichflag == 1 && utils::strmatch(update->integrate_style, "^respa")) {
-    auto respa = dynamic_cast<Respa *>(update->integrate);
+    auto *respa = dynamic_cast<Respa *>(update->integrate);
     if (respa->level_inner >= 0) list_style = NeighConst::REQ_RESPA_INOUT;
     if (respa->level_middle >= 0) list_style = NeighConst::REQ_RESPA_ALL;
   }

--- a/src/EXTRA-PAIR/pair_lj_expand_coul_long.cpp
+++ b/src/EXTRA-PAIR/pair_lj_expand_coul_long.cpp
@@ -684,7 +684,7 @@ void PairLJExpandCoulLong::init_style()
   int list_style = NeighConst::REQ_DEFAULT;
 
   if (update->whichflag == 1 && utils::strmatch(update->integrate_style, "^respa")) {
-    auto respa = dynamic_cast<Respa *>(update->integrate);
+    auto *respa = dynamic_cast<Respa *>(update->integrate);
     if (respa->level_inner >= 0) list_style = NeighConst::REQ_RESPA_INOUT;
     if (respa->level_middle >= 0) list_style = NeighConst::REQ_RESPA_ALL;
   }

--- a/src/EXTRA-PAIR/pair_lj_pirani.cpp
+++ b/src/EXTRA-PAIR/pair_lj_pirani.cpp
@@ -678,7 +678,7 @@ void PairLJPirani::init_style()
   int list_style = NeighConst::REQ_DEFAULT;
 
   if (update->whichflag == 1 && utils::strmatch(update->integrate_style, "^respa")) {
-    auto respa = dynamic_cast<Respa *>(update->integrate);
+    auto *respa = dynamic_cast<Respa *>(update->integrate);
     if (respa->level_inner >= 0) list_style = NeighConst::REQ_RESPA_INOUT;
     if (respa->level_middle >= 0) list_style = NeighConst::REQ_RESPA_ALL;
   }

--- a/src/EXTRA-PAIR/pair_mie_cut.cpp
+++ b/src/EXTRA-PAIR/pair_mie_cut.cpp
@@ -499,7 +499,7 @@ void PairMIECut::init_style()
   int list_style = NeighConst::REQ_DEFAULT;
 
   if (update->whichflag == 1 && utils::strmatch(update->integrate_style, "^respa")) {
-    auto respa = dynamic_cast<Respa *>(update->integrate);
+    auto *respa = dynamic_cast<Respa *>(update->integrate);
     if (respa->level_inner >= 0) list_style = NeighConst::REQ_RESPA_INOUT;
     if (respa->level_middle >= 0) list_style = NeighConst::REQ_RESPA_ALL;
   }

--- a/src/FEP/compute_fep.cpp
+++ b/src/FEP/compute_fep.cpp
@@ -220,7 +220,7 @@ void ComputeFEP::init()
 
       if ((strcmp(force->pair_style, "hybrid") == 0 ||
            strcmp(force->pair_style, "hybrid/overlay") == 0)) {
-        auto pair = dynamic_cast<PairHybrid *>(force->pair);
+        auto *pair = dynamic_cast<PairHybrid *>(force->pair);
         for (i = pert->ilo; i <= pert->ihi; i++)
           for (j = MAX(pert->jlo, i); j <= pert->jhi; j++)
             if (!pair->check_ijtype(i, j, pert->pstyle))

--- a/src/FEP/fix_adapt_fep.cpp
+++ b/src/FEP/fix_adapt_fep.cpp
@@ -306,7 +306,7 @@ void FixAdaptFEP::init()
 
       if (ad->pdim == 2 && (strcmp(force->pair_style,"hybrid") == 0 ||
                             strcmp(force->pair_style,"hybrid/overlay") == 0)) {
-        auto pair = dynamic_cast<PairHybrid *>(force->pair);
+        auto *pair = dynamic_cast<PairHybrid *>(force->pair);
         for (i = ad->ilo; i <= ad->ihi; i++)
           for (j = MAX(ad->jlo,i); j <= ad->jhi; j++)
             if (!pair->check_ijtype(i,j,ad->pstyle))

--- a/src/FEP/pair_lj_charmm_coul_long_soft.cpp
+++ b/src/FEP/pair_lj_charmm_coul_long_soft.cpp
@@ -686,7 +686,7 @@ void PairLJCharmmCoulLongSoft::init_style()
   int list_style = NeighConst::REQ_DEFAULT;
 
   if (update->whichflag == 1 && utils::strmatch(update->integrate_style, "^respa")) {
-    auto respa = dynamic_cast<Respa *>(update->integrate);
+    auto *respa = dynamic_cast<Respa *>(update->integrate);
     if (respa->level_inner >= 0) list_style = NeighConst::REQ_RESPA_INOUT;
     if (respa->level_middle >= 0) list_style = NeighConst::REQ_RESPA_ALL;
   }

--- a/src/FEP/pair_lj_cut_coul_long_soft.cpp
+++ b/src/FEP/pair_lj_cut_coul_long_soft.cpp
@@ -629,7 +629,7 @@ void PairLJCutCoulLongSoft::init_style()
   int list_style = NeighConst::REQ_DEFAULT;
 
   if (update->whichflag == 1 && utils::strmatch(update->integrate_style, "^respa")) {
-    auto respa = dynamic_cast<Respa *>(update->integrate);
+    auto *respa = dynamic_cast<Respa *>(update->integrate);
     if (respa->level_inner >= 0) list_style = NeighConst::REQ_RESPA_INOUT;
     if (respa->level_middle >= 0) list_style = NeighConst::REQ_RESPA_ALL;
   }

--- a/src/FEP/pair_lj_cut_soft.cpp
+++ b/src/FEP/pair_lj_cut_soft.cpp
@@ -513,7 +513,7 @@ void PairLJCutSoft::init_style()
   int list_style = NeighConst::REQ_DEFAULT;
 
   if (update->whichflag == 1 && utils::strmatch(update->integrate_style, "^respa")) {
-    auto respa = dynamic_cast<Respa *>(update->integrate);
+    auto *respa = dynamic_cast<Respa *>(update->integrate);
     if (respa->level_inner >= 0) list_style = NeighConst::REQ_RESPA_INOUT;
     if (respa->level_middle >= 0) list_style = NeighConst::REQ_RESPA_ALL;
   }

--- a/src/GPU/fix_gpu.cpp
+++ b/src/GPU/fix_gpu.cpp
@@ -272,7 +272,7 @@ void FixGPU::init()
   // also disallow GPU neighbor lists for hybrid styles
 
   if (force->pair_match("^hybrid",0) != nullptr) {
-    auto hybrid = dynamic_cast<PairHybrid *>(force->pair);
+    auto *hybrid = dynamic_cast<PairHybrid *>(force->pair);
     for (int i = 0; i < hybrid->nstyles; i++)
       if (!utils::strmatch(hybrid->keywords[i],"/gpu$"))
         force->pair->no_virial_fdotr_compute = 1;

--- a/src/GPU/fix_nh_gpu.cpp
+++ b/src/GPU/fix_nh_gpu.cpp
@@ -77,7 +77,7 @@ void FixNHGPU::remap()
   double oldlo,oldhi;
   double expfac;
 
-  dbl3_t * _noalias const x = (dbl3_t *) atom->x[0];
+  auto * _noalias const x = (dbl3_t *) atom->x[0];
   int *mask = atom->mask;
   int nlocal = atom->nlocal;
   double *h = domain->h;
@@ -410,7 +410,7 @@ void FixNHGPU::nh_v_press()
     return;
   }
 
-  dbl3_t * _noalias const v = (dbl3_t *)atom->v[0];
+  auto * _noalias const v = (dbl3_t *)atom->v[0];
   int *mask = atom->mask;
   int nlocal = atom->nlocal;
   if (igroup == atom->firstgroup) nlocal = atom->nfirst;

--- a/src/GPU/pair_amoeba_gpu.cpp
+++ b/src/GPU/pair_amoeba_gpu.cpp
@@ -742,7 +742,7 @@ void PairAmoebaGPU::udirect2b(double **field, double **fieldp)
 
   int nlocal = atom->nlocal;
   if (acc_float) {
-    auto field_ptr = (float *)fieldp_pinned;
+    auto *field_ptr = (float *)fieldp_pinned;
 
     for (int i = 0; i < nlocal; i++) {
       int idx = 3*i;
@@ -759,7 +759,7 @@ void PairAmoebaGPU::udirect2b(double **field, double **fieldp)
       fieldp[i][2] += field_ptr[idx+2];
     }
   } else {
-    auto field_ptr = (double *)fieldp_pinned;
+    auto *field_ptr = (double *)fieldp_pinned;
 
     for (int i = 0; i < nlocal; i++) {
       int idx = 3*i;
@@ -973,7 +973,7 @@ void PairAmoebaGPU::ufield0c(double **field, double **fieldp)
 
   int inum = atom->nlocal;
   if (acc_float) {
-    auto field_ptr = (float *)fieldp_pinned;
+    auto *field_ptr = (float *)fieldp_pinned;
 
     for (int i = 0; i < nlocal; i++) {
       int idx = 3*i;
@@ -990,7 +990,7 @@ void PairAmoebaGPU::ufield0c(double **field, double **fieldp)
       fieldp[i][2] += field_ptr[idx+2];
     }
   } else {
-    auto field_ptr = (double *)fieldp_pinned;
+    auto *field_ptr = (double *)fieldp_pinned;
 
     for (int i = 0; i < nlocal; i++) {
       int idx = 3*i;
@@ -1055,7 +1055,7 @@ void PairAmoebaGPU::umutual1(double **field, double **fieldp)
 
   // gridpre = my portion of 4d grid in brick decomp w/ ghost values
 
-  FFT_SCALAR ****gridpre = (FFT_SCALAR ****) ic_kspace->zero();
+  auto ****gridpre = (FFT_SCALAR ****) ic_kspace->zero();
 
   // map 2 values to grid
 
@@ -1101,7 +1101,7 @@ void PairAmoebaGPU::umutual1(double **field, double **fieldp)
   // post-convolution operations including backward FFT
   // gridppost = my portion of 4d grid in brick decomp w/ ghost values
 
-  FFT_SCALAR ****gridpost = (FFT_SCALAR ****) ic_kspace->post_convolution();
+  auto ****gridpost = (FFT_SCALAR ****) ic_kspace->post_convolution();
 
   // get potential
 
@@ -1171,7 +1171,7 @@ void PairAmoebaGPU::fphi_uind(FFT_SCALAR ****grid, double **fdip_phi1,
 
   int nlocal = atom->nlocal;
   if (acc_float) {
-    auto _fdip_phi1_ptr = (float *)fdip_phi1_pinned;
+    auto *_fdip_phi1_ptr = (float *)fdip_phi1_pinned;
     for (int i = 0; i < nlocal; i++) {
       int n = i;
       for (int m = 0; m < 10; m++) {
@@ -1180,7 +1180,7 @@ void PairAmoebaGPU::fphi_uind(FFT_SCALAR ****grid, double **fdip_phi1,
       }
     }
 
-    auto _fdip_phi2_ptr = (float *)fdip_phi2_pinned;
+    auto *_fdip_phi2_ptr = (float *)fdip_phi2_pinned;
     for (int i = 0; i < nlocal; i++) {
       int n = i;
       for (int m = 0; m < 10; m++) {
@@ -1189,7 +1189,7 @@ void PairAmoebaGPU::fphi_uind(FFT_SCALAR ****grid, double **fdip_phi1,
       }
     }
 
-    auto _fdip_sum_phi_ptr = (float *)fdip_sum_phi_pinned;
+    auto *_fdip_sum_phi_ptr = (float *)fdip_sum_phi_pinned;
     for (int i = 0; i < nlocal; i++) {
       int n = i;
       for (int m = 0; m < 20; m++) {
@@ -1199,7 +1199,7 @@ void PairAmoebaGPU::fphi_uind(FFT_SCALAR ****grid, double **fdip_phi1,
     }
 
   } else {
-    auto _fdip_phi1_ptr = (double *)fdip_phi1_pinned;
+    auto *_fdip_phi1_ptr = (double *)fdip_phi1_pinned;
     for (int i = 0; i < nlocal; i++) {
       int n = i;
       for (int m = 0; m < 10; m++) {
@@ -1208,7 +1208,7 @@ void PairAmoebaGPU::fphi_uind(FFT_SCALAR ****grid, double **fdip_phi1,
       }
     }
 
-    auto _fdip_phi2_ptr = (double *)fdip_phi2_pinned;
+    auto *_fdip_phi2_ptr = (double *)fdip_phi2_pinned;
     for (int i = 0; i < nlocal; i++) {
       int n = i;
       for (int m = 0; m < 10; m++) {
@@ -1217,7 +1217,7 @@ void PairAmoebaGPU::fphi_uind(FFT_SCALAR ****grid, double **fdip_phi1,
       }
     }
 
-    auto _fdip_sum_phi_ptr = (double *)fdip_sum_phi_pinned;
+    auto *_fdip_sum_phi_ptr = (double *)fdip_sum_phi_pinned;
     for (int i = 0; i < nlocal; i++) {
       int n = i;
       for (int m = 0; m < 20; m++) {
@@ -1427,7 +1427,7 @@ void PairAmoebaGPU::polar_kspace()
 
     // gridpre = my portion of 3d grid in brick decomp w/ ghost values
 
-    FFT_SCALAR ***gridpre = (FFT_SCALAR ***) p_kspace->zero();
+    auto ***gridpre = (FFT_SCALAR ***) p_kspace->zero();
 
     // map atoms to grid
 
@@ -1486,7 +1486,7 @@ void PairAmoebaGPU::polar_kspace()
     // post-convolution operations including backward FFT
     // gridppost = my portion of 3d grid in brick decomp w/ ghost values
 
-    FFT_SCALAR ***gridpost = (FFT_SCALAR ***) p_kspace->post_convolution();
+    auto ***gridpost = (FFT_SCALAR ***) p_kspace->post_convolution();
 
     // get potential
 
@@ -1502,7 +1502,7 @@ void PairAmoebaGPU::polar_kspace()
       void* fphi_pinned = nullptr;
       amoeba_gpu_fphi_mpole(gridpost, &fphi_pinned, felec);
       if (acc_float) {
-        auto _fphi_ptr = (float *)fphi_pinned;
+        auto *_fphi_ptr = (float *)fphi_pinned;
         for (int i = 0; i < nlocal; i++) {
           int idx = i;
           for (int m = 0; m < 20; m++) {
@@ -1511,7 +1511,7 @@ void PairAmoebaGPU::polar_kspace()
           }
         }
       } else {
-        auto _fphi_ptr = (double *)fphi_pinned;
+        auto *_fphi_ptr = (double *)fphi_pinned;
         for (int i = 0; i < nlocal; i++) {
           int idx = i;
           for (int m = 0; m < 20; m++) {
@@ -1544,7 +1544,7 @@ void PairAmoebaGPU::polar_kspace()
 
   // gridpre2 = my portion of 4d grid in brick decomp w/ ghost values
 
-  FFT_SCALAR ****gridpre2 = (FFT_SCALAR ****) pc_kspace->zero();
+  auto ****gridpre2 = (FFT_SCALAR ****) pc_kspace->zero();
 
   // map 2 values to grid
 
@@ -1576,7 +1576,7 @@ void PairAmoebaGPU::polar_kspace()
   // post-convolution operations including backward FFT
   // gridppost = my portion of 4d grid in brick decomp w/ ghost values
 
-  FFT_SCALAR ****gridpost = (FFT_SCALAR ****) pc_kspace->post_convolution();
+  auto ****gridpost = (FFT_SCALAR ****) pc_kspace->post_convolution();
 
   // get potential
 
@@ -1824,7 +1824,7 @@ void PairAmoebaGPU::polar_kspace()
   // gridpre = my portion of 3d grid in brick decomp w/ ghost values
   // zeroed by zero()
 
-  FFT_SCALAR ***gridpre = (FFT_SCALAR ***) p_kspace->zero();
+  auto ***gridpre = (FFT_SCALAR ***) p_kspace->zero();
 
   // map atoms to grid
 
@@ -1920,7 +1920,7 @@ void PairAmoebaGPU::polar_kspace()
     // gridpre = my portion of 3d grid in brick decomp w/ ghost values
     // zeroed by zero()
 
-    FFT_SCALAR ***gridpre = (FFT_SCALAR ***) p_kspace->zero();
+    auto ***gridpre = (FFT_SCALAR ***) p_kspace->zero();
 
     // map atoms to grid
 

--- a/src/GPU/pair_eam_alloy_gpu.cpp
+++ b/src/GPU/pair_eam_alloy_gpu.cpp
@@ -237,13 +237,13 @@ int PairEAMAlloyGPU::pack_forward_comm(int n, int *list, double *buf, int /* pbc
   m = 0;
 
   if (fp_single) {
-    auto fp_ptr = (float *) fp_pinned;
+    auto *fp_ptr = (float *) fp_pinned;
     for (i = 0; i < n; i++) {
       j = list[i];
       buf[m++] = static_cast<double>(fp_ptr[j]);
     }
   } else {
-    auto fp_ptr = (double *) fp_pinned;
+    auto *fp_ptr = (double *) fp_pinned;
     for (i = 0; i < n; i++) {
       j = list[i];
       buf[m++] = fp_ptr[j];
@@ -262,10 +262,10 @@ void PairEAMAlloyGPU::unpack_forward_comm(int n, int first, double *buf)
   m = 0;
   last = first + n;
   if (fp_single) {
-    auto fp_ptr = (float *) fp_pinned;
+    auto *fp_ptr = (float *) fp_pinned;
     for (i = first; i < last; i++) fp_ptr[i] = buf[m++];
   } else {
-    auto fp_ptr = (double *) fp_pinned;
+    auto *fp_ptr = (double *) fp_pinned;
     for (i = first; i < last; i++) fp_ptr[i] = buf[m++];
   }
 }

--- a/src/GPU/pair_eam_fs_gpu.cpp
+++ b/src/GPU/pair_eam_fs_gpu.cpp
@@ -237,13 +237,13 @@ int PairEAMFSGPU::pack_forward_comm(int n, int *list, double *buf, int /* pbc_fl
   m = 0;
 
   if (fp_single) {
-    auto fp_ptr = (float *) fp_pinned;
+    auto *fp_ptr = (float *) fp_pinned;
     for (i = 0; i < n; i++) {
       j = list[i];
       buf[m++] = static_cast<double>(fp_ptr[j]);
     }
   } else {
-    auto fp_ptr = (double *) fp_pinned;
+    auto *fp_ptr = (double *) fp_pinned;
     for (i = 0; i < n; i++) {
       j = list[i];
       buf[m++] = fp_ptr[j];
@@ -262,10 +262,10 @@ void PairEAMFSGPU::unpack_forward_comm(int n, int first, double *buf)
   m = 0;
   last = first + n;
   if (fp_single) {
-    auto fp_ptr = (float *) fp_pinned;
+    auto *fp_ptr = (float *) fp_pinned;
     for (i = first; i < last; i++) fp_ptr[i] = buf[m++];
   } else {
-    auto fp_ptr = (double *) fp_pinned;
+    auto *fp_ptr = (double *) fp_pinned;
     for (i = first; i < last; i++) fp_ptr[i] = buf[m++];
   }
 }

--- a/src/GPU/pair_eam_gpu.cpp
+++ b/src/GPU/pair_eam_gpu.cpp
@@ -232,13 +232,13 @@ int PairEAMGPU::pack_forward_comm(int n, int *list, double *buf, int /* pbc_flag
   m = 0;
 
   if (fp_single) {
-    auto fp_ptr = (float *) fp_pinned;
+    auto *fp_ptr = (float *) fp_pinned;
     for (i = 0; i < n; i++) {
       j = list[i];
       buf[m++] = static_cast<double>(fp_ptr[j]);
     }
   } else {
-    auto fp_ptr = (double *) fp_pinned;
+    auto *fp_ptr = (double *) fp_pinned;
     for (i = 0; i < n; i++) {
       j = list[i];
       buf[m++] = fp_ptr[j];
@@ -257,10 +257,10 @@ void PairEAMGPU::unpack_forward_comm(int n, int first, double *buf)
   m = 0;
   last = first + n;
   if (fp_single) {
-    auto fp_ptr = (float *) fp_pinned;
+    auto *fp_ptr = (float *) fp_pinned;
     for (i = first; i < last; i++) fp_ptr[i] = buf[m++];
   } else {
-    auto fp_ptr = (double *) fp_pinned;
+    auto *fp_ptr = (double *) fp_pinned;
     for (i = first; i < last; i++) fp_ptr[i] = buf[m++];
   }
 }

--- a/src/GPU/pair_edpd_gpu.cpp
+++ b/src/GPU/pair_edpd_gpu.cpp
@@ -132,12 +132,12 @@ void PairEDPDGPU::compute(int eflag, int vflag)
 
   int nlocal = atom->nlocal;
   if (acc_float) {
-    auto flux_ptr = (float *)flux_pinned;
+    auto *flux_ptr = (float *)flux_pinned;
     for (int i = 0; i < nlocal; i++)
       Q[i] = flux_ptr[i];
 
   } else {
-    auto flux_ptr = (double *)flux_pinned;
+    auto *flux_ptr = (double *)flux_pinned;
     for (int i = 0; i < nlocal; i++)
       Q[i] = flux_ptr[i];
   }

--- a/src/GPU/pair_hippo_gpu.cpp
+++ b/src/GPU/pair_hippo_gpu.cpp
@@ -856,7 +856,7 @@ void PairHippoGPU::udirect2b(double **field, double **fieldp)
 
   int nlocal = atom->nlocal;
   if (acc_float) {
-    auto field_ptr = (float *)fieldp_pinned;
+    auto *field_ptr = (float *)fieldp_pinned;
 
     for (int i = 0; i < nlocal; i++) {
       int idx = 3*i;
@@ -875,7 +875,7 @@ void PairHippoGPU::udirect2b(double **field, double **fieldp)
 
   } else {
 
-    auto field_ptr = (double *)fieldp_pinned;
+    auto *field_ptr = (double *)fieldp_pinned;
     for (int i = 0; i < nlocal; i++) {
       int idx = 3*i;
       field[i][0] += field_ptr[idx];
@@ -1167,7 +1167,7 @@ void PairHippoGPU::umutual1(double **field, double **fieldp)
 
   // gridpre = my portion of 4d grid in brick decomp w/ ghost values
 
-  FFT_SCALAR ****gridpre = (FFT_SCALAR ****) ic_kspace->zero();
+  auto ****gridpre = (FFT_SCALAR ****) ic_kspace->zero();
 
   // map 2 values to grid
 
@@ -1213,7 +1213,7 @@ void PairHippoGPU::umutual1(double **field, double **fieldp)
   // post-convolution operations including backward FFT
   // gridppost = my portion of 4d grid in brick decomp w/ ghost values
 
-  FFT_SCALAR ****gridpost = (FFT_SCALAR ****) ic_kspace->post_convolution();
+  auto ****gridpost = (FFT_SCALAR ****) ic_kspace->post_convolution();
 
   // get potential
 
@@ -1290,7 +1290,7 @@ void PairHippoGPU::fphi_uind(FFT_SCALAR ****grid, double **fdip_phi1,
 
   int nlocal = atom->nlocal;
   if (acc_float) {
-    auto _fdip_phi1_ptr = (float *)fdip_phi1_pinned;
+    auto *_fdip_phi1_ptr = (float *)fdip_phi1_pinned;
     for (int i = 0; i < nlocal; i++) {
       int n = i;
       for (int m = 0; m < 10; m++) {
@@ -1299,7 +1299,7 @@ void PairHippoGPU::fphi_uind(FFT_SCALAR ****grid, double **fdip_phi1,
       }
     }
 
-    auto _fdip_phi2_ptr = (float *)fdip_phi2_pinned;
+    auto *_fdip_phi2_ptr = (float *)fdip_phi2_pinned;
     for (int i = 0; i < nlocal; i++) {
       int n = i;
       for (int m = 0; m < 10; m++) {
@@ -1308,7 +1308,7 @@ void PairHippoGPU::fphi_uind(FFT_SCALAR ****grid, double **fdip_phi1,
       }
     }
 
-    auto _fdip_sum_phi_ptr = (float *)fdip_sum_phi_pinned;
+    auto *_fdip_sum_phi_ptr = (float *)fdip_sum_phi_pinned;
     for (int i = 0; i < nlocal; i++) {
       int n = i;
       for (int m = 0; m < 20; m++) {
@@ -1319,7 +1319,7 @@ void PairHippoGPU::fphi_uind(FFT_SCALAR ****grid, double **fdip_phi1,
 
   } else {
 
-    auto _fdip_phi1_ptr = (double *)fdip_phi1_pinned;
+    auto *_fdip_phi1_ptr = (double *)fdip_phi1_pinned;
     for (int i = 0; i < nlocal; i++) {
       int n = i;
       for (int m = 0; m < 10; m++) {
@@ -1328,7 +1328,7 @@ void PairHippoGPU::fphi_uind(FFT_SCALAR ****grid, double **fdip_phi1,
       }
     }
 
-    auto _fdip_phi2_ptr = (double *)fdip_phi2_pinned;
+    auto *_fdip_phi2_ptr = (double *)fdip_phi2_pinned;
     for (int i = 0; i < nlocal; i++) {
       int n = i;
       for (int m = 0; m < 10; m++) {
@@ -1337,7 +1337,7 @@ void PairHippoGPU::fphi_uind(FFT_SCALAR ****grid, double **fdip_phi1,
       }
     }
 
-    auto _fdip_sum_phi_ptr = (double *)fdip_sum_phi_pinned;
+    auto *_fdip_sum_phi_ptr = (double *)fdip_sum_phi_pinned;
     for (int i = 0; i < nlocal; i++) {
       int n = i;
       for (int m = 0; m < 20; m++) {

--- a/src/GPU/pair_lj_cut_tip4p_long_gpu.cpp
+++ b/src/GPU/pair_lj_cut_tip4p_long_gpu.cpp
@@ -198,7 +198,7 @@ void PairLJCutTIP4PLongGPU::init_style()
       atom->get_map_size(), atom->get_max_same());
   GPU_EXTRA::check_flag(success, error, world);
   if (gpu_mode == GPU_FORCE) {
-    auto req = neighbor->add_request(this, NeighConst::REQ_FULL);
+    auto *req = neighbor->add_request(this, NeighConst::REQ_FULL);
     req->set_cutoff(cut_coulplus + neighbor->skin);
   }
 }

--- a/src/GPU/pair_sph_heatconduction_gpu.cpp
+++ b/src/GPU/pair_sph_heatconduction_gpu.cpp
@@ -133,13 +133,13 @@ void PairSPHHeatConductionGPU::compute(int eflag, int vflag)
 
   int nlocal = atom->nlocal;
   if (acc_float) {
-    auto dE_ptr = (float *)dE_pinned;
+    auto *dE_ptr = (float *)dE_pinned;
     for (int i = 0; i < nlocal; i++) {
       desph[i] = dE_ptr[i];
     }
 
   } else {
-    auto dE_ptr = (double *)dE_pinned;
+    auto *dE_ptr = (double *)dE_pinned;
     for (int i = 0; i < nlocal; i++) {
       desph[i] = dE_ptr[i];
     }

--- a/src/GPU/pair_sph_lj_gpu.cpp
+++ b/src/GPU/pair_sph_lj_gpu.cpp
@@ -135,7 +135,7 @@ void PairSPHLJGPU::compute(int eflag, int vflag)
 
   int nlocal = atom->nlocal;
   if (acc_float) {
-    auto drhoE_ptr = (float *)drhoE_pinned;
+    auto *drhoE_ptr = (float *)drhoE_pinned;
     for (int i = 0; i < nlocal; i++)
       drho[i] += drhoE_ptr[i];
 
@@ -144,7 +144,7 @@ void PairSPHLJGPU::compute(int eflag, int vflag)
       desph[i] += drhoE_ptr[i];
 
   } else {
-    auto drhoE_ptr = (double *)drhoE_pinned;
+    auto *drhoE_ptr = (double *)drhoE_pinned;
     for (int i = 0; i < nlocal; i++)
       drho[i] += drhoE_ptr[i];
 

--- a/src/GPU/pair_sph_taitwater_gpu.cpp
+++ b/src/GPU/pair_sph_taitwater_gpu.cpp
@@ -150,7 +150,7 @@ void PairSPHTaitwaterGPU::compute(int eflag, int vflag)
 
   int nlocal = atom->nlocal;
   if (acc_float) {
-    auto drhoE_ptr = (float *)drhoE_pinned;
+    auto *drhoE_ptr = (float *)drhoE_pinned;
     for (int i = 0; i < nlocal; i++)
       drho[i] += drhoE_ptr[i];
 
@@ -159,7 +159,7 @@ void PairSPHTaitwaterGPU::compute(int eflag, int vflag)
       desph[i] += drhoE_ptr[i];
 
   } else {
-    auto drhoE_ptr = (double *)drhoE_pinned;
+    auto *drhoE_ptr = (double *)drhoE_pinned;
     for (int i = 0; i < nlocal; i++)
       drho[i] += drhoE_ptr[i];
 

--- a/src/GPU/pppm_gpu.cpp
+++ b/src/GPU/pppm_gpu.cpp
@@ -500,7 +500,7 @@ void PPPMGPU::poisson_ik()
 
 void PPPMGPU::pack_forward_grid(int flag, void *vbuf, int nlist, int *list)
 {
-  auto buf = (FFT_SCALAR *) vbuf;
+  auto *buf = (FFT_SCALAR *) vbuf;
 
   int n = 0;
 
@@ -560,7 +560,7 @@ void PPPMGPU::pack_forward_grid(int flag, void *vbuf, int nlist, int *list)
 
 void PPPMGPU::unpack_forward_grid(int flag, void *vbuf, int nlist, int *list)
 {
-  auto buf = (FFT_SCALAR *) vbuf;
+  auto *buf = (FFT_SCALAR *) vbuf;
 
   int n = 0;
 
@@ -620,7 +620,7 @@ void PPPMGPU::unpack_forward_grid(int flag, void *vbuf, int nlist, int *list)
 
 void PPPMGPU::pack_reverse_grid(int flag, void *vbuf, int nlist, int *list)
 {
-  auto buf = (FFT_SCALAR *) vbuf;
+  auto *buf = (FFT_SCALAR *) vbuf;
 
   if (flag == REVERSE_RHO_GPU) {
     FFT_SCALAR *src = &density_brick_gpu[nzlo_out][nylo_out][nxlo_out];
@@ -639,7 +639,7 @@ void PPPMGPU::pack_reverse_grid(int flag, void *vbuf, int nlist, int *list)
 
 void PPPMGPU::unpack_reverse_grid(int flag, void *vbuf, int nlist, int *list)
 {
-  auto buf = (FFT_SCALAR *) vbuf;
+  auto *buf = (FFT_SCALAR *) vbuf;
 
   if (flag == REVERSE_RHO_GPU) {
     FFT_SCALAR *dest = &density_brick_gpu[nzlo_out][nylo_out][nxlo_out];
@@ -665,9 +665,9 @@ FFT_SCALAR ***PPPMGPU::create_3d_offset(int n1lo, int n1hi, int n2lo, int n2hi,
   int n2 = n2hi - n2lo + 1;
   int n3 = n3hi - n3lo + 1;
 
-  auto plane = (FFT_SCALAR **)
+  auto *plane = (FFT_SCALAR **)
     memory->smalloc(n1*n2*sizeof(FFT_SCALAR *),name);
-  auto array = (FFT_SCALAR ***)
+  auto *array = (FFT_SCALAR ***)
     memory->smalloc(n1*sizeof(FFT_SCALAR **),name);
 
   int n = 0;

--- a/src/GRANULAR/compute_fabric.cpp
+++ b/src/GRANULAR/compute_fabric.cpp
@@ -156,7 +156,7 @@ void ComputeFabric::init()
   // set size to same value as request made by force->pair
   // this should enable it to always be a copy list (e.g. for granular pstyle)
 
-  auto pairrequest = neighbor->find_request(force->pair);
+  auto *pairrequest = neighbor->find_request(force->pair);
   if (pairrequest && pairrequest->get_size())
     neighbor->add_request(this, NeighConst::REQ_SIZE | NeighConst::REQ_OCCASIONAL);
   else

--- a/src/GRANULAR/fix_damping_cundall.cpp
+++ b/src/GRANULAR/fix_damping_cundall.cpp
@@ -120,7 +120,7 @@ void FixDampingCundall::init()
   }
 
   bool fflag = false;
-  for (auto &ifix : modify->get_fix_list()) {
+  for (const auto &ifix : modify->get_fix_list()) {
     if (fflag && (comm->me == 0) && (ifix->setmask() & POST_FORCE))
       error->warning(FLERR, "Fix {} alters forces after fix damping/cundall", ifix->id);
     if (ifix == this) fflag = true;

--- a/src/GRANULAR/fix_granular_mdr.cpp
+++ b/src/GRANULAR/fix_granular_mdr.cpp
@@ -678,7 +678,7 @@ void FixGranularMDR::update_fix_gran_wall()
   double *ddelta_bar = atom->dvector[index_ddelta_bar];
 
   for (auto &ifix : fix_wall_list) {
-    FixWallGranRegion *fix = dynamic_cast<FixWallGranRegion *>(ifix);
+    auto *fix = dynamic_cast<FixWallGranRegion *>(ifix);
     if (fix) {
       GranularModel *model = fix->model;
       const int size_history = model->size_history;

--- a/src/GRANULAR/fix_pour.cpp
+++ b/src/GRANULAR/fix_pour.cpp
@@ -91,7 +91,7 @@ FixPour::FixPour(LAMMPS *lmp, int narg, char **arg) :
   if (region->dynamic_check()) error->all(FLERR, "Fix pour region {} cannot be dynamic", idregion);
 
   if (strcmp(region->style, "block") == 0) {
-    auto block = dynamic_cast<RegBlock *>(region);
+    auto *block = dynamic_cast<RegBlock *>(region);
     region_style = 1;
     xlo = block->xlo;
     xhi = block->xhi;
@@ -103,7 +103,7 @@ FixPour::FixPour(LAMMPS *lmp, int narg, char **arg) :
         yhi > domain->boxhi[1] || zlo < domain->boxlo[2] || zhi > domain->boxhi[2])
       error->all(FLERR, "Insertion region extends outside simulation box");
   } else if (strcmp(region->style, "cylinder") == 0) {
-    auto cylinder = dynamic_cast<RegCylinder *>(region);
+    auto *cylinder = dynamic_cast<RegCylinder *>(region);
     region_style = 2;
     char axis = cylinder->axis;
     xc = cylinder->c1;
@@ -213,7 +213,7 @@ void FixPour::init()
   auto fixlist = modify->get_fix_by_style("^gravity");
   if (fixlist.size() != 1)
     error->all(FLERR, "There must be exactly one fix gravity defined for fix pour");
-  auto fixgrav = dynamic_cast<FixGravity *>(fixlist.front());
+  auto *fixgrav = dynamic_cast<FixGravity *>(fixlist.front());
   if (fixgrav->varflag != FixGravity::CONSTANT)
     error->all(FLERR, "Fix gravity for fix pour must be constant");
 

--- a/src/GRANULAR/pair_gran_hertz_history.cpp
+++ b/src/GRANULAR/pair_gran_hertz_history.cpp
@@ -68,7 +68,7 @@ void PairGranHertzHistory::compute(int eflag, int vflag)
   if (fix_rigid && neighbor->ago == 0) {
     int tmp;
     int *body = (int *) fix_rigid->extract("body",tmp);
-    auto mass_body = (double *) fix_rigid->extract("masstotal",tmp);
+    auto *mass_body = (double *) fix_rigid->extract("masstotal",tmp);
     if (atom->nmax > nmax) {
       memory->destroy(mass_rigid);
       nmax = atom->nmax;

--- a/src/GRANULAR/pair_gran_hooke.cpp
+++ b/src/GRANULAR/pair_gran_hooke.cpp
@@ -61,7 +61,7 @@ void PairGranHooke::compute(int eflag, int vflag)
   if (fix_rigid && neighbor->ago == 0) {
     int tmp;
     int *body = (int *) fix_rigid->extract("body",tmp);
-    auto mass_body = (double *) fix_rigid->extract("masstotal",tmp);
+    auto *mass_body = (double *) fix_rigid->extract("masstotal",tmp);
     if (atom->nmax > nmax) {
       memory->destroy(mass_rigid);
       nmax = atom->nmax;

--- a/src/GRANULAR/pair_gran_hooke_history.cpp
+++ b/src/GRANULAR/pair_gran_hooke_history.cpp
@@ -125,7 +125,7 @@ void PairGranHookeHistory::compute(int eflag, int vflag)
   if (fix_rigid && neighbor->ago == 0) {
     int tmp;
     int *body = (int *) fix_rigid->extract("body", tmp);
-    auto mass_body = (double *) fix_rigid->extract("masstotal", tmp);
+    auto *mass_body = (double *) fix_rigid->extract("masstotal", tmp);
     if (atom->nmax > nmax) {
       memory->destroy(mass_rigid);
       nmax = atom->nmax;

--- a/src/GRANULAR/pair_granular.cpp
+++ b/src/GRANULAR/pair_granular.cpp
@@ -135,7 +135,7 @@ void PairGranular::compute(int eflag, int vflag)
   if (fix_rigid && neighbor->ago == 0) {
     int tmp;
     int *body = (int *) fix_rigid->extract("body",tmp);
-    auto mass_body = (double *) fix_rigid->extract("masstotal",tmp);
+    auto *mass_body = (double *) fix_rigid->extract("masstotal",tmp);
     if (atom->nmax > nmax) {
       memory->destroy(mass_rigid);
       nmax = atom->nmax;

--- a/src/KIM/fix_store_kim.cpp
+++ b/src/KIM/fix_store_kim.cpp
@@ -82,25 +82,25 @@ FixStoreKIM::~FixStoreKIM()
   // free associated storage
 
   if (simulator_model) {
-    auto sm = (KIM_SimulatorModel *) simulator_model;
+    auto *sm = (KIM_SimulatorModel *) simulator_model;
     KIM_SimulatorModel_Destroy(&sm);
     simulator_model = nullptr;
   }
 
   if (model_name) {
-    auto mn = (char *) model_name;
+    auto *mn = (char *) model_name;
     delete[] mn;
     model_name = nullptr;
   }
 
   if (model_units) {
-    auto mu = (char *) model_units;
+    auto *mu = (char *) model_units;
     delete[] mu;
     model_units = nullptr;
   }
 
   if (user_units) {
-    auto uu = (char *) user_units;
+    auto *uu = (char *) user_units;
     delete[] uu;
     user_units = nullptr;
   }
@@ -120,25 +120,25 @@ void FixStoreKIM::setptr(const std::string &name, void *ptr)
 {
   if (name == "simulator_model") {
     if (simulator_model) {
-      auto sm = (KIM_SimulatorModel *) simulator_model;
+      auto *sm = (KIM_SimulatorModel *) simulator_model;
       KIM_SimulatorModel_Destroy(&sm);
     }
     simulator_model = ptr;
   } else if (name == "model_name") {
     if (model_name) {
-      auto mn = (char *) model_name;
+      auto *mn = (char *) model_name;
       delete[] mn;
     }
     model_name = ptr;
   } else if (name == "model_units") {
     if (model_units) {
-      auto mu = (char *) model_units;
+      auto *mu = (char *) model_units;
       delete[] mu;
     }
     model_units = ptr;
   } else if (name == "user_units") {
     if (user_units) {
-      auto uu = (char *) user_units;
+      auto *uu = (char *) user_units;
       delete[] uu;
     }
     user_units = ptr;

--- a/src/KIM/kim_command.cpp
+++ b/src/KIM/kim_command.cpp
@@ -111,24 +111,24 @@ void KimCommand::command(int narg, char **arg)
   if (lmp->citeme) lmp->citeme->add(cite_openkim);
 
   if (subcmd == "init") {
-    auto cmd = new KimInit(lmp);
+    auto *cmd = new KimInit(lmp);
     cmd->command(narg, arg);
     delete cmd;
   } else if (subcmd == "interactions") {
-    auto cmd = new KimInteractions(lmp);
+    auto *cmd = new KimInteractions(lmp);
     cmd->command(narg, arg);
     delete cmd;
   } else if (subcmd == "param") {
-    auto cmd = new KimParam(lmp);
+    auto *cmd = new KimParam(lmp);
     cmd->command(narg, arg);
     delete cmd;
   } else if (subcmd == "property") {
-    auto cmd = new KimProperty(lmp);
+    auto *cmd = new KimProperty(lmp);
     cmd->command(narg, arg);
     delete cmd;
   } else if (subcmd == "query") {
     if (lmp->citeme) lmp->citeme->add(cite_openkim_query);
-    auto cmd = new KimQuery(lmp);
+    auto *cmd = new KimQuery(lmp);
     cmd->command(narg, arg);
     delete cmd;
   } else

--- a/src/KIM/kim_init.cpp
+++ b/src/KIM/kim_init.cpp
@@ -206,7 +206,7 @@ void KimInit::determine_model_type_and_units(char *model_name, char *user_units,
     } else if (unit_conversion_mode) {
       KIM_Model_Destroy(&pkim);
       const char *unit_systems[] = {"metal", "real", "si", "cgs", "electron"};
-      for (auto units : unit_systems) {
+      for (const auto *units : unit_systems) {
         get_kim_unit_names(units, lengthUnit, energyUnit, chargeUnit, temperatureUnit, timeUnit,
                            error);
         kim_error = KIM_Model_Create(KIM_NUMBERING_zeroBased, lengthUnit, energyUnit, chargeUnit,
@@ -267,7 +267,7 @@ void KimInit::do_init(char *model_name, char *user_units, char *model_units, KIM
   // create storage proxy fix. delete existing fix, if needed.
 
   if (modify->get_fix_by_id("KIM_MODEL_STORE")) modify->delete_fix("KIM_MODEL_STORE");
-  auto fix_store = dynamic_cast<FixStoreKIM *>(modify->add_fix("KIM_MODEL_STORE all STORE/KIM"));
+  auto *fix_store = dynamic_cast<FixStoreKIM *>(modify->add_fix("KIM_MODEL_STORE all STORE/KIM"));
   fix_store->setptr("model_name", (void *) model_name);
   fix_store->setptr("user_units", (void *) user_units);
   fix_store->setptr("model_units", (void *) model_units);
@@ -411,7 +411,7 @@ void KimInit::do_variables(const std::string &from, const std::string &to)
 
   input->write_echo(fmt::format("# Conversion factors from {} to {}:\n", from, to));
 
-  auto variable = input->variable;
+  auto *variable = input->variable;
   for (int i = 0; units[i] != nullptr; ++i) {
     var_str = std::string("_u_") + units[i];
     v_unit = variable->find(var_str.c_str());

--- a/src/KIM/kim_interactions.cpp
+++ b/src/KIM/kim_interactions.cpp
@@ -118,7 +118,7 @@ void KimInteractions::do_setup(int narg, char **arg)
   // retrieve model name and pointer to simulator model class instance.
   // validate model name if not given as null pointer.
 
-  auto fix_store = dynamic_cast<FixStoreKIM *>(modify->get_fix_by_id("KIM_MODEL_STORE"));
+  auto *fix_store = dynamic_cast<FixStoreKIM *>(modify->get_fix_by_id("KIM_MODEL_STORE"));
   if (fix_store) {
     model_name = (char *)fix_store->getptr("model_name");
     simulatorModel = (KIM_SimulatorModel *)fix_store->getptr("simulator_model");

--- a/src/KIM/kim_param.cpp
+++ b/src/KIM/kim_param.cpp
@@ -108,7 +108,7 @@ void KimParam::command(int narg, char **arg)
     error->all(FLERR, "Incorrect arguments in 'kim param' command.\n"
                "'kim param get/set' is mandatory");
 
-  auto fix_store = dynamic_cast<FixStoreKIM *>(modify->get_fix_by_id("KIM_MODEL_STORE"));
+  auto *fix_store = dynamic_cast<FixStoreKIM *>(modify->get_fix_by_id("KIM_MODEL_STORE"));
   if (fix_store) {
     auto *simulatorModel = reinterpret_cast<KIM_SimulatorModel *>(
       fix_store->getptr("simulator_model"));
@@ -127,7 +127,7 @@ void KimParam::command(int narg, char **arg)
   if (force->pair) {
     Pair *pair = force->pair_match("kim", 1, 0);
     if (pair) {
-      auto pairKIM = reinterpret_cast<PairKIM *>(pair);
+      auto *pairKIM = reinterpret_cast<PairKIM *>(pair);
 
       pkim = pairKIM->get_kim_model();
       if (!pkim) error->all(FLERR, "Unable to get the KIM Portable Model");

--- a/src/KIM/kim_query.cpp
+++ b/src/KIM/kim_query.cpp
@@ -154,7 +154,7 @@ void KimQuery::command(int narg, char **arg)
     // if the model name is not provided by the user
     if (model_name.empty()) {
       // check if we had a kim init command by finding fix STORE/KIM
-      auto fix_store = dynamic_cast<FixStoreKIM *>(modify->get_fix_by_id("KIM_MODEL_STORE"));
+      auto *fix_store = dynamic_cast<FixStoreKIM *>(modify->get_fix_by_id("KIM_MODEL_STORE"));
       if (fix_store) {
         char *model_name_c = (char *) fix_store->getptr("model_name");
         model_name = model_name_c;
@@ -270,7 +270,7 @@ namespace {
 // copy data to the user provided data structure, optionally in increments
 size_t write_callback(void *data, size_t size, size_t nmemb, void *userp)
 {
-  auto buf = (WriteBuf *) userp;
+  auto *buf = (WriteBuf *) userp;
 
   // copy chunks into the buffer for as long as there is space left
   if (buf->sizeleft) {

--- a/src/KIM/kim_units.cpp
+++ b/src/KIM/kim_units.cpp
@@ -1404,7 +1404,7 @@ int kim_units::lammps_unit_conversion(const string &unit_type_str, const string 
   // convert input to enumeration
   unit_type unit_type_enum;
   {
-    map<string, unit_type>::const_iterator itr = unit_dic.find(unit_type_str);
+    auto itr = unit_dic.find(unit_type_str);
     if (itr != unit_dic.end())
       unit_type_enum = itr->second;
     else
@@ -1412,7 +1412,7 @@ int kim_units::lammps_unit_conversion(const string &unit_type_str, const string 
   }
   sys_type from_system_enum;
   {
-    map<string, sys_type>::const_iterator itr = system_dic.find(from_system_str);
+    auto itr = system_dic.find(from_system_str);
     if (itr != system_dic.end())
       from_system_enum = itr->second;
     else
@@ -1420,7 +1420,7 @@ int kim_units::lammps_unit_conversion(const string &unit_type_str, const string 
   }
   sys_type to_system_enum;
   {
-    map<string, sys_type>::const_iterator itr = system_dic.find(to_system_str);
+    auto itr = system_dic.find(to_system_str);
     if (itr != system_dic.end())
       to_system_enum = itr->second;
     else

--- a/src/KIM/pair_kim.cpp
+++ b/src/KIM/pair_kim.cpp
@@ -589,7 +589,7 @@ void PairKIM::init_style()
     int neighflags = NeighConst::REQ_FULL | NeighConst::REQ_NEWTON_OFF;
     if (!modelWillNotRequestNeighborsOfNoncontributingParticles[i])
       neighflags |= NeighConst::REQ_GHOST;
-    auto req = neighbor->add_request(this, neighflags);
+    auto *req = neighbor->add_request(this, neighflags);
     req->set_id(i);
 
     // set cutoff
@@ -774,7 +774,7 @@ int PairKIM::get_neigh(void const * const dataObject,
                        int * const numberOfNeighbors,
                        int const ** const neighborsOfParticle)
 {
-  auto  const Model = reinterpret_cast<PairKIM const *>(dataObject);
+  const auto *const   Model = reinterpret_cast<PairKIM const *>(dataObject);
 
   if (numberOfNeighborLists != Model->kim_number_of_neighbor_lists)
     return true;

--- a/src/KSPACE/ewald.cpp
+++ b/src/KSPACE/ewald.cpp
@@ -126,7 +126,7 @@ void Ewald::init()
   pair_check();
 
   int itmp;
-  auto p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
+  auto *p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
   if (p_cutoff == nullptr)
     error->all(FLERR,"KSpace style is incompatible with Pair style");
   double cutoff = *p_cutoff;

--- a/src/KSPACE/ewald_dipole.cpp
+++ b/src/KSPACE/ewald_dipole.cpp
@@ -112,7 +112,7 @@ void EwaldDipole::init()
   pair_check();
 
   int itmp;
-  auto p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
+  auto *p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
   if (p_cutoff == nullptr)
     error->all(FLERR,"KSpace style is incompatible with Pair style");
   double cutoff = *p_cutoff;

--- a/src/KSPACE/ewald_dipole_spin.cpp
+++ b/src/KSPACE/ewald_dipole_spin.cpp
@@ -96,7 +96,7 @@ void EwaldDipoleSpin::init()
   pair_check();
 
   int itmp;
-  auto p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
+  auto *p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
   if (p_cutoff == nullptr)
     error->all(FLERR,"KSpace style is incompatible with Pair style");
   double cutoff = *p_cutoff;

--- a/src/KSPACE/ewald_disp.cpp
+++ b/src/KSPACE/ewald_disp.cpp
@@ -547,7 +547,7 @@ void EwaldDisp::init_coeffs()
   int n = atom->ntypes;
 
   if (function[1]) {                                        // geometric 1/r^6
-    auto b = (double **) force->pair->extract("B",tmp);
+    auto *b = (double **) force->pair->extract("B",tmp);
     delete [] B;
     B = new double[n+1];
     B[0] = 0.0;
@@ -555,8 +555,8 @@ void EwaldDisp::init_coeffs()
     for (int i=1; i<=n; ++i) B[i] = sqrt(fabs(b[i][i]));
   }
   if (function[2]) {                                        // arithmetic 1/r^6
-    auto epsilon = (double **) force->pair->extract("epsilon",tmp);
-    auto sigma = (double **) force->pair->extract("sigma",tmp);
+    auto *epsilon = (double **) force->pair->extract("epsilon",tmp);
+    auto *sigma = (double **) force->pair->extract("sigma",tmp);
     delete [] B;
     double eps_i, sigma_i, sigma_n, *bi = B = new double[7*n+7];
     double c[7] = {
@@ -776,7 +776,7 @@ void EwaldDisp::compute_ek()
   int lbytes = (2*nbox+1)*sizeof(cvector);
   hvector *h = nullptr;
   kvector *k, *nk = kvec+nkvec;
-  auto z = new cvector[2*nbox+1];
+  auto *z = new cvector[2*nbox+1];
   cvector z1, *zx, *zy, *zz, *zn = z+2*nbox;
   complex *cek, zxyz, zxy = COMPLEX_NULL, cx = COMPLEX_NULL;
   double mui[3];

--- a/src/KSPACE/fix_tune_kspace.cpp
+++ b/src/KSPACE/fix_tune_kspace.cpp
@@ -102,7 +102,7 @@ void FixTuneKspace::init()
   acc_str = std::to_string(old_acc);
 
   int itmp;
-  auto p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
+  auto *p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
   pair_cut_coul = *p_cutoff;
 }
 
@@ -118,7 +118,7 @@ void FixTuneKspace::pre_exchange()
   if (next_reneighbor != update->ntimestep) return;
   next_reneighbor = update->ntimestep + nevery;
 
-  auto info = new Info(lmp);
+  auto *info = new Info(lmp);
   bool has_msm = info->has_style("pair", base_pair_style + "/msm");
   delete info;
 
@@ -228,7 +228,7 @@ void FixTuneKspace::update_pair_style(const std::string &new_pair_style,
                                       double pair_cut_coul)
 {
   int itmp;
-  auto p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
+  auto *p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
   *p_cutoff = pair_cut_coul;
 
   // check to see if we need to change pair styles
@@ -248,7 +248,7 @@ void FixTuneKspace::update_pair_style(const std::string &new_pair_style,
   // restore current pair settings from temporary file
   force->pair->read_restart(p_pair_settings_file);
 
-  auto pcutoff = (double *) force->pair->extract("cut_coul",itmp);
+  auto *pcutoff = (double *) force->pair->extract("cut_coul",itmp);
   double current_cutoff = *pcutoff;
   if (comm->me == 0)
     utils::logmesg(lmp,"Coulomb cutoff for real space: {}\n",current_cutoff);
@@ -266,7 +266,7 @@ void FixTuneKspace::update_kspace_style(const std::string &new_kspace_style,
 {
   // delete old kspace style and create new one
 
-  auto tmp_acc_str = (char *)new_acc_str.c_str();
+  auto *tmp_acc_str = (char *)new_acc_str.c_str();
   force->create_kspace(new_kspace_style,1);
   force->kspace->settings(1,&tmp_acc_str);
   force->kspace->differentiation_flag = old_differentiation_flag;
@@ -306,7 +306,7 @@ void FixTuneKspace::adjust_rcut(double time)
 
   // get the current cutoff
   int itmp;
-  auto p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
+  auto *p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
   double current_cutoff = *p_cutoff;
   if (comm->me == 0)
     utils::logmesg(lmp,"Old Coulomb cutoff for real space: {}\n",current_cutoff);
@@ -377,7 +377,7 @@ void FixTuneKspace::adjust_rcut(double time)
   *p_cutoff = pair_cut_coul;
 
   // report the new cutoff
-  auto new_cutoff = (double *) force->pair->extract("cut_coul",itmp);
+  auto *new_cutoff = (double *) force->pair->extract("cut_coul",itmp);
   current_cutoff = *new_cutoff;
   if (comm->me == 0)
     utils::logmesg(lmp,"Adjusted Coulomb cutoff for real space: {}\n", current_cutoff);

--- a/src/KSPACE/msm.cpp
+++ b/src/KSPACE/msm.cpp
@@ -147,7 +147,7 @@ void MSM::init()
   pair_check();
 
   int itmp;
-  auto p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
+  auto *p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
   if (p_cutoff == nullptr)
     error->all(FLERR, Error::NOLASTLINE, "KSpace style is incompatible with Pair style");
   cutoff = *p_cutoff;
@@ -1065,7 +1065,7 @@ void MSM::set_grid_global()
 
     cutoff = pow(k*k*sum/3.0,1.0/(2.0*p));
     int itmp;
-    auto p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
+    auto *p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
     *p_cutoff = cutoff;
 
     if (me == 0)
@@ -2516,7 +2516,7 @@ void MSM::grid_swap_reverse(int n, double*** &gridn)
 
 void MSM::pack_forward_grid(int flag, void *vbuf, int nlist, int *list)
 {
-  auto buf = (double *) vbuf;
+  auto *buf = (double *) vbuf;
 
   int n = current_level;
   int k = 0;
@@ -2562,7 +2562,7 @@ void MSM::pack_forward_grid(int flag, void *vbuf, int nlist, int *list)
 
 void MSM::unpack_forward_grid(int flag, void *vbuf, int nlist, int *list)
 {
-  auto buf = (double *) vbuf;
+  auto *buf = (double *) vbuf;
 
   int n = current_level;
   int k = 0;
@@ -2608,7 +2608,7 @@ void MSM::unpack_forward_grid(int flag, void *vbuf, int nlist, int *list)
 
 void MSM::pack_reverse_grid(int flag, void *vbuf, int nlist, int *list)
 {
-  auto buf = (double *) vbuf;
+  auto *buf = (double *) vbuf;
 
   int n = current_level;
   int k = 0;
@@ -2654,7 +2654,7 @@ void MSM::pack_reverse_grid(int flag, void *vbuf, int nlist, int *list)
 
 void MSM::unpack_reverse_grid(int flag, void *vbuf, int nlist, int *list)
 {
-  auto buf = (double *) vbuf;
+  auto *buf = (double *) vbuf;
 
   int n = current_level;
   int k = 0;

--- a/src/KSPACE/pair_buck_long_coul_long.cpp
+++ b/src/KSPACE/pair_buck_long_coul_long.cpp
@@ -259,7 +259,7 @@ void PairBuckLongCoulLong::init_style()
     int list_style = NeighConst::REQ_DEFAULT;
 
     if (update->whichflag == 1 && utils::strmatch(update->integrate_style, "^respa")) {
-      auto respa = dynamic_cast<Respa *>(update->integrate);
+      auto *respa = dynamic_cast<Respa *>(update->integrate);
       if (respa->level_inner >= 0) list_style = NeighConst::REQ_RESPA_INOUT;
       if (respa->level_middle >= 0) list_style = NeighConst::REQ_RESPA_ALL;
     }

--- a/src/KSPACE/pair_lj_charmm_coul_long.cpp
+++ b/src/KSPACE/pair_lj_charmm_coul_long.cpp
@@ -684,7 +684,7 @@ void PairLJCharmmCoulLong::init_style()
   int list_style = NeighConst::REQ_DEFAULT;
 
   if (update->whichflag == 1 && utils::strmatch(update->integrate_style, "^respa")) {
-    auto respa = dynamic_cast<Respa *>(update->integrate);
+    auto *respa = dynamic_cast<Respa *>(update->integrate);
     if (respa->level_inner >= 0) list_style = NeighConst::REQ_RESPA_INOUT;
     if (respa->level_middle >= 0) list_style = NeighConst::REQ_RESPA_ALL;
   }

--- a/src/KSPACE/pair_lj_charmmfsw_coul_long.cpp
+++ b/src/KSPACE/pair_lj_charmmfsw_coul_long.cpp
@@ -733,7 +733,7 @@ void PairLJCharmmfswCoulLong::init_style()
   int list_style = NeighConst::REQ_DEFAULT;
 
   if (update->whichflag == 1 && utils::strmatch(update->integrate_style, "^respa")) {
-    auto respa = dynamic_cast<Respa *>(update->integrate);
+    auto *respa = dynamic_cast<Respa *>(update->integrate);
     if (respa->level_inner >= 0) list_style = NeighConst::REQ_RESPA_INOUT;
     if (respa->level_middle >= 0) list_style = NeighConst::REQ_RESPA_ALL;
   }

--- a/src/KSPACE/pair_lj_cut_coul_long.cpp
+++ b/src/KSPACE/pair_lj_cut_coul_long.cpp
@@ -652,7 +652,7 @@ void PairLJCutCoulLong::init_style()
   int list_style = NeighConst::REQ_DEFAULT;
 
   if (update->whichflag == 1 && utils::strmatch(update->integrate_style, "^respa")) {
-    auto respa = dynamic_cast<Respa *>(update->integrate);
+    auto *respa = dynamic_cast<Respa *>(update->integrate);
     if (respa->level_inner >= 0) list_style = NeighConst::REQ_RESPA_INOUT;
     if (respa->level_middle >= 0) list_style = NeighConst::REQ_RESPA_ALL;
   }

--- a/src/KSPACE/pair_lj_long_coul_long.cpp
+++ b/src/KSPACE/pair_lj_long_coul_long.cpp
@@ -251,7 +251,7 @@ void PairLJLongCoulLong::init_style()
     int list_style = NeighConst::REQ_DEFAULT;
 
     if (update->whichflag == 1 && utils::strmatch(update->integrate_style, "^respa")) {
-      auto respa = dynamic_cast<Respa *>(update->integrate);
+      auto *respa = dynamic_cast<Respa *>(update->integrate);
       if (respa->level_inner >= 0) list_style = NeighConst::REQ_RESPA_INOUT;
       if (respa->level_middle >= 0) list_style = NeighConst::REQ_RESPA_ALL;
     }

--- a/src/KSPACE/pppm.cpp
+++ b/src/KSPACE/pppm.cpp
@@ -221,7 +221,7 @@ void PPPM::init()
   pair_check();
 
   int itmp = 0;
-  auto p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
+  auto *p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
   if (p_cutoff == nullptr)
     error->all(FLERR,"KSpace style is incompatible with Pair style");
   cutoff = *p_cutoff;
@@ -234,7 +234,7 @@ void PPPM::init()
   if (tip4pflag) {
     if (me == 0) utils::logmesg(lmp,"  extracting TIP4P info from pair style\n");
 
-    auto p_qdist = (double *) force->pair->extract("qdist",itmp);
+    auto *p_qdist = (double *) force->pair->extract("qdist",itmp);
     int *p_typeO = (int *) force->pair->extract("typeO",itmp);
     int *p_typeH = (int *) force->pair->extract("typeH",itmp);
     int *p_typeA = (int *) force->pair->extract("typeA",itmp);
@@ -2548,7 +2548,7 @@ void PPPM::fieldforce_peratom()
 
 void PPPM::pack_forward_grid(int flag, void *vbuf, int nlist, int *list)
 {
-  auto buf = (FFT_SCALAR *) vbuf;
+  auto *buf = (FFT_SCALAR *) vbuf;
 
   int n = 0;
 
@@ -2608,7 +2608,7 @@ void PPPM::pack_forward_grid(int flag, void *vbuf, int nlist, int *list)
 
 void PPPM::unpack_forward_grid(int flag, void *vbuf, int nlist, int *list)
 {
-  auto buf = (FFT_SCALAR *) vbuf;
+  auto *buf = (FFT_SCALAR *) vbuf;
 
   int n = 0;
 
@@ -2668,7 +2668,7 @@ void PPPM::unpack_forward_grid(int flag, void *vbuf, int nlist, int *list)
 
 void PPPM::pack_reverse_grid(int flag, void *vbuf, int nlist, int *list)
 {
-  auto buf = (FFT_SCALAR *) vbuf;
+  auto *buf = (FFT_SCALAR *) vbuf;
 
   if (flag == REVERSE_RHO) {
     FFT_SCALAR *src = &density_brick[nzlo_out][nylo_out][nxlo_out];
@@ -2683,7 +2683,7 @@ void PPPM::pack_reverse_grid(int flag, void *vbuf, int nlist, int *list)
 
 void PPPM::unpack_reverse_grid(int flag, void *vbuf, int nlist, int *list)
 {
-  auto buf = (FFT_SCALAR *) vbuf;
+  auto *buf = (FFT_SCALAR *) vbuf;
 
   if (flag == REVERSE_RHO) {
     FFT_SCALAR *dest = &density_brick[nzlo_out][nylo_out][nxlo_out];

--- a/src/KSPACE/pppm_dipole.cpp
+++ b/src/KSPACE/pppm_dipole.cpp
@@ -141,7 +141,7 @@ void PPPMDipole::init()
   pair_check();
 
   int itmp = 0;
-  auto p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
+  auto *p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
   if (p_cutoff == nullptr)
     error->all(FLERR,"KSpace style is incompatible with Pair style");
   cutoff = *p_cutoff;
@@ -2230,7 +2230,7 @@ void PPPMDipole::fieldforce_peratom_dipole()
 
 void PPPMDipole::pack_forward_grid(int flag, void *vbuf, int nlist, int *list)
 {
-  auto buf = (FFT_SCALAR *) vbuf;
+  auto *buf = (FFT_SCALAR *) vbuf;
 
   int n = 0;
 
@@ -2303,7 +2303,7 @@ void PPPMDipole::pack_forward_grid(int flag, void *vbuf, int nlist, int *list)
 
 void PPPMDipole::unpack_forward_grid(int flag, void *vbuf, int nlist, int *list)
 {
-  auto buf = (FFT_SCALAR *) vbuf;
+  auto *buf = (FFT_SCALAR *) vbuf;
 
   int n = 0;
 
@@ -2376,7 +2376,7 @@ void PPPMDipole::unpack_forward_grid(int flag, void *vbuf, int nlist, int *list)
 
 void PPPMDipole::pack_reverse_grid(int flag, void *vbuf, int nlist, int *list)
 {
-  auto buf = (FFT_SCALAR *) vbuf;
+  auto *buf = (FFT_SCALAR *) vbuf;
 
   int n = 0;
   if (flag == REVERSE_MU) {
@@ -2397,7 +2397,7 @@ void PPPMDipole::pack_reverse_grid(int flag, void *vbuf, int nlist, int *list)
 
 void PPPMDipole::unpack_reverse_grid(int flag, void *vbuf, int nlist, int *list)
 {
-  auto buf = (FFT_SCALAR *) vbuf;
+  auto *buf = (FFT_SCALAR *) vbuf;
 
   int n = 0;
   if (flag == REVERSE_MU) {

--- a/src/KSPACE/pppm_dipole_spin.cpp
+++ b/src/KSPACE/pppm_dipole_spin.cpp
@@ -123,7 +123,7 @@ void PPPMDipoleSpin::init()
   pair_check();
 
   int itmp = 0;
-  auto p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
+  auto *p_cutoff = (double *) force->pair->extract("cut_coul",itmp);
   // check the correct extract here
   if (p_cutoff == nullptr)
     error->all(FLERR,"KSpace style is incompatible with Pair style");

--- a/src/KSPACE/pppm_disp.cpp
+++ b/src/KSPACE/pppm_disp.cpp
@@ -354,7 +354,7 @@ void PPPMDisp::init()
 
   if (tip4pflag) {
     int itmp;
-    auto p_qdist = (double *) force->pair->extract("qdist",itmp);
+    auto *p_qdist = (double *) force->pair->extract("qdist",itmp);
     int *p_typeO = (int *) force->pair->extract("typeO",itmp);
     int *p_typeH = (int *) force->pair->extract("typeH",itmp);
     int *p_typeA = (int *) force->pair->extract("typeA",itmp);
@@ -1278,7 +1278,7 @@ void PPPMDisp::init_coeffs()
     double **Q=nullptr;
     if (n > 1) {
       // get dispersion coefficients
-      auto b = (double **) force->pair->extract("B",tmp);
+      auto *b = (double **) force->pair->extract("B",tmp);
       memory->create(A,n,n,"pppm/disp:A");
       memory->create(Q,n,n,"pppm/disp:Q");
       // fill coefficients to matrix a
@@ -1393,15 +1393,15 @@ void PPPMDisp::init_coeffs()
   }
 
   if (function[1]) {                                    // geometric 1/r^6
-    auto b = (double **) force->pair->extract("B",tmp);
+    auto *b = (double **) force->pair->extract("B",tmp);
     B = new double[n+1];
     B[0] = 0.0;
     for (int i=1; i<=n; ++i) B[i] = sqrt(fabs(b[i][i]));
   }
 
   if (function[2]) {                                    // arithmetic 1/r^6
-    auto epsilon = (double **) force->pair->extract("epsilon",tmp);
-    auto sigma = (double **) force->pair->extract("sigma",tmp);
+    auto *epsilon = (double **) force->pair->extract("epsilon",tmp);
+    auto *sigma = (double **) force->pair->extract("sigma",tmp);
     if (!(epsilon&&sigma))
       error->all(FLERR,"Epsilon or sigma reference not set by pair style for PPPMDisp");
     double eps_i,sigma_i,sigma_n;
@@ -6761,7 +6761,7 @@ void PPPMDisp::fieldforce_none_peratom()
 
 void PPPMDisp::pack_forward_grid(int flag, void *vbuf, int nlist, int *list)
 {
-  auto buf = (FFT_SCALAR *) vbuf;
+  auto *buf = (FFT_SCALAR *) vbuf;
 
   int n = 0;
 
@@ -7274,7 +7274,7 @@ void PPPMDisp::pack_forward_grid(int flag, void *vbuf, int nlist, int *list)
 
 void PPPMDisp::unpack_forward_grid(int flag, void *vbuf, int nlist, int *list)
 {
-  auto buf = (FFT_SCALAR *) vbuf;
+  auto *buf = (FFT_SCALAR *) vbuf;
 
   int n = 0;
 
@@ -7787,7 +7787,7 @@ void PPPMDisp::unpack_forward_grid(int flag, void *vbuf, int nlist, int *list)
 
 void PPPMDisp::pack_reverse_grid(int flag, void *vbuf, int nlist, int *list)
 {
-  auto buf = (FFT_SCALAR *) vbuf;
+  auto *buf = (FFT_SCALAR *) vbuf;
 
   int n = 0;
 
@@ -7842,7 +7842,7 @@ void PPPMDisp::pack_reverse_grid(int flag, void *vbuf, int nlist, int *list)
 
 void PPPMDisp::unpack_reverse_grid(int flag, void *vbuf, int nlist, int *list)
 {
-  auto buf = (FFT_SCALAR *) vbuf;
+  auto *buf = (FFT_SCALAR *) vbuf;
 
   int n = 0;
 

--- a/src/KSPACE/remap.cpp
+++ b/src/KSPACE/remap.cpp
@@ -125,8 +125,8 @@ void remap_3d(FFT_SCALAR *in, FFT_SCALAR *out, FFT_SCALAR *buf,
       for (int i=0;i<plan->nrecv;i++)
         recvBufferSize += plan->recv_size[i];
 
-      auto packedSendBuffer = (FFT_SCALAR *) malloc(sizeof(FFT_SCALAR) * sendBufferSize + 1);
-      auto packedRecvBuffer = (FFT_SCALAR *) malloc(sizeof(FFT_SCALAR) * recvBufferSize + 1);
+      auto *packedSendBuffer = (FFT_SCALAR *) malloc(sizeof(FFT_SCALAR) * sendBufferSize + 1);
+      auto *packedRecvBuffer = (FFT_SCALAR *) malloc(sizeof(FFT_SCALAR) * recvBufferSize + 1);
 
       int *sendcnts = (int *) malloc(sizeof(int) * plan->commringlen);
       int *rcvcnts = (int *) malloc(sizeof(int) * plan->commringlen);

--- a/src/LATBOLTZ/fix_lb_fluid.cpp
+++ b/src/LATBOLTZ/fix_lb_fluid.cpp
@@ -4433,7 +4433,7 @@ void FixLbFluid::calc_MPT(double &totalmass, double totalmomentum[3], double &Ta
 bigint FixLbFluid::adjust_dof_fix() /* Based on same private method in compute class */
 {                                   /* altered to return fix_dof */
   bigint fix_dof = 0;
-  for (auto &ifix : modify->get_fix_list())
+  for (const auto &ifix : modify->get_fix_list())
     if (ifix->dof_flag) fix_dof += ifix->dof(igroup);
   return fix_dof;
 }

--- a/src/LEPTON/fix_efield_lepton.cpp
+++ b/src/LEPTON/fix_efield_lepton.cpp
@@ -131,7 +131,7 @@ void FixEfieldLepton::init()
   }
 
   if (utils::strmatch(update->integrate_style, "^respa")) {
-    auto respa = dynamic_cast<Respa *>(update->integrate);
+    auto *respa = dynamic_cast<Respa *>(update->integrate);
     if (respa) ilevel_respa = respa->nlevels - 1;
     if (respa_level >= 0) ilevel_respa = MIN(respa_level, ilevel_respa);
   }
@@ -149,7 +149,7 @@ void FixEfieldLepton::init()
 void FixEfieldLepton::setup(int vflag)
 {
   if (utils::strmatch(update->integrate_style, "^respa")) {
-    auto respa = dynamic_cast<Respa *>(update->integrate);
+    auto *respa = dynamic_cast<Respa *>(update->integrate);
     if (respa) {
       respa->copy_flevel_f(ilevel_respa);
       post_force_respa(vflag, ilevel_respa, 0);

--- a/src/LEPTON/lepton_utils.cpp
+++ b/src/LEPTON/lepton_utils.cpp
@@ -155,7 +155,7 @@ std::string LeptonUtils::substitute(const std::string &in, LAMMPS_NS::LAMMPS *lm
     vars.insert(name);
   }
 
-  auto variable = lmp->input->variable;
+  auto *variable = lmp->input->variable;
   fmt::dynamic_format_arg_store<fmt::format_context> args;
   for (const auto &v : vars) {
     const char *val = variable->retrieve(v.c_str());

--- a/src/MACHDYN/compute_smd_hourglass_error.cpp
+++ b/src/MACHDYN/compute_smd_hourglass_error.cpp
@@ -86,7 +86,7 @@ void ComputeSMDHourglassError::compute_peratom() {
         }
 
         int itmp = 0;
-        auto hourglass_error = (double *) force->pair->extract("smd/tlsph/hourglass_error_ptr", itmp);
+        auto *hourglass_error = (double *) force->pair->extract("smd/tlsph/hourglass_error_ptr", itmp);
         if (hourglass_error == nullptr) {
                 error->all(FLERR, "compute smd/hourglass_error failed to access hourglass_error array");
         }

--- a/src/MACHDYN/compute_smd_tlsph_dt.cpp
+++ b/src/MACHDYN/compute_smd_tlsph_dt.cpp
@@ -87,7 +87,7 @@ void ComputeSMDTlsphDt::compute_peratom() {
         }
 
         int itmp = 0;
-        auto particle_dt = (double *) force->pair->extract("smd/tlsph/particle_dt_ptr",
+        auto *particle_dt = (double *) force->pair->extract("smd/tlsph/particle_dt_ptr",
                         itmp);
         if (particle_dt == nullptr) {
                 error->all(FLERR,

--- a/src/MACHDYN/compute_smd_tlsph_shape.cpp
+++ b/src/MACHDYN/compute_smd_tlsph_shape.cpp
@@ -89,12 +89,12 @@ void ComputeSmdTlsphShape::compute_peratom() {
         }
 
         int itmp = 0;
-        auto R = (Matrix3d *) force->pair->extract("smd/tlsph/rotation_ptr", itmp);
+        auto *R = (Matrix3d *) force->pair->extract("smd/tlsph/rotation_ptr", itmp);
         if (R == nullptr) {
                 error->all(FLERR, "compute smd/tlsph_shape failed to access rotation array");
         }
 
-        auto F = (Matrix3d *) force->pair->extract("smd/tlsph/Fincr_ptr", itmp);
+        auto *F = (Matrix3d *) force->pair->extract("smd/tlsph/Fincr_ptr", itmp);
         if (F == nullptr) {
                 error->all(FLERR, "compute smd/tlsph_shape failed to access deformation gradient array");
         }

--- a/src/MACHDYN/compute_smd_tlsph_strain.cpp
+++ b/src/MACHDYN/compute_smd_tlsph_strain.cpp
@@ -92,7 +92,7 @@ void ComputeSMDTLSPHstrain::compute_peratom() {
 
         // copy data to output array
         int itmp = 0;
-        auto Fincr = (Matrix3d *) force->pair->extract("smd/tlsph/Fincr_ptr", itmp);
+        auto *Fincr = (Matrix3d *) force->pair->extract("smd/tlsph/Fincr_ptr", itmp);
         if (Fincr == nullptr) {
                 error->all(FLERR, "compute smd/tlsph_strain failed to access Fincr array");
         }

--- a/src/MACHDYN/compute_smd_tlsph_strain_rate.cpp
+++ b/src/MACHDYN/compute_smd_tlsph_strain_rate.cpp
@@ -89,7 +89,7 @@ void ComputeSMDTLSPHStrainRate::compute_peratom() {
         }
 
         int itmp = 0;
-        auto D = (Matrix3d *) force->pair->extract("smd/tlsph/strain_rate_ptr", itmp);
+        auto *D = (Matrix3d *) force->pair->extract("smd/tlsph/strain_rate_ptr", itmp);
         if (D == nullptr) {
                 error->all(FLERR,
                                 "compute smd/tlsph_strain_rate could not access strain rate. Are the matching pair styles present?");

--- a/src/MACHDYN/compute_smd_tlsph_stress.cpp
+++ b/src/MACHDYN/compute_smd_tlsph_stress.cpp
@@ -99,7 +99,7 @@ void ComputeSMDTLSPHStress::compute_peratom() {
         }
 
         int itmp = 0;
-        auto T = (Matrix3d *) force->pair->extract("smd/tlsph/stressTensor_ptr", itmp);
+        auto *T = (Matrix3d *) force->pair->extract("smd/tlsph/stressTensor_ptr", itmp);
         if (T == nullptr) {
                 error->all(FLERR, "compute smd/tlsph_stress could not access stress tensors. Are the matching pair styles present?");
         }

--- a/src/MACHDYN/compute_smd_ulsph_effm.cpp
+++ b/src/MACHDYN/compute_smd_ulsph_effm.cpp
@@ -89,7 +89,7 @@ void ComputeSMD_Ulsph_Effm::compute_peratom() {
         }
 
         int itmp = 0;
-        auto particle_dt = (double *) force->pair->extract("smd/ulsph/effective_modulus_ptr", itmp);
+        auto *particle_dt = (double *) force->pair->extract("smd/ulsph/effective_modulus_ptr", itmp);
         if (particle_dt == nullptr)
           error->all(FLERR, "compute smd/ulsph_effm failed to access particle_dt array");
 

--- a/src/MACHDYN/compute_smd_ulsph_strain_rate.cpp
+++ b/src/MACHDYN/compute_smd_ulsph_strain_rate.cpp
@@ -87,7 +87,7 @@ void ComputeSMDULSPHStrainRate::compute_peratom() {
         }
 
         int itmp = 0;
-        auto L = (Matrix3d *) force->pair->extract("smd/ulsph/velocityGradient_ptr", itmp);
+        auto *L = (Matrix3d *) force->pair->extract("smd/ulsph/velocityGradient_ptr", itmp);
         if (L == nullptr) {
                 error->all(FLERR,
                                 "compute smd/ulsph_strain_rate could not access any velocity gradients. Are the matching pair styles present?");

--- a/src/MACHDYN/compute_smd_ulsph_stress.cpp
+++ b/src/MACHDYN/compute_smd_ulsph_stress.cpp
@@ -99,7 +99,7 @@ void ComputeSMDULSPHStress::compute_peratom() {
         }
 
         int itmp = 0;
-        auto T = (Matrix3d *) force->pair->extract("smd/ulsph/stressTensor_ptr", itmp);
+        auto *T = (Matrix3d *) force->pair->extract("smd/ulsph/stressTensor_ptr", itmp);
         if (T == nullptr) {
                 error->all(FLERR, "compute smd/ulsph_stress could not access stress tensors. Are the matching pair styles present?");
         }

--- a/src/MACHDYN/fix_smd_adjust_dt.cpp
+++ b/src/MACHDYN/fix_smd_adjust_dt.cpp
@@ -102,11 +102,11 @@ void FixSMDTlsphDtReset::end_of_step() {
          * extract minimum CFL timestep from TLSPH and ULSPH pair styles
          */
 
-        auto dtCFL_TLSPH = (double *) force->pair->extract("smd/tlsph/dtCFL_ptr", itmp);
-        auto dtCFL_ULSPH = (double *) force->pair->extract("smd/ulsph/dtCFL_ptr", itmp);
-        auto dt_TRI = (double *) force->pair->extract("smd/tri_surface/stable_time_increment_ptr", itmp);
-        auto dt_HERTZ = (double *) force->pair->extract("smd/hertz/stable_time_increment_ptr", itmp);
-        auto dt_PERI_IPMB = (double *) force->pair->extract("smd/peri_ipmb/stable_time_increment_ptr", itmp);
+        auto *dtCFL_TLSPH = (double *) force->pair->extract("smd/tlsph/dtCFL_ptr", itmp);
+        auto *dtCFL_ULSPH = (double *) force->pair->extract("smd/ulsph/dtCFL_ptr", itmp);
+        auto *dt_TRI = (double *) force->pair->extract("smd/tri_surface/stable_time_increment_ptr", itmp);
+        auto *dt_HERTZ = (double *) force->pair->extract("smd/hertz/stable_time_increment_ptr", itmp);
+        auto *dt_PERI_IPMB = (double *) force->pair->extract("smd/peri_ipmb/stable_time_increment_ptr", itmp);
 
         if ((dtCFL_TLSPH == nullptr) && (dtCFL_ULSPH == nullptr) && (dt_TRI == nullptr) && (dt_HERTZ == nullptr)
                         && (dt_PERI_IPMB == nullptr)) {
@@ -221,7 +221,7 @@ void FixSMDTlsphDtReset::write_restart(FILE *fp) {
 
 void FixSMDTlsphDtReset::restart(char *buf) {
         int n = 0;
-        auto list = (double *) buf;
+        auto *list = (double *) buf;
         t_elapsed = list[n++];
 }
 

--- a/src/MACHDYN/fix_smd_integrate_tlsph.cpp
+++ b/src/MACHDYN/fix_smd_integrate_tlsph.cpp
@@ -145,7 +145,7 @@ void FixSMDIntegrateTlsph::initial_integrate(int /*vflag*/) {
         if (igroup == atom->firstgroup)
                 nlocal = atom->nfirst;
 
-        auto smoothVelDifference = (Vector3d *) force->pair->extract("smd/tlsph/smoothVel_ptr", itmp);
+        auto *smoothVelDifference = (Vector3d *) force->pair->extract("smd/tlsph/smoothVel_ptr", itmp);
 
         if (xsphFlag) {
                 if (smoothVelDifference == nullptr) {

--- a/src/MACHDYN/fix_smd_integrate_ulsph.cpp
+++ b/src/MACHDYN/fix_smd_integrate_ulsph.cpp
@@ -177,7 +177,7 @@ void FixSMDIntegrateUlsph::initial_integrate(int /*vflag*/) {
          * get smoothed velocities from ULSPH pair style
          */
 
-        auto smoothVel = (Vector3d *) force->pair->extract("smd/ulsph/smoothVel_ptr", itmp);
+        auto *smoothVel = (Vector3d *) force->pair->extract("smd/ulsph/smoothVel_ptr", itmp);
 
         if (xsphFlag) {
                 if (smoothVel == nullptr) {
@@ -272,7 +272,7 @@ void FixSMDIntegrateUlsph::final_integrate() {
                 error->one(FLERR, "fix smd/integrate_ulsph failed to accesss num_neighs array");
         }
 
-        auto L = (Matrix3d *) force->pair->extract("smd/ulsph/velocityGradient_ptr", itmp);
+        auto *L = (Matrix3d *) force->pair->extract("smd/ulsph/velocityGradient_ptr", itmp);
         if (L == nullptr) {
                 error->one(FLERR, "fix smd/integrate_ulsph failed to accesss velocityGradient array");
         }

--- a/src/MACHDYN/pair_smd_tlsph.cpp
+++ b/src/MACHDYN/pair_smd_tlsph.cpp
@@ -1606,7 +1606,7 @@ void PairTlsph::init_style() {
     error->all(FLERR, "Pair style tlsph requires its particles to be part of a group named tlsph. This group does not exist.");
 
   if (fix_tlsph_reference_configuration == nullptr) {
-    auto fixarg = new char*[3];
+    auto *fixarg = new char*[3];
     fixarg[0] = (char *) "SMD_TLSPH_NEIGHBORS";
     fixarg[1] = (char *) "tlsph";
     fixarg[2] = (char *) "SMD_TLSPH_NEIGHBORS";

--- a/src/MANIFOLD/manifold_thylakoid.cpp
+++ b/src/MANIFOLD/manifold_thylakoid.cpp
@@ -447,7 +447,7 @@ thyla_part *manifold_thylakoid::make_plane_part (double a, double b, double c,
   args[3] = pt[0];
   args[4] = pt[1];
   args[5] = pt[2];
-  auto p = new thyla_part(thyla_part::THYLA_TYPE_PLANE,args,0,0,0,0,0,0);
+  auto *p = new thyla_part(thyla_part::THYLA_TYPE_PLANE,args,0,0,0,0,0,0);
   return p;
 }
 
@@ -462,7 +462,7 @@ thyla_part *manifold_thylakoid::make_cyl_part   (double a, double b, double c,
   args[4] = pt[1];
   args[5] = pt[2];
   args[6] = R;
-  auto p = new thyla_part(thyla_part::THYLA_TYPE_CYL,args,0,0,0,0,0,0);
+  auto *p = new thyla_part(thyla_part::THYLA_TYPE_CYL,args,0,0,0,0,0,0);
   return p;
 }
 
@@ -474,7 +474,7 @@ thyla_part *manifold_thylakoid::make_sphere_part(const std::vector<double> &pt, 
   args[1] = pt[0];
   args[2] = pt[1];
   args[3] = pt[2];
-  auto p = new thyla_part(thyla_part::THYLA_TYPE_SPHERE,args,0,0,0,0,0,0);
+  auto *p = new thyla_part(thyla_part::THYLA_TYPE_SPHERE,args,0,0,0,0,0,0);
   return p;
 }
 
@@ -490,6 +490,6 @@ thyla_part *manifold_thylakoid::make_cyl_to_plane_part(double X0, double R0, dou
   args[4] = pt[1];
   args[5] = pt[2];
   args[6] = s;
-  auto p = new thyla_part(thyla_part::THYLA_TYPE_CYL_TO_PLANE,args,0,0,0,0,0,0);
+  auto *p = new thyla_part(thyla_part::THYLA_TYPE_CYL_TO_PLANE,args,0,0,0,0,0,0);
   return p;
 }

--- a/src/MANYBODY/pair_eam_cd.cpp
+++ b/src/MANYBODY/pair_eam_cd.cpp
@@ -503,7 +503,7 @@ void PairEAMCD::read_h_coeff(char *filename)
       error->one(FLERR,"Failure to seek to end-of-file for reading h(x) coeffs: {}",
                  utils::getsyserror());
 
-    auto buf = new char[MAXLINE+1];
+    auto *buf = new char[MAXLINE+1];
     auto rv = fread(buf,1,MAXLINE,fptr);
     if (rv == 0) error->one(FLERR,"Failure to read h(x) coeffs: {}", utils::getsyserror());
     buf[rv] = '\0';        // must 0-terminate buffer for string processing

--- a/src/MANYBODY/pair_meam_spline.cpp
+++ b/src/MANYBODY/pair_meam_spline.cpp
@@ -664,7 +664,7 @@ void PairMEAMSpline::SplineFunction::prepareSpline()
   h = (xmax-xmin)/(N-1);
   hsq = h*h;
 
-  auto  u = new double[N];
+  auto *  u = new double[N];
   Y2[0] = -0.5;
   u[0] = (3.0/(X[1]-X[0])) * ((Y[1]-Y[0])/(X[1]-X[0]) - deriv0);
   for (int i = 1; i <= N-2; i++) {

--- a/src/MANYBODY/pair_meam_sw_spline.cpp
+++ b/src/MANYBODY/pair_meam_sw_spline.cpp
@@ -545,7 +545,7 @@ void PairMEAMSWSpline::SplineFunction::prepareSpline()
   h = (xmax-xmin)/((double)(N-1));
   hsq = h*h;
 
-  auto  u = new double[N];
+  auto *  u = new double[N];
   Y2[0] = -0.5;
   u[0] = (3.0/(X[1]-X[0])) * ((Y[1]-Y[0])/(X[1]-X[0]) - deriv0);
   for (int i = 1; i <= N-2; i++) {

--- a/src/MANYBODY/pair_polymorphic.cpp
+++ b/src/MANYBODY/pair_polymorphic.cpp
@@ -635,7 +635,7 @@ void PairPolymorphic::read_file(char *file)
   MPI_Bcast(pairParameters, npair*sizeof(PairParameters), MPI_BYTE, 0, world);
 
   // start reading tabular functions
-  auto  singletable = new double[nr];
+  auto *  singletable = new double[nr];
   for (int i = 0; i < npair; i++) { // U
     PairParameters &p = pairParameters[i];
     if (comm->me == 0) reader->next_dvector(singletable, nr);

--- a/src/MANYBODY/pair_sw_angle_table.cpp
+++ b/src/MANYBODY/pair_sw_angle_table.cpp
@@ -672,7 +672,7 @@ void PairSWAngleTable::spline(double *x, double *y, int n, double yp1, double yp
 {
   int i, k;
   double p, qn, sig, un;
-  double *u = new double[n];
+  auto *u = new double[n];
 
   if (yp1 > 0.99e300)
     y2[0] = u[0] = 0.0;

--- a/src/MC/fix_atom_swap.cpp
+++ b/src/MC/fix_atom_swap.cpp
@@ -831,7 +831,7 @@ void FixAtomSwap::write_restart(FILE *fp)
 void FixAtomSwap::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
 
   seed = static_cast<int>(list[n++]);
   random_equal->reset(seed);

--- a/src/MC/fix_charge_regulation.cpp
+++ b/src/MC/fix_charge_regulation.cpp
@@ -1281,7 +1281,7 @@ void FixChargeRegulation::write_restart(FILE *fp)
 void FixChargeRegulation::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
 
   seed = static_cast<int>(list[n++]);
   random_equal->reset(seed);

--- a/src/MC/fix_gcmc.cpp
+++ b/src/MC/fix_gcmc.cpp
@@ -1384,7 +1384,7 @@ void FixGCMC::attempt_molecule_insertion()
   MathExtra::quat_to_mat(quat,rotmat);
 
   double insertion_energy = 0.0;
-  auto procflag = new bool[natoms_per_molecule];
+  auto *procflag = new bool[natoms_per_molecule];
 
   for (int i = 0; i < natoms_per_molecule; i++) {
     MathExtra::matvec(rotmat,onemols[imol]->x[i],molcoords[i]);
@@ -2470,9 +2470,9 @@ void FixGCMC::update_gas_atoms_list()
       for (int i = 0; i < nlocal; i++) maxmol = MAX(maxmol,molecule[i]);
       tagint maxmol_all;
       MPI_Allreduce(&maxmol,&maxmol_all,1,MPI_LMP_TAGINT,MPI_MAX,world);
-      auto comx = new double[maxmol_all];
-      auto comy = new double[maxmol_all];
-      auto comz = new double[maxmol_all];
+      auto *comx = new double[maxmol_all];
+      auto *comy = new double[maxmol_all];
+      auto *comz = new double[maxmol_all];
       for (int imolecule = 0; imolecule < maxmol_all; imolecule++) {
         for (int i = 0; i < nlocal; i++) {
           if (molecule[i] == imolecule) {
@@ -2592,7 +2592,7 @@ void FixGCMC::write_restart(FILE *fp)
 void FixGCMC::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
 
   seed = static_cast<int> (list[n++]);
   random_equal->reset(seed);

--- a/src/MC/fix_mol_swap.cpp
+++ b/src/MC/fix_mol_swap.cpp
@@ -139,7 +139,7 @@ void FixMolSwap::init()
 {
   // c_pe = compute used to calculate before/after potential energy
 
-  auto id_pe = (char *) "thermo_pe";
+  auto *id_pe = (char *) "thermo_pe";
   int ipe = modify->find_compute(id_pe);
   c_pe = modify->compute[ipe];
 
@@ -488,7 +488,7 @@ void FixMolSwap::write_restart(FILE *fp)
 void FixMolSwap::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
 
   seed = static_cast<int> (list[n++]);
   random->reset(seed);

--- a/src/MC/fix_widom.cpp
+++ b/src/MC/fix_widom.cpp
@@ -663,7 +663,7 @@ void FixWidom::attempt_molecule_insertion()
     MathExtra::quat_to_mat(quat,rotmat);
 
     double insertion_energy = 0.0;
-    auto procflag = new bool[natoms_per_molecule];
+    auto *procflag = new bool[natoms_per_molecule];
 
     for (int i = 0; i < natoms_per_molecule; i++) {
       MathExtra::matvec(rotmat,onemol->x[i],molcoords[i]);
@@ -1130,7 +1130,7 @@ void FixWidom::write_restart(FILE *fp)
 void FixWidom::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
 
   seed = static_cast<int> (list[n++]);
   random_equal->reset(seed);

--- a/src/MDI/fix_mdi_qm.cpp
+++ b/src/MDI/fix_mdi_qm.cpp
@@ -1114,7 +1114,7 @@ void FixMDIQM::unit_conversions()
 
 int compare_IDs(const int i, const int j, void *ptr)
 {
-  tagint *ids = (tagint *) ptr;
+  auto *ids = (tagint *) ptr;
   if (ids[i] < ids[j]) return -1;
   if (ids[i] > ids[j]) return 1;
   return 0;

--- a/src/MDI/fix_mdi_qmmm.cpp
+++ b/src/MDI/fix_mdi_qmmm.cpp
@@ -1962,7 +1962,7 @@ void FixMDIQMMM::unit_conversions()
 
 int compare_IDs(const int i, const int j, void *ptr)
 {
-  tagint *ids = (tagint *) ptr;
+  auto *ids = (tagint *) ptr;
   if (ids[i] < ids[j]) return -1;
   if (ids[i] > ids[j]) return 1;
   return 0;

--- a/src/MDI/mdi_engine.cpp
+++ b/src/MDI/mdi_engine.cpp
@@ -315,7 +315,7 @@ void MDIEngine::engine_node(const char *node)
 
 int MDIEngine::execute_command_plugin_wrapper(const char *command, MDI_Comm comm, void *class_obj)
 {
-  auto mdi_engine = (MDIEngine *) class_obj;
+  auto *mdi_engine = (MDIEngine *) class_obj;
   return mdi_engine->execute_command(command, comm);
 }
 
@@ -1469,7 +1469,7 @@ void MDIEngine::send_total_energy()
 
 void MDIEngine::send_labels()
 {
-  auto labels = new char[sys_natoms * MDI_LABEL_LENGTH];
+  auto *labels = new char[sys_natoms * MDI_LABEL_LENGTH];
   memset(labels, ' ', sys_natoms * MDI_LABEL_LENGTH);
 
   memset(ibuf1, 0, sys_natoms * sizeof(int));
@@ -1721,7 +1721,7 @@ void MDIEngine::single_command()
 {
   if (nbytes < 0) error->all(FLERR, "MDI: COMMAND nbytes has not been set");
 
-  auto cmd = new char[nbytes + 1];
+  auto *cmd = new char[nbytes + 1];
   int ierr = MDI_Recv(cmd, nbytes + 1, MDI_CHAR, mdicomm);
   if (ierr) error->all(FLERR, "MDI: COMMAND data");
   MPI_Bcast(cmd, nbytes + 1, MPI_CHAR, 0, world);
@@ -1742,7 +1742,7 @@ void MDIEngine::many_commands()
 {
   if (nbytes < 0) error->all(FLERR, "MDI: COMMANDS nbytes has not been set");
 
-  auto cmds = new char[nbytes + 1];
+  auto *cmds = new char[nbytes + 1];
   int ierr = MDI_Recv(cmds, nbytes + 1, MDI_CHAR, mdicomm);
   if (ierr) error->all(FLERR, "MDI: COMMANDS data");
   MPI_Bcast(cmds, nbytes + 1, MPI_CHAR, 0, world);
@@ -1763,7 +1763,7 @@ void MDIEngine::infile()
 {
   if (nbytes < 0) error->all(FLERR, "MDI: INFILE nbytes has not been set");
 
-  auto infile = new char[nbytes + 1];
+  auto *infile = new char[nbytes + 1];
   int ierr = MDI_Recv(infile, nbytes + 1, MDI_CHAR, mdicomm);
   if (ierr) error->all(FLERR, "MDI: INFILE data for {}", infile);
   MPI_Bcast(infile, nbytes + 1, MPI_CHAR, 0, world);

--- a/src/MDI/mdi_plugin.cpp
+++ b/src/MDI/mdi_plugin.cpp
@@ -105,7 +105,7 @@ MDIPlugin::MDIPlugin(LAMMPS *_lmp, int narg, char **arg) : Pointers(_lmp)
   int n = strlen(mdi_arg) + 16;
   if (infile_arg) n += strlen(infile_arg);
   if (extra_arg) n += strlen(extra_arg);
-  auto plugin_args = new char[n];
+  auto *plugin_args = new char[n];
   plugin_args[0] = 0;
   strcat(plugin_args, "-mdi \"");
   strcat(plugin_args, mdi_arg);
@@ -139,7 +139,7 @@ MDIPlugin::MDIPlugin(LAMMPS *_lmp, int narg, char **arg) : Pointers(_lmp)
 
 int MDIPlugin::plugin_wrapper(void * /*pmpicomm*/, MDI_Comm mdicomm, void *vptr)
 {
-  auto ptr = (MDIPlugin *) vptr;
+  auto *ptr = (MDIPlugin *) vptr;
   LAMMPS *lammps = ptr->lmp;
   char *lammps_command = ptr->lammps_command;
 

--- a/src/MGPT/mgpt_splinetab.cpp
+++ b/src/MGPT/mgpt_splinetab.cpp
@@ -36,8 +36,8 @@ static void trisolve(int n,double A[][3],double y[]) {
 void makespline(int ntab,int stride,double tab[],double C[][4]) {
   int n = 3*(ntab-1);
 
-  double (*A)[3] = new double[n][3];
-  double *y = new double[n];
+  auto *A = new double[n][3];
+  auto *y = new double[n];
 
   double h_left,h_right,d;
   int i,j;

--- a/src/MGPT/pair_mgpt.cpp
+++ b/src/MGPT/pair_mgpt.cpp
@@ -104,7 +104,7 @@ PairMGPT::~PairMGPT()
 static double t_make_b2 = 0.0,n_make_b2 = 0.0;
 
 template<typename intype,typename outtype,int ni,int nj> void fmatconv(intype *array) {
-  outtype *cast = (outtype *) array;
+  auto *cast = (outtype *) array;
   for (int i = 0; i<ni; i++)
     for (int j = 0; j<nj; j++)
       cast[i*nj+j] = array[i*nj+j];
@@ -1720,10 +1720,10 @@ void PairMGPT::compute(int eflag, int vflag)
       if (i > nmax) nmax = i;
     }
     nmax++;
-    double *ffwork = new double[3*nmax];
-    double *ffloc = new double[3*listfull->inum];
-    double *ffloc2 = new double[3*listfull->inum];
-    double **ffptr = new double *[nmax];
+    auto *ffwork = new double[3*nmax];
+    auto *ffloc = new double[3*listfull->inum];
+    auto *ffloc2 = new double[3*listfull->inum];
+    auto **ffptr = new double *[nmax];
     for (ii = 0; ii<listfull->inum + listfull->gnum; ii++)
       ffptr[ii] = &ffwork[3*ii];
 

--- a/src/MISC/fix_imd.cpp
+++ b/src/MISC/fix_imd.cpp
@@ -652,7 +652,7 @@ FixIMD::~FixIMD()
     pthread_cond_destroy(&write_cond);
   }
 #endif
-  auto hashtable = (taginthash_t *)idmap;
+  auto *hashtable = (taginthash_t *)idmap;
   memory->destroy(coord_data);
   memory->destroy(vel_data);
   memory->destroy(force_data);
@@ -802,17 +802,17 @@ void FixIMD::setup_v2() {
     error->all(FLERR,"LAMMPS terminated on error in setting up IMD connection.");
 
   /* initialize and build hashtable. */
-  auto hashtable=new taginthash_t;
+  auto *hashtable=new taginthash_t;
   taginthash_init(hashtable, num_coords);
   idmap = (void *)hashtable;
 
   int tmp, ndata;
-  auto buf = static_cast<struct commdata *>(coord_data);
+  auto *buf = static_cast<struct commdata *>(coord_data);
 
   if (me == 0) {
     MPI_Status status;
     MPI_Request request;
-    auto taglist = new tagint[num_coords];
+    auto *taglist = new tagint[num_coords];
     int numtag=0; /* counter to map atom tags to a 0-based consecutive index list */
 
     for (i=0; i < nlocal; ++i) {
@@ -904,7 +904,7 @@ void FixIMD::setup_v3()
     error->all(FLERR,"LAMMPS terminated on error in setting up IMD connection.");
 
   /* initialize and build hashtable. */
-  auto hashtable=new taginthash_t;
+  auto *hashtable=new taginthash_t;
   taginthash_init(hashtable, num_coords);
   idmap = (void *)hashtable;
 
@@ -925,7 +925,7 @@ void FixIMD::setup_v3()
     }
     MPI_Status status;
     MPI_Request request;
-    auto taglist = new tagint[num_coords];
+    auto *taglist = new tagint[num_coords];
     int numtag=0; /* counter to map atom tags to a 0-based consecutive index list */
 
     for (i=0; i < nlocal; ++i) {
@@ -979,7 +979,7 @@ void FixIMD::setup_v3()
 /* c bindings wrapper */
 void *fix_imd_ioworker(void *t)
 {
-  FixIMD *imd=(FixIMD *)t;
+  auto *imd=(FixIMD *)t;
   imd->ioworker();
   return nullptr;
 }
@@ -1137,8 +1137,8 @@ void FixIMD::handle_step_v2() {
           break;
 
         case IMD_MDCOMM: {
-          auto imd_tags = new int32[length];
-          auto imd_fdat = new float[3*length];
+          auto *imd_tags = new int32[length];
+          auto *imd_fdat = new float[3*length];
           imd_recv_mdcomm(clientsock, length, imd_tags, imd_fdat);
 
           if (imd_forces < length) { /* grow holding space for forces, if needed. */
@@ -1243,7 +1243,7 @@ void FixIMD::handle_step_v2() {
      * us one extra copy of the data. */
     imd_fill_header((IMDheader *)msgdata, IMD_FCOORDS, num_coords);
     /* array pointer, to the offset where we receive the coordinates. */
-    auto recvcoord = (float *) (msgdata+IMDHEADERSIZE);
+    auto *recvcoord = (float *) (msgdata+IMDHEADERSIZE);
 
     /* add local data */
     if (imdsinfo->unwrap) {
@@ -1462,8 +1462,8 @@ void FixIMD::handle_client_input_v3() {
           break;
 
         case IMD_MDCOMM: {
-          auto imd_tags = new int32[length];
-          auto imd_fdat = new float[3*length];
+          auto *imd_tags = new int32[length];
+          auto *imd_fdat = new float[3*length];
           imd_recv_mdcomm(clientsock, length, imd_tags, imd_fdat);
 
           if (imd_forces < length) { /* grow holding space for forces, if needed. */
@@ -1590,7 +1590,7 @@ void FixIMD::handle_output_v3() {
     if (imdsinfo->box) {
       imd_fill_header((IMDheader *)(msgdata + offset), IMD_BOX, 1);
       // Get triclinic box vectors
-      float *box = (float *)(msgdata+offset+IMDHEADERSIZE);
+      auto *box = (float *)(msgdata+offset+IMDHEADERSIZE);
       box[0] = domain->h[0];
       box[1] = 0.0;
       box[2] = 0.0;
@@ -1850,7 +1850,7 @@ void * imdsock_create() {
 /* ---------------------------------------------------------------------- */
 
 int imdsock_bind(void * v, int port) {
-  auto s = (imdsocket *) v;
+  auto *s = (imdsocket *) v;
   auto *addr = &(s->addr);
   s->addrlen = sizeof(s->addr);
   memset(addr, 0, s->addrlen);
@@ -1863,7 +1863,7 @@ int imdsock_bind(void * v, int port) {
 /* ---------------------------------------------------------------------- */
 
 int imdsock_listen(void * v) {
-  auto s = (imdsocket *) v;
+  auto *s = (imdsocket *) v;
   return listen(s->sd, 5);
 }
 
@@ -1901,7 +1901,7 @@ void *imdsock_accept(void * v) {
 /* ---------------------------------------------------------------------- */
 
 int  imdsock_write(void * v, const void *buf, int len) {
-  auto s = (imdsocket *) v;
+  auto *s = (imdsocket *) v;
 #if defined(_MSC_VER) || defined(__MINGW32__)
   return send(s->sd, (const char*) buf, len, 0);  /* windows lacks the write() call */
 #else
@@ -1912,7 +1912,7 @@ int  imdsock_write(void * v, const void *buf, int len) {
 /* ---------------------------------------------------------------------- */
 
 int  imdsock_read(void * v, void *buf, int len) {
-  auto s = (imdsocket *) v;
+  auto *s = (imdsocket *) v;
 #if defined(_MSC_VER) || defined(__MINGW32__)
   return recv(s->sd, (char*) buf, len, 0); /* windows lacks the read() call */
 #else
@@ -1924,7 +1924,7 @@ int  imdsock_read(void * v, void *buf, int len) {
 /* ---------------------------------------------------------------------- */
 
 void imdsock_shutdown(void *v) {
-  auto  s = (imdsocket *) v;
+  auto *  s = (imdsocket *) v;
   if (s == nullptr)
     return;
 
@@ -1938,7 +1938,7 @@ void imdsock_shutdown(void *v) {
 /* ---------------------------------------------------------------------- */
 
 void imdsock_destroy(void * v) {
-  auto  s = (imdsocket *) v;
+  auto *  s = (imdsocket *) v;
   if (s == nullptr)
     return;
 
@@ -1953,7 +1953,7 @@ void imdsock_destroy(void * v) {
 /* ---------------------------------------------------------------------- */
 
 int imdsock_selread(void *v, int sec) {
-  auto s = (imdsocket *)v;
+  auto *s = (imdsocket *)v;
   fd_set rfd;
   struct timeval tv;
   int rc;
@@ -1974,7 +1974,7 @@ int imdsock_selread(void *v, int sec) {
 /* ---------------------------------------------------------------------- */
 
 int imdsock_selwrite(void *v, int sec) {
-  auto s = (imdsocket *)v;
+  auto *s = (imdsocket *)v;
   fd_set wfd;
   struct timeval tv;
   int rc;

--- a/src/MISC/fix_ipi.cpp
+++ b/src/MISC/fix_ipi.cpp
@@ -259,7 +259,7 @@ void FixIPI::init()
   socketflag = 1;
 
   // asks for evaluation of PE at first step
-  auto c_pe = modify->get_compute_by_id("thermo_pe");
+  auto *c_pe = modify->get_compute_by_id("thermo_pe");
   if (c_pe) {
     c_pe->invoked_scalar = -1;
     modify->addstep_compute_all(update->ntimestep + 1);
@@ -387,7 +387,7 @@ void FixIPI::initial_integrate(int /*vflag*/)
   // ensures continuity of trajectories relative to the
   // snapshot at neighbor list creation, minimizing the
   // number of neighbor list updates
-  auto xhold = neighbor->get_xhold();
+  auto *xhold = neighbor->get_xhold();
   if (xhold != nullptr && !firsttime) {
     // don't wrap if xhold is not used in the NL, or the
     // first call (because the NL is initialized from the
@@ -461,7 +461,7 @@ void FixIPI::final_integrate()
 
   int nat=bsize/3;
   double **f= atom->f;
-  auto lbuf = new double[bsize];
+  auto *lbuf = new double[bsize];
 
   // reassembles the force vector from the local arrays
   int nlocal = atom->nlocal;

--- a/src/MISC/fix_srp.cpp
+++ b/src/MISC/fix_srp.cpp
@@ -116,7 +116,7 @@ void FixSRP::init()
   // because this fix's pre_exchange() creates per-atom data structure
   // that data must be current for atom migration to carry it along
 
-  for (auto &ifix : modify->get_fix_list()) {
+  for (const auto &ifix : modify->get_fix_list()) {
     if (ifix == this) break;
     if (ifix->pre_exchange_migrate)
       error->all(FLERR,"Fix {} comes after a fix which migrates atoms in pre_exchange", style);
@@ -604,7 +604,7 @@ void FixSRP::write_restart(FILE *fp)
 void FixSRP::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
 
   comm->cutghostuser = static_cast<double> (list[n++]);
   btype = static_cast<int> (list[n++]);

--- a/src/ML-HDNNP/pair_hdnnp.cpp
+++ b/src/ML-HDNNP/pair_hdnnp.cpp
@@ -319,7 +319,7 @@ void PairHDNNP::handleExtrapolationWarnings()
           MPI_Status ms;
           // Get buffer size.
           MPI_Recv(&bs, 1, MPI_LONG, i, 0, world, &ms);
-          auto buf = new char[bs];
+          auto *buf = new char[bs];
           // Receive buffer.
           MPI_Recv(buf, bs, MPI_BYTE, i, 0, world, &ms);
           interface->extractEWBuffer(buf, bs);
@@ -331,7 +331,7 @@ void PairHDNNP::handleExtrapolationWarnings()
       // Get desired buffer length for all extrapolation warning entries.
       long bs = interface->getEWBufferSize();
       // Allocate and fill buffer.
-      auto buf = new char[bs];
+      auto *buf = new char[bs];
       interface->fillEWBuffer(buf, bs);
       // Send buffer size and buffer.
       MPI_Send(&bs, 1, MPI_LONG, 0, 0, world);

--- a/src/ML-IAP/mliap_so3.cpp
+++ b/src/ML-IAP/mliap_so3.cpp
@@ -367,16 +367,16 @@ void MLIAP_SO3::compute_W(int nmax, double *arr)
   }
 
   int i, j, k, n = nmax;
-  auto outeig = new double[n];
-  auto outeigvec = new double[n * n];
-  auto arrinv = new double[n * n];
+  auto *outeig = new double[n];
+  auto *outeigvec = new double[n * n];
+  auto *arrinv = new double[n * n];
 
-  auto sqrtD = new double[n * n];
-  auto tempM = new double[n * n];
+  auto *sqrtD = new double[n * n];
+  auto *tempM = new double[n * n];
 
-  auto temparr = new double *[n];
-  auto tempvl = new double *[n];
-  auto tempout = new double[n];
+  auto *temparr = new double *[n];
+  auto *tempvl = new double *[n];
+  auto *tempout = new double[n];
 
   int info;
 

--- a/src/ML-IAP/mliap_unified.cpp
+++ b/src/ML-IAP/mliap_unified.cpp
@@ -211,8 +211,8 @@ MLIAPBuildUnified_t LAMMPS_NS::build_unified(char *unified_fname, MLIAPData *dat
   }
 
   // Connect dummy model, dummy descriptor, data to Python unified
-  MLIAPDummyModel *model = new MLIAPDummyModel(lmp, coefffilename);
-  MLIAPDummyDescriptor *descriptor = new MLIAPDummyDescriptor(lmp);
+  auto *model = new MLIAPDummyModel(lmp, coefffilename);
+  auto *descriptor = new MLIAPDummyDescriptor(lmp);
 
   PyObject *unified_interface = mliap_unified_connect(unified_fname, model, descriptor);
   if (PyErr_Occurred()) {

--- a/src/ML-POD/fitpod_command.cpp
+++ b/src/ML-POD/fitpod_command.cpp
@@ -797,9 +797,9 @@ std::vector<int> FitPOD::linspace(int start_in, int end_in, int num_in)
 
   std::vector<int> linspaced;
 
-  double start = static_cast<double>(start_in);
-  double end = static_cast<double>(end_in);
-  double num = static_cast<double>(num_in);
+  auto start = static_cast<double>(start_in);
+  auto end = static_cast<double>(end_in);
+  auto num = static_cast<double>(num_in);
 
   int elm;
 

--- a/src/MOLECULE/angle_table.cpp
+++ b/src/MOLECULE/angle_table.cpp
@@ -571,7 +571,7 @@ void AngleTable::spline(double *x, double *y, int n, double yp1, double ypn, dou
 {
   int i, k;
   double p, qn, sig, un;
-  auto u = new double[n];
+  auto *u = new double[n];
 
   if (yp1 > 0.99e300)
     y2[0] = u[0] = 0.0;

--- a/src/MOLECULE/bond_table.cpp
+++ b/src/MOLECULE/bond_table.cpp
@@ -529,7 +529,7 @@ void BondTable::spline(double *x, double *y, int n, double yp1, double ypn, doub
 {
   int i, k;
   double p, qn, sig, un;
-  auto u = new double[n];
+  auto *u = new double[n];
 
   if (yp1 > 0.99e300)
     y2[0] = u[0] = 0.0;

--- a/src/MOLECULE/dihedral_charmm.cpp
+++ b/src/MOLECULE/dihedral_charmm.cpp
@@ -350,7 +350,7 @@ void DihedralCharmm::coeff(int narg, char **arg)
 void DihedralCharmm::init_style()
 {
   if (utils::strmatch(update->integrate_style, "^respa")) {
-    auto r = dynamic_cast<Respa *>(update->integrate);
+    auto *r = dynamic_cast<Respa *>(update->integrate);
     if (r->level_pair >= 0 && (r->level_pair != r->level_dihedral))
       error->all(FLERR, "Dihedral style charmm must be set to same r-RESPA level as 'pair'");
     if (r->level_outer >= 0 && (r->level_outer != r->level_dihedral))

--- a/src/MOLECULE/dihedral_charmmfsw.cpp
+++ b/src/MOLECULE/dihedral_charmmfsw.cpp
@@ -369,7 +369,7 @@ void DihedralCharmmfsw::coeff(int narg, char **arg)
 void DihedralCharmmfsw::init_style()
 {
   if (utils::strmatch(update->integrate_style, "^respa")) {
-    auto r = dynamic_cast<Respa *>(update->integrate);
+    auto *r = dynamic_cast<Respa *>(update->integrate);
     if (r->level_pair >= 0 && (r->level_pair != r->level_dihedral))
       error->all(FLERR, "Dihedral style charmmfsw must be set to same r-RESPA level as 'pair'");
     if (r->level_outer >= 0 && (r->level_outer != r->level_dihedral))
@@ -405,9 +405,9 @@ void DihedralCharmmfsw::init_style()
 
   int itmp;
   int *p_dihedflag = (int *) force->pair->extract("dihedflag", itmp);
-  auto p_cutljinner = (double *) force->pair->extract("cut_lj_inner", itmp);
-  auto p_cutlj = (double *) force->pair->extract("cut_lj", itmp);
-  auto p_cutcoul = (double *) force->pair->extract("cut_coul", itmp);
+  auto *p_cutljinner = (double *) force->pair->extract("cut_lj_inner", itmp);
+  auto *p_cutlj = (double *) force->pair->extract("cut_lj", itmp);
+  auto *p_cutcoul = (double *) force->pair->extract("cut_coul", itmp);
 
   if (p_cutcoul == nullptr || p_cutljinner == nullptr || p_cutlj == nullptr ||
       p_dihedflag == nullptr)

--- a/src/MOLECULE/dihedral_table.cpp
+++ b/src/MOLECULE/dihedral_table.cpp
@@ -78,11 +78,11 @@ static int solve_cyc_tridiag( const double diag[], size_t d_stride,
                               size_t N, Error *error)
 {
   int status = GSL_SUCCESS;
-  auto  delta = (double *) malloc (N * sizeof (double));
-  auto  gamma = (double *) malloc (N * sizeof (double));
-  auto  alpha = (double *) malloc (N * sizeof (double));
-  auto  c = (double *) malloc (N * sizeof (double));
-  auto  z = (double *) malloc (N * sizeof (double));
+  auto *  delta = (double *) malloc (N * sizeof (double));
+  auto *  gamma = (double *) malloc (N * sizeof (double));
+  auto *  alpha = (double *) malloc (N * sizeof (double));
+  auto *  c = (double *) malloc (N * sizeof (double));
+  auto *  z = (double *) malloc (N * sizeof (double));
 
   if (delta == nullptr || gamma == nullptr || alpha == nullptr || c == nullptr || z == nullptr) {
     error->one(FLERR, "Internal Cyclic Spline Error: failed to allocate work space");
@@ -188,9 +188,9 @@ static int cyc_spline(double const *xa, double const *ya, int n,
                       double period, double *y2a, Error *error)
 {
 
-  auto diag    = new double[n];
-  auto offdiag = new double[n];
-  auto rhs     = new double[n];
+  auto *diag    = new double[n];
+  auto *offdiag = new double[n];
+  auto *rhs     = new double[n];
   double xa_im1, xa_ip1;
 
   // In the cyclic case, there are n equations with n unknows.
@@ -787,9 +787,9 @@ void DihedralTable::coeff(int narg, char **arg)
   // We also want the angles to be sorted in increasing order.
   // This messy code fixes these problems with the user's data:
   {
-    auto phifile_tmp = new double[tb->ninput];  //temporary arrays
-    auto ffile_tmp = new double[tb->ninput];  //used for sorting
-    auto efile_tmp = new double[tb->ninput];
+    auto *phifile_tmp = new double[tb->ninput];  //temporary arrays
+    auto *ffile_tmp = new double[tb->ninput];  //used for sorting
+    auto *efile_tmp = new double[tb->ninput];
 
     // After re-imaging, does the range of angles cross the 0 or 2*PI boundary?
     // If so, find the discontinuity:

--- a/src/MOLFILE/molfile_interface.cpp
+++ b/src/MOLFILE/molfile_interface.cpp
@@ -46,7 +46,7 @@ extern "C" {
   // callback function for plugin registration.
   static int plugin_register_cb(void *v, vmdplugin_t *p)
   {
-    auto r = static_cast<plugin_reginfo_t *>(v);
+    auto *r = static_cast<plugin_reginfo_t *>(v);
     // make sure we have the proper plugin type (native reader)
     // for the desired file type (called "name" at this level)
     if ((strcmp(MOLFILE_PLUGIN_TYPE,p->type) == 0)
@@ -213,7 +213,7 @@ MolfileInterface::~MolfileInterface()
   forget_plugin();
 
   if (_info) {
-    auto a = static_cast<molfile_atom_t *>(_info);
+    auto *a = static_cast<molfile_atom_t *>(_info);
     delete[] a;
     _info = nullptr;
   }
@@ -277,7 +277,7 @@ int MolfileInterface::load_plugin(const char *filename)
   ((regfunc)rfunc)(&reginfo, plugin_register_cb);
 
   // make some checks to see if the plugin is suitable or not.
-  auto plugin = static_cast<molfile_plugin_t *>(reginfo.p);
+  auto *plugin = static_cast<molfile_plugin_t *>(reginfo.p);
 
   // if the callback found a matching plugin and copied the struct,
   // its name element will point to a different location now.
@@ -395,7 +395,7 @@ int MolfileInterface::open(const char *name, int *natoms)
 {
   if (!_plugin || !_dso || !natoms)
     return E_FILE;
-  auto p = static_cast<molfile_plugin_t *>(_plugin);
+  auto *p = static_cast<molfile_plugin_t *>(_plugin);
 
   if (_mode & M_WRITE)
     _ptr = p->open_file_write(name,_type,*natoms);
@@ -409,7 +409,7 @@ int MolfileInterface::open(const char *name, int *natoms)
   // we need to deal with structure information,
   // so we allocate and initialize storage for it.
   if (_mode & (M_RSTRUCT|M_WSTRUCT)) {
-    auto a = new molfile_atom_t[_natoms];
+    auto *a = new molfile_atom_t[_natoms];
     _info = a;
     memset(_info,0,_natoms*sizeof(molfile_atom_t));
     for (int i=0; i < _natoms; ++i) {
@@ -428,7 +428,7 @@ int MolfileInterface::structure()
 {
   if (!_plugin || !_dso)
     return E_FILE;
-  auto p = static_cast<molfile_plugin_t *>(_plugin);
+  auto *p = static_cast<molfile_plugin_t *>(_plugin);
 
   int optflags = MOLFILE_NOOPTIONS;
 
@@ -440,10 +440,10 @@ int MolfileInterface::structure()
     optflags |= (_props & P_RADS) ? MOLFILE_RADIUS : 0;
     optflags |= (_props & P_ATMN) ? MOLFILE_ATOMICNUMBER : 0;
 
-    auto a = static_cast<molfile_atom_t *>(_info);
+    auto *a = static_cast<molfile_atom_t *>(_info);
     p->write_structure(_ptr,optflags,a);
   } else if (_mode & M_RSTRUCT) {
-    auto a = static_cast<molfile_atom_t *>(_info);
+    auto *a = static_cast<molfile_atom_t *>(_info);
     p->read_structure(_ptr,&optflags,a);
     // mandatory properties
     _props = P_NAME|P_TYPE|P_RESN|P_RESI|P_SEGN|P_CHAI;
@@ -464,7 +464,7 @@ int MolfileInterface::close()
   if (!_plugin || !_dso || !_ptr)
     return E_FILE;
 
-  auto p = static_cast<molfile_plugin_t *>(_plugin);
+  auto *p = static_cast<molfile_plugin_t *>(_plugin);
 
   if (_mode & M_WRITE) {
     p->close_file_write(_ptr);
@@ -473,7 +473,7 @@ int MolfileInterface::close()
   }
 
   if (_info) {
-    auto a = static_cast<molfile_atom_t *>(_info);
+    auto *a = static_cast<molfile_atom_t *>(_info);
     delete[] a;
     _info = nullptr;
   }
@@ -491,8 +491,8 @@ int MolfileInterface::timestep(float *coords, float *vels,
   if (!_plugin || !_dso || !_ptr)
     return 1;
 
-  auto p = static_cast<molfile_plugin_t *>(_plugin);
-  auto t = new molfile_timestep_t;
+  auto *p = static_cast<molfile_plugin_t *>(_plugin);
+  auto *t = new molfile_timestep_t;
   int rv;
 
   if (_mode & M_WRITE) {
@@ -707,7 +707,7 @@ int MolfileInterface::property(int propid, int idx, float *prop)
   if ((_info == nullptr) || (prop == nullptr) || (idx < 0) || (idx >= _natoms))
     return P_NONE;
 
-  auto a = static_cast<molfile_atom_t *>(_info);
+  auto *a = static_cast<molfile_atom_t *>(_info);
 
   if (_mode & M_WSTRUCT)
     _props |= write_atom_property(a[idx], propid, *prop);
@@ -724,7 +724,7 @@ int MolfileInterface::property(int propid, int *types, float *prop)
   if ((_info == nullptr) || (types == nullptr) || (prop == nullptr))
     return P_NONE;
 
-  auto a = static_cast<molfile_atom_t *>(_info);
+  auto *a = static_cast<molfile_atom_t *>(_info);
 
   if (_mode & M_WSTRUCT) {
     for (int i=0; i < _natoms; ++i)
@@ -744,7 +744,7 @@ int MolfileInterface::property(int propid, float *prop)
   if ((_info == nullptr) || (prop == nullptr))
     return P_NONE;
 
-  auto a = static_cast<molfile_atom_t *>(_info);
+  auto *a = static_cast<molfile_atom_t *>(_info);
 
   if (_mode & M_WSTRUCT) {
     for (int i=0; i < _natoms; ++i)
@@ -765,7 +765,7 @@ int MolfileInterface::property(int propid, int idx, double *prop)
   if ((_info == nullptr) || (prop == nullptr) || (idx < 0) || (idx >= _natoms))
     return P_NONE;
 
-  auto a = static_cast<molfile_atom_t *>(_info);
+  auto *a = static_cast<molfile_atom_t *>(_info);
 
   if (_mode & M_WSTRUCT)
     return write_atom_property(a[idx], propid, *prop);
@@ -782,7 +782,7 @@ int MolfileInterface::property(int propid, int *types, double *prop)
   if ((_info == nullptr) || (types == nullptr) || (prop == nullptr))
     return P_NONE;
 
-  auto a = static_cast<molfile_atom_t *>(_info);
+  auto *a = static_cast<molfile_atom_t *>(_info);
 
   if (_mode & M_WSTRUCT) {
     for (int i=0; i < _natoms; ++i)
@@ -802,7 +802,7 @@ int MolfileInterface::property(int propid, double *prop)
   if ((_info == nullptr) || (prop == nullptr))
     return P_NONE;
 
-  auto a = static_cast<molfile_atom_t *>(_info);
+  auto *a = static_cast<molfile_atom_t *>(_info);
 
   if (_mode & M_WSTRUCT) {
     for (int i=0; i < _natoms; ++i)
@@ -837,7 +837,7 @@ int MolfileInterface::property(int propid, int idx, int *prop)
   if ((_info == nullptr) || (prop == nullptr) || (idx < 0) || (idx >= _natoms))
     return P_NONE;
 
-  auto a = static_cast<molfile_atom_t *>(_info);
+  auto *a = static_cast<molfile_atom_t *>(_info);
 
   if (_mode & M_WSTRUCT) {
     char buf[64];
@@ -862,7 +862,7 @@ int MolfileInterface::property(int propid, int *types, int *prop)
   if ((_info == nullptr) || (types == nullptr) || (prop == nullptr))
     return P_NONE;
 
-  auto a = static_cast<molfile_atom_t *>(_info);
+  auto *a = static_cast<molfile_atom_t *>(_info);
 
   if (_mode & M_WSTRUCT) {
     char buf[64];
@@ -891,7 +891,7 @@ int MolfileInterface::property(int propid, int *prop)
   if ((_info == nullptr) || (prop == nullptr))
     return P_NONE;
 
-  auto a = static_cast<molfile_atom_t *>(_info);
+  auto *a = static_cast<molfile_atom_t *>(_info);
 
   if (_mode & M_WSTRUCT) {
     char buf[64];
@@ -922,7 +922,7 @@ int MolfileInterface::property(int propid, int idx, char *prop)
   if ((_info == nullptr) || (prop == nullptr) || (idx < 0) || (idx >= _natoms))
     return P_NONE;
 
-  auto a = static_cast<molfile_atom_t *>(_info);
+  auto *a = static_cast<molfile_atom_t *>(_info);
 
   if (_mode & M_WSTRUCT) {
     _props |= write_atom_property(a[idx], propid, prop);
@@ -940,7 +940,7 @@ int MolfileInterface::property(int propid, int *types, char **prop)
   if ((_info == nullptr) || (types == nullptr) || (prop == nullptr))
     return P_NONE;
 
-  auto a = static_cast<molfile_atom_t *>(_info);
+  auto *a = static_cast<molfile_atom_t *>(_info);
 
   if (_mode & M_WSTRUCT) {
     for (int i=0; i < _natoms; ++i) {
@@ -961,7 +961,7 @@ int MolfileInterface::property(int propid, char **prop)
   if ((_info == nullptr) || (prop == nullptr))
     return P_NONE;
 
-  auto a = static_cast<molfile_atom_t *>(_info);
+  auto *a = static_cast<molfile_atom_t *>(_info);
 
   if (_mode & M_WSTRUCT) {
     for (int i=0; i < _natoms; ++i) {

--- a/src/OPENMP/fix_nvt_sllod_omp.cpp
+++ b/src/OPENMP/fix_nvt_sllod_omp.cpp
@@ -91,7 +91,7 @@ void FixNVTSllodOMP::init()
   if (deform.size() < 1) error->all(FLERR,"Using fix nvt/sllod/omp with no fix deform defined");
 
   for (auto &ifix : deform) {
-    auto f = dynamic_cast<FixDeform *>(ifix);
+    auto *f = dynamic_cast<FixDeform *>(ifix);
     if (f && (f->remapflag != Domain::V_REMAP))
       error->all(FLERR,"Using fix nvt/sllod/omp with inconsistent fix deform remap option");
   }

--- a/src/OPENMP/fix_omp.cpp
+++ b/src/OPENMP/fix_omp.cpp
@@ -129,7 +129,7 @@ FixOMP::FixOMP(LAMMPS *lmp, int narg, char **arg)
 #endif
   {
     const int tid = get_tid();
-    auto t = new Timer(lmp);
+    auto *t = new Timer(lmp);
     thr[tid] = new ThrData(tid,t);
   }
 }
@@ -184,7 +184,7 @@ void FixOMP::init()
 #endif
     {
       const int tid = get_tid();
-      auto t = new Timer(lmp);
+      auto *t = new Timer(lmp);
       thr[tid] = new ThrData(tid,t);
     }
   }

--- a/src/OPENMP/pair_gran_hertz_history_omp.cpp
+++ b/src/OPENMP/pair_gran_hertz_history_omp.cpp
@@ -57,7 +57,7 @@ void PairGranHertzHistoryOMP::compute(int eflag, int vflag)
   if (fix_rigid && neighbor->ago == 0) {
     int tmp;
     int *body = (int *) fix_rigid->extract("body",tmp);
-    auto mass_body = (double *) fix_rigid->extract("masstotal",tmp);
+    auto *mass_body = (double *) fix_rigid->extract("masstotal",tmp);
     if (atom->nmax > nmax) {
       memory->destroy(mass_rigid);
       nmax = atom->nmax;

--- a/src/OPENMP/pair_gran_hooke_history_omp.cpp
+++ b/src/OPENMP/pair_gran_hooke_history_omp.cpp
@@ -54,7 +54,7 @@ void PairGranHookeHistoryOMP::compute(int eflag, int vflag)
   if (fix_rigid && neighbor->ago == 0) {
     int tmp;
     int *body = (int *) fix_rigid->extract("body",tmp);
-    auto mass_body = (double *) fix_rigid->extract("masstotal",tmp);
+    auto *mass_body = (double *) fix_rigid->extract("masstotal",tmp);
     if (atom->nmax > nmax) {
       memory->destroy(mass_rigid);
       nmax = atom->nmax;

--- a/src/OPENMP/pair_gran_hooke_omp.cpp
+++ b/src/OPENMP/pair_gran_hooke_omp.cpp
@@ -53,7 +53,7 @@ void PairGranHookeOMP::compute(int eflag, int vflag)
   if (fix_rigid && neighbor->ago == 0) {
     int tmp;
     int *body = (int *) fix_rigid->extract("body",tmp);
-    auto mass_body = (double *) fix_rigid->extract("masstotal",tmp);
+    auto *mass_body = (double *) fix_rigid->extract("masstotal",tmp);
     if (atom->nmax > nmax) {
       memory->destroy(mass_rigid);
       nmax = atom->nmax;

--- a/src/OPENMP/pair_hbond_dreiding_lj_angleoffset_omp.cpp
+++ b/src/OPENMP/pair_hbond_dreiding_lj_angleoffset_omp.cpp
@@ -49,7 +49,7 @@ PairHbondDreidingLJAngleoffsetOMP::PairHbondDreidingLJAngleoffsetOMP(LAMMPS *lmp
 
 void PairHbondDreidingLJAngleoffsetOMP::coeff(int narg, char **arg)
 {
-  auto mylmp = PairHbondDreidingLJ::lmp;
+  auto *mylmp = PairHbondDreidingLJ::lmp;
   if (narg < 6 || narg > 11)
     error->all(FLERR,"Incorrect args for pair coefficients" + utils::errorurl(21));
   if (!allocated) allocate();

--- a/src/OPENMP/pair_hbond_dreiding_morse_angleoffset_omp.cpp
+++ b/src/OPENMP/pair_hbond_dreiding_morse_angleoffset_omp.cpp
@@ -49,7 +49,7 @@ PairHbondDreidingMorseAngleoffsetOMP::PairHbondDreidingMorseAngleoffsetOMP(LAMMP
 
 void PairHbondDreidingMorseAngleoffsetOMP::coeff(int narg, char **arg)
 {
-  auto mylmp = PairHbondDreidingMorse::lmp;
+  auto *mylmp = PairHbondDreidingMorse::lmp;
   if (narg < 7 || narg > 12)
     error->all(FLERR,"Incorrect args for pair coefficients" + utils::errorurl(21));
   if (!allocated) allocate();

--- a/src/OPENMP/pair_lj_cut_coul_debye_dielectric_omp.cpp
+++ b/src/OPENMP/pair_lj_cut_coul_debye_dielectric_omp.cpp
@@ -100,7 +100,7 @@ void PairLJCutCoulDebyeDielectricOMP::eval(int iifrom, int iito, ThrData *const 
   evdwl = ecoul = 0.0;
 
   const dbl3_t *_noalias const x = (dbl3_t *) atom->x[0];
-  dbl3_t *_noalias const f = (dbl3_t *) thr->get_f()[0];
+  auto *_noalias const f = (dbl3_t *) thr->get_f()[0];
   const double *_noalias const q = atom->q_scaled;
   const double *_noalias const eps = atom->epsilon;
   const dbl3_t *_noalias const norm = (dbl3_t *) atom->mu[0];

--- a/src/OPENMP/pair_meam_spline_omp.cpp
+++ b/src/OPENMP/pair_meam_spline_omp.cpp
@@ -100,7 +100,7 @@ void PairMEAMSplineOMP::eval(int iifrom, int iito, ThrData * const thr)
   }
 
   // Allocate array for temporary bond info.
-  auto myTwoBodyInfo = new MEAM2Body[myMaxNeighbors];
+  auto *myTwoBodyInfo = new MEAM2Body[myMaxNeighbors];
 
   const double * const * const x = atom->x;
   double * const * const forces = thr->get_f();

--- a/src/OPENMP/pair_reaxff_omp.cpp
+++ b/src/OPENMP/pair_reaxff_omp.cpp
@@ -439,7 +439,7 @@ int PairReaxFFOMP::write_reax_lists()
 #endif
   for (int itr_i = 0; itr_i < numall; ++itr_i) {
     int i = ilist[itr_i];
-    auto jlist = firstneigh[i];
+    auto *jlist = firstneigh[i];
     Set_Start_Index(i, num_nbrs_offset[i], far_nbrs);
 
     if (i < inum)

--- a/src/OPENMP/reaxff_bond_orders_omp.cpp
+++ b/src/OPENMP/reaxff_bond_orders_omp.cpp
@@ -44,7 +44,7 @@ namespace ReaxFF {
     dbond_coefficients coef;
     int pk, k, j;
 
-    auto pair_reax_ptr = static_cast<class PairReaxFFOMP*>(system->pair_ptr);
+    auto *pair_reax_ptr = static_cast<class PairReaxFFOMP*>(system->pair_ptr);
 
     int tid = get_tid();
     ThrData *thr = pair_reax_ptr->getFixOMP()->get_thr(tid);

--- a/src/OPENMP/reaxff_init_md_omp.cpp
+++ b/src/OPENMP/reaxff_init_md_omp.cpp
@@ -42,7 +42,7 @@ namespace ReaxFF {
     int mincap = system->mincap;
     double safezone = system->safezone;
     double saferzone = system->saferzone;
-    auto error = system->error_ptr;
+    auto *error = system->error_ptr;
 
     bond_top = (int*) calloc(system->total_cap, sizeof(int));
     hb_top = (int*) calloc(system->local_cap, sizeof(int));

--- a/src/OPENMP/thr_omp.cpp
+++ b/src/OPENMP/thr_omp.cpp
@@ -210,7 +210,7 @@ void ThrOMP::reduce_thr(void *style, const int eflag, const int vflag,
     }
 
     if (evflag) {
-      auto  const pair = (Pair *)style;
+      auto *const   pair = (Pair *)style;
 
 #if defined(_OPENMP)
 #pragma omp critical

--- a/src/ORIENT/fix_orient_bcc.cpp
+++ b/src/ORIENT/fix_orient_bcc.cpp
@@ -567,8 +567,8 @@ void FixOrientBCC::find_best_ref(double *displs, int which_crystal,
 
 int FixOrientBCC::compare(const void *pi, const void *pj)
 {
-  auto ineigh = (FixOrientBCC::Sort *) pi;
-  auto jneigh = (FixOrientBCC::Sort *) pj;
+  auto *ineigh = (FixOrientBCC::Sort *) pi;
+  auto *jneigh = (FixOrientBCC::Sort *) pj;
 
   if (ineigh->rsq < jneigh->rsq) return -1;
   else if (ineigh->rsq > jneigh->rsq) return 1;

--- a/src/ORIENT/fix_orient_fcc.cpp
+++ b/src/ORIENT/fix_orient_fcc.cpp
@@ -564,8 +564,8 @@ void FixOrientFCC::find_best_ref(double *displs, int which_crystal,
 
 int FixOrientFCC::compare(const void *pi, const void *pj)
 {
-  auto ineigh = (FixOrientFCC::Sort *) pi;
-  auto jneigh = (FixOrientFCC::Sort *) pj;
+  auto *ineigh = (FixOrientFCC::Sort *) pi;
+  auto *jneigh = (FixOrientFCC::Sort *) pj;
 
   if (ineigh->rsq < jneigh->rsq) return -1;
   else if (ineigh->rsq > jneigh->rsq) return 1;

--- a/src/PERI/atom_vec_peri.cpp
+++ b/src/PERI/atom_vec_peri.cpp
@@ -88,7 +88,7 @@ void AtomVecPeri::grow_pointers()
 
 void AtomVecPeri::create_atom_post(int ilocal)
 {
-  const auto xinit = atom->x;
+  auto *const xinit = atom->x;
   vfrac[ilocal] = 1.0;
   rmass[ilocal] = 1.0;
   s0[ilocal] = DBL_MAX;
@@ -104,7 +104,7 @@ void AtomVecPeri::create_atom_post(int ilocal)
 
 void AtomVecPeri::data_atom_post(int ilocal)
 {
-  const auto xinit = atom->x;
+  auto *const xinit = atom->x;
   s0[ilocal] = DBL_MAX;
   x0[ilocal][0] = xinit[ilocal][0];
   x0[ilocal][1] = xinit[ilocal][1];

--- a/src/PERI/compute_dilatation_atom.cpp
+++ b/src/PERI/compute_dilatation_atom.cpp
@@ -82,8 +82,8 @@ void ComputeDilatationAtom::compute_peratom()
   // extract dilatation for each atom in group
 
   int tmp;
-  auto anypair = force->pair_match("^peri",0);
-  auto theta = (double *)anypair->extract("theta",tmp);
+  auto *anypair = force->pair_match("^peri",0);
+  auto *theta = (double *)anypair->extract("theta",tmp);
 
   int *mask = atom->mask;
   int nlocal = atom->nlocal;

--- a/src/PERI/fix_peri_neigh.cpp
+++ b/src/PERI/fix_peri_neigh.cpp
@@ -561,7 +561,7 @@ void FixPeriNeigh::write_restart(FILE *fp)
 void FixPeriNeigh::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
 
   first = static_cast<int> (list[n++]);
   maxpartner = static_cast<int> (list[n++]);

--- a/src/PHONON/dynamical_matrix.cpp
+++ b/src/PHONON/dynamical_matrix.cpp
@@ -269,11 +269,11 @@ void DynamicalMatrix::calculateMatrix()
   double *m = atom->mass;
   double **f = atom->f;
 
-  auto dynmat = new double*[3];
+  auto *dynmat = new double*[3];
   for (int i=0; i<3; i++)
     dynmat[i] = new double[dynlenb];
 
-  auto fdynmat = new double*[3];
+  auto *fdynmat = new double*[3];
   for (int i=0; i<3; i++)
     fdynmat[i] = new double[dynlenb];
 
@@ -574,7 +574,7 @@ void DynamicalMatrix::create_groupmap()
   bigint natoms = atom->natoms;
   int *recv = new int[comm->nprocs];
   int *displs = new int[comm->nprocs];
-  auto temp_groupmap = new bigint[natoms];
+  auto *temp_groupmap = new bigint[natoms];
 
   //find number of local atoms in the group (final_gid)
   for (bigint i=1; i<=natoms; i++) {
@@ -583,7 +583,7 @@ void DynamicalMatrix::create_groupmap()
       gid += 1; // gid at the end of loop is final_Gid
   }
   //create an array of length final_gid
-  auto sub_groupmap = new bigint[gid];
+  auto *sub_groupmap = new bigint[gid];
 
   gid = 0;
   //create a map between global atom id and group atom id for each proc

--- a/src/PHONON/fix_phonon.cpp
+++ b/src/PHONON/fix_phonon.cpp
@@ -672,7 +672,7 @@ void FixPhonon::postprocess( )
 
   // to get Phi = KT.G^-1; normalization of FFTW data is done here
   double boltz = force->boltz, TempAve = 0.;
-  auto kbtsqrt = new double[sysdim];
+  auto *kbtsqrt = new double[sysdim];
   double TempFac = inv_neval * inv_nTemp;
   double NormFac = TempFac * double(ntotal);
 
@@ -696,7 +696,7 @@ void FixPhonon::postprocess( )
   MPI_Gatherv(Phi_q[0],mynq*fft_dim2*2,MPI_DOUBLE,Phi_all[0],recvcnts,displs,MPI_DOUBLE,0,world);
 
   // to collect all basis info and averaged it on root
-  auto basis_root = new double[fft_dim];
+  auto *basis_root = new double[fft_dim];
   if (fft_dim > sysdim) MPI_Reduce(&basis[1][0], &basis_root[sysdim], fft_dim-sysdim, MPI_DOUBLE, MPI_SUM, 0, world);
 
   if (me == 0) { // output dynamic matrix by root

--- a/src/PHONON/third_order.cpp
+++ b/src/PHONON/third_order.cpp
@@ -286,8 +286,8 @@ void ThirdOrder::calculateMatrix()
   bigint j;
   bigint *firstneigh;
 
-  auto dynmat = new double[dynlenb];
-  auto fdynmat = new double[dynlenb];
+  auto *dynmat = new double[dynlenb];
+  auto *fdynmat = new double[dynlenb];
   memset(&dynmat[0],0,dynlenb*sizeof(double));
   memset(&fdynmat[0],0,dynlenb*sizeof(double));
 
@@ -618,7 +618,7 @@ void ThirdOrder::create_groupmap()
   bigint natoms = atom->natoms;
   int *recv = new int[comm->nprocs];
   int *displs = new int[comm->nprocs];
-  auto temp_groupmap = new bigint[natoms];
+  auto *temp_groupmap = new bigint[natoms];
 
   //find number of local atoms in the group (final_gid)
   for (bigint i=1; i<=natoms; i++) {
@@ -627,7 +627,7 @@ void ThirdOrder::create_groupmap()
       gid += 1; // gid at the end of loop is final_Gid
   }
   //create an array of length final_gid
-  auto sub_groupmap = new bigint[gid];
+  auto *sub_groupmap = new bigint[gid];
 
   gid = 0;
   //create a map between global atom id and group atom id for each proc
@@ -715,8 +715,8 @@ void ThirdOrder::getNeighbortags() {
   }
 
   bigint nbytes = ((bigint) sizeof(bigint)) * sum;
-  auto data = (bigint *) memory->smalloc(nbytes, "thirdorder:firsttags");
-  auto datarecv = (bigint *) memory->smalloc(nbytes, "thirdorder:neighbortags");
+  auto *data = (bigint *) memory->smalloc(nbytes, "thirdorder:firsttags");
+  auto *datarecv = (bigint *) memory->smalloc(nbytes, "thirdorder:neighbortags");
   nbytes = ((bigint) sizeof(bigint *)) * natoms;
   firsttags = (bigint **) memory->smalloc(nbytes, "thirdorder:firsttags");
   neighbortags = (bigint **) memory->smalloc(nbytes, "thirdorder:neighbortags");

--- a/src/POEMS/fix_poems.cpp
+++ b/src/POEMS/fix_poems.cpp
@@ -354,7 +354,7 @@ void FixPOEMS::init()
 
   if (earlyflag) {
     bool pflag = false;
-    for (auto &ifix : modify->get_fix_list()) {
+    for (const auto &ifix : modify->get_fix_list()) {
       if (utils::strmatch(ifix->style, "^poems")) pflag = true;
       if (pflag && (ifix->setmask() & POST_FORCE) && !ifix->rigid_flag)
         if (comm->me == 0)
@@ -365,7 +365,7 @@ void FixPOEMS::init()
 
   // error if npt,nph fix comes before rigid fix
   bool pflag = false;
-  for (auto &ifix : modify->get_fix_list()) {
+  for (const auto &ifix : modify->get_fix_list()) {
     if (!pflag && utils::strmatch(ifix->style, "np[th]"))
       error->all(FLERR, "POEMS fix must come before NPT/NPH fix");
     if (utils::strmatch(ifix->style, "^poems")) pflag = true;
@@ -942,7 +942,7 @@ void FixPOEMS::readfile(const char *file)
   nbody = bodies.size();
   MPI_Bcast(&nbody, 1, MPI_INT, 0, world);
   MPI_Bcast(&maxbody, 1, MPI_INT, 0, world);
-  bigint *buf = new bigint[maxbody + 1];
+  auto *buf = new bigint[maxbody + 1];
   const int nlocal = atom->nlocal;
 
   for (int i = 0; i < nbody; ++i) {

--- a/src/PTM/compute_ptm_atom.cpp
+++ b/src/PTM/compute_ptm_atom.cpp
@@ -125,7 +125,7 @@ ComputePTMAtom::ComputePTMAtom(LAMMPS *lmp, int narg, char **arg)
   if (rmsd_threshold == 0)
     rmsd_threshold = INFINITY;
 
-  auto  group_name = (char *)"all";
+  auto *  group_name = (char *)"all";
   if (narg > 5) {
     group_name = arg[5];
   }
@@ -191,7 +191,7 @@ static bool sorthelper_compare(ptmnbr_t const &a, ptmnbr_t const &b) {
 
 static int get_neighbours(void* vdata, size_t central_index, size_t atom_index, int num, size_t* nbr_indices, int32_t* numbers, double (*nbr_pos)[3])
 {
-  auto  data = (ptmnbrdata_t*)vdata;
+  auto *  data = (ptmnbrdata_t*)vdata;
   int *mask = data->mask;
   int group2bit = data->group2bit;
 

--- a/src/PTM/ptm_neighbour_ordering.cpp
+++ b/src/PTM/ptm_neighbour_ordering.cpp
@@ -179,7 +179,7 @@ static int _calculate_neighbour_ordering(void* _voronoi_handle, int num_points, 
 {
         assert(num_points <= PTM_MAX_INPUT_POINTS);
 
-        auto  voronoi_handle = (ptm_voro::voronoicell_neighbor*)_voronoi_handle;
+        auto *  voronoi_handle = (ptm_voro::voronoicell_neighbor*)_voronoi_handle;
 
         double max_norm = 0;
         double points[PTM_MAX_INPUT_POINTS][3];
@@ -277,13 +277,13 @@ static int find_diamond_neighbours(void* _voronoi_handle, int num_points, double
 
 void* voronoi_initialize_local()
 {
-        auto  ptr = new ptm_voro::voronoicell_neighbor;
+        auto *  ptr = new ptm_voro::voronoicell_neighbor;
         return (void*)ptr;
 }
 
 void voronoi_uninitialize_local(void* _ptr)
 {
-        auto  ptr = (ptm_voro::voronoicell_neighbor*)_ptr;
+        auto *  ptr = (ptm_voro::voronoicell_neighbor*)_ptr;
         delete ptr;
 }
 

--- a/src/PYTHON/pair_python.cpp
+++ b/src/PYTHON/pair_python.cpp
@@ -106,7 +106,7 @@ void PairPython::compute(int eflag, int vflag)
   // prepare access to compute_force and compute_energy functions
 
   PyUtils::GIL lock;
-  auto py_pair_instance = (PyObject *) py_potential;
+  auto *py_pair_instance = (PyObject *) py_potential;
   PyObject *py_compute_force = PyObject_GetAttrString(py_pair_instance,"compute_force");
   if (!py_compute_force) {
     PyUtils::Print_Errors();
@@ -347,8 +347,8 @@ double PairPython::single(int /* i */, int /* j */, int itype, int jtype,
   // prepare access to compute_force and compute_energy functions
 
   PyUtils::GIL lock;
-  auto py_compute_force = (PyObject *) get_member_function("compute_force");
-  auto py_compute_energy = (PyObject *) get_member_function("compute_energy");
+  auto *py_compute_force = (PyObject *) get_member_function("compute_force");
+  auto *py_compute_energy = (PyObject *) get_member_function("compute_energy");
   PyObject *py_compute_args = Py_BuildValue("(dii)", rsq, itype, jtype);
 
   if (!py_compute_args) {
@@ -383,7 +383,7 @@ double PairPython::single(int /* i */, int /* j */, int itype, int jtype,
 void * PairPython::get_member_function(const char * name)
 {
   PyUtils::GIL lock;
-  auto py_pair_instance = (PyObject *) py_potential;
+  auto *py_pair_instance = (PyObject *) py_potential;
   PyObject * py_mfunc = PyObject_GetAttrString(py_pair_instance, name);
   if (!py_mfunc) {
     PyUtils::Print_Errors();

--- a/src/PYTHON/python_impl.cpp
+++ b/src/PYTHON/python_impl.cpp
@@ -315,7 +315,7 @@ void PythonImpl::command(int narg, char **arg)
 
   // pFunc = function object for requested function
 
-  auto pModule = (PyObject *) pyMain;
+  auto *pModule = (PyObject *) pyMain;
   PyObject *pFunc = PyObject_GetAttrString(pModule, pfuncs[ifunc].name);
 
   if (!pFunc) {
@@ -345,7 +345,7 @@ void PythonImpl::invoke_function(int ifunc, char *result, double *dvalue)
   PyObject *pValue;
   char *str;
 
-  auto pFunc = (PyObject *) pfuncs[ifunc].pFunc;
+  auto *pFunc = (PyObject *) pfuncs[ifunc].pFunc;
 
   // create Python tuple of input arguments
 

--- a/src/QEQ/fix_qeq.cpp
+++ b/src/QEQ/fix_qeq.cpp
@@ -272,7 +272,7 @@ void FixQEq::allocate_matrix()
     i = ilist[ii];
     m += numneigh[i];
   }
-  bigint m_cap_big = (bigint)MAX(m * safezone, mincap * MIN_NBRS);
+  auto m_cap_big = (bigint)MAX(m * safezone, mincap * MIN_NBRS);
   if (m_cap_big > MAXSMALLINT)
     error->one(FLERR,"Too many neighbors in fix {}",style);
   m_cap = m_cap_big;

--- a/src/QTB/fix_qbmsst.cpp
+++ b/src/QTB/fix_qbmsst.cpp
@@ -396,7 +396,7 @@ void FixQBMSST::init()
   // detect if any fix rigid exist so rigid bodies move when box is dilated
 
    rfix.clear();
-   for (auto &ifix : modify->get_fix_list())
+   for (const auto &ifix : modify->get_fix_list())
      if (ifix->rigid_flag) rfix.push_back(ifix);
 }
 
@@ -842,7 +842,7 @@ void FixQBMSST::write_restart(FILE *fp)
 void FixQBMSST::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
   omega[direction] = list[n++];
   e0 = list[n++];
   v0 = list[n++];

--- a/src/REACTION/fix_bond_react.cpp
+++ b/src/REACTION/fix_bond_react.cpp
@@ -2764,7 +2764,7 @@ void FixBondReact::dedup_mega_gloves(int dedup_mode)
   // let's randomly mix up our reaction instances first
   // then we can feel okay about ignoring ones we've already deleted (or accepted)
   // based off std::shuffle
-  double *temp_rxn = new double[max_natoms+cuff];
+  auto *temp_rxn = new double[max_natoms+cuff];
   for (int i = dedup_size-1; i > 0; --i) { //dedup_size
     // choose random entry to swap current one with
     int k = floor(random[0]->uniform()*(i+1));
@@ -4291,7 +4291,7 @@ void FixBondReact::ReadConstraints(char *line, int myrxn)
   double tmp[MAXCONARGS];
   char **strargs,*ptr,*lptr;
   memory->create(strargs,MAXCONARGS,MAXLINE,"bond/react:strargs");
-  auto constraint_type = new char[MAXLINE];
+  auto *constraint_type = new char[MAXLINE];
   strcpy(constraintstr[myrxn],"("); // string for boolean constraint logic
   for (int i = 0; i < nconstraints[myrxn]; i++) {
     readline(line);

--- a/src/REAXFF/compute_reaxff_atom.cpp
+++ b/src/REAXFF/compute_reaxff_atom.cpp
@@ -206,7 +206,7 @@ void ComputeReaxFFAtom::compute_local()
   }
 
   size_local_rows = nbonds;
-  auto tag = atom->tag;
+  auto *tag = atom->tag;
 
   int b = 0;
 
@@ -216,7 +216,7 @@ void ComputeReaxFFAtom::compute_local()
     const int numbonds = bondcount[i];
 
     for (int k = 0; k < numbonds; k++) {
-      auto bond = array_local[b++];
+      auto *bond = array_local[b++];
       bond[0] = tag[i];
       bond[1] = neighid[i][k];
       bond[2] = abo[i][k];
@@ -237,7 +237,7 @@ void ComputeReaxFFAtom::compute_peratom()
   const int nlocal = atom->nlocal;
 
   for (int i = 0; i < nlocal; ++i) {
-    auto ptr = array_atom[i];
+    auto *ptr = array_atom[i];
     ptr[0] = reaxff->api->workspace->total_bond_order[i];
     ptr[1] = reaxff->api->workspace->nlp[i];
     ptr[2] = bondcount[i];

--- a/src/REAXFF/fix_qeq_reaxff.cpp
+++ b/src/REAXFF/fix_qeq_reaxff.cpp
@@ -362,7 +362,7 @@ void FixQEqReaxFF::allocate_matrix()
     i = ilist[ii];
     m += numneigh[i];
   }
-  bigint m_cap_big = (bigint)MAX(m * safezone, mincap * REAX_MIN_NBRS);
+  auto m_cap_big = (bigint)MAX(m * safezone, mincap * REAX_MIN_NBRS);
   if (m_cap_big > MAXSMALLINT)
     error->one(FLERR, Error::NOLASTLINE, "Too many neighbors in fix {}",style);
   m_cap = m_cap_big;
@@ -1117,7 +1117,7 @@ void FixQEqReaxFF::get_chi_field()
   memset(&chi_field[0],0,atom->nmax*sizeof(double));
   if (!efield) return;
 
-  const auto x = (const double * const *)atom->x;
+  const auto *const x = (const double * const *)atom->x;
   const int *mask = atom->mask;
   const imageint *image = atom->image;
   const int nlocal = atom->nlocal;

--- a/src/REAXFF/fix_qeq_rel_reaxff.cpp
+++ b/src/REAXFF/fix_qeq_rel_reaxff.cpp
@@ -47,7 +47,7 @@ void FixQEqRelReaxFF::calc_chi_eff()
 {
   memset(&chi_eff[0], 0, atom->nmax * sizeof(double));
 
-  const auto x = (const double *const *) atom->x;
+  const auto *const x = (const double *const *) atom->x;
   const int *type = atom->type;
 
   double dx, dy, dz, dist_sq, overlap, sum_n, sum_d, chia, phia, phib;

--- a/src/REAXFF/pair_reaxff.cpp
+++ b/src/REAXFF/pair_reaxff.cpp
@@ -469,7 +469,7 @@ void PairReaxFF::compute(int eflag, int vflag)
   api->system->N = atom->nlocal + atom->nghost; // mine + ghosts
 
   if (api->system->acks2_flag) {
-    auto ifix = modify->get_fix_by_style("^acks2/reax").front();
+    auto *ifix = modify->get_fix_by_style("^acks2/reax").front();
     api->workspace->s = (dynamic_cast<FixACKS2ReaxFF*>(ifix))->get_s();
   }
 

--- a/src/REAXFF/reaxff_allocate.cpp
+++ b/src/REAXFF/reaxff_allocate.cpp
@@ -62,7 +62,7 @@ namespace ReaxFF {
 
   void DeAllocate_System(reax_system *system)
   {
-    auto memory = system->mem_ptr;
+    auto *memory = system->mem_ptr;
 
     // deallocate the atom list
     sfree(system->my_atoms);
@@ -120,7 +120,7 @@ namespace ReaxFF {
   void Allocate_Workspace(control_params *control, storage *workspace, int total_cap)
   {
     int total_real, total_rvec;
-    auto error = control->error_ptr;
+    auto *error = control->error_ptr;
 
     workspace->allocated = 1;
     total_real = total_cap * sizeof(double);
@@ -181,7 +181,7 @@ namespace ReaxFF {
       }
     total_hbonds_big = (LAMMPS_NS::bigint)(MAX(total_hbonds_big*saferzone, mincap*system->minhbonds));
 
-    auto error = system->error_ptr;
+    auto *error = system->error_ptr;
     if (total_hbonds_big > MAXSMALLINT)
       error->one(FLERR,"Too many hydrogen bonds in pair reaxff");
 
@@ -210,7 +210,7 @@ namespace ReaxFF {
     }
     total_bonds_big = (LAMMPS_NS::bigint)(MAX(total_bonds_big * safezone, mincap*MIN_BONDS));
 
-    auto error = system->error_ptr;
+    auto *error = system->error_ptr;
     if (total_bonds_big > MAXSMALLINT)
       error->one(FLERR,"Too many bonds in pair reaxff");
 
@@ -240,7 +240,7 @@ namespace ReaxFF {
     double safezone = system->safezone;
     double saferzone = system->saferzone;
 
-    auto error = system->error_ptr;
+    auto *error = system->error_ptr;
     reallocate_data *wsr = &(workspace->realloc);
 
     if (system->n >= DANGER_ZONE * system->local_cap)

--- a/src/REAXFF/reaxff_control.cpp
+++ b/src/REAXFF/reaxff_control.cpp
@@ -67,7 +67,7 @@ namespace ReaxFF {
 
   void Read_Control_File(const char *control_file, control_params *control)
   {
-    auto error = control->error_ptr;
+    auto *error = control->error_ptr;
 
     /* assign default values */
     control->nthreads = 1;

--- a/src/REAXFF/reaxff_ffield.cpp
+++ b/src/REAXFF/reaxff_ffield.cpp
@@ -57,9 +57,9 @@ namespace ReaxFF {
                         control_params *control, MPI_Comm world)
   {
     char ****tor_flag;
-    auto error = control->error_ptr;
-    auto lmp = control->lmp_ptr;
-    auto memory = control->lmp_ptr->memory;
+    auto *error = control->error_ptr;
+    auto *lmp = control->lmp_ptr;
+    auto *memory = control->lmp_ptr->memory;
 
     // read and parse the force field only on rank 0
 
@@ -84,7 +84,7 @@ namespace ReaxFF {
 
         // check if header comment line is present
 
-        auto line = reader.next_line();
+        auto *line = reader.next_line();
         if (strmatch(line, "^\\s*[0-9]+\\s+!.*general parameters.*"))
           THROW_ERROR("First line of ReaxFF potential file must be a comment or empty");
         ++lineno;
@@ -556,7 +556,7 @@ namespace ReaxFF {
             for (k = 0; k < ntypes; ++k)
               hbp[i][j][k].r0_hb = -1.0;
 
-        auto thisline = reader.next_line();
+        auto *thisline = reader.next_line();
         if (!thisline) throw EOFException("ReaxFF parameter file has no hydrogen bond parameters");
 
         values = ValueTokenizer(thisline);

--- a/src/REPLICA/compute_pressure_alchemy.cpp
+++ b/src/REPLICA/compute_pressure_alchemy.cpp
@@ -98,7 +98,7 @@ void ComputePressureAlchemy::compute_vector()
     error->all(FLERR, Error::NOLASTLINE, "Virial was not tallied on needed timestep{}", utils::errorurl(22));
 
   int dim = 0;
-  double *pressure = (double *) fix->extract("pressure", dim);
+  auto *pressure = (double *) fix->extract("pressure", dim);
   if (!pressure || (dim != 1))
     error->all(FLERR, Error::NOLASTLINE, "Could not extract pressure from fix alchemy");
 

--- a/src/REPLICA/fix_alchemy.cpp
+++ b/src/REPLICA/fix_alchemy.cpp
@@ -133,7 +133,7 @@ void FixAlchemy::check_consistency_atoms()
   // check that owned atom ordering is same for each pair of replica procs
   // re-use communication buffer for positions and forces
 
-  tagint *tagbuf = (tagint *) commbuf;
+  auto *tagbuf = (tagint *) commbuf;
   tagint *tag = atom->tag;
   if (universe->iworld == 0) {
     for (int i = 0; i < nlocal; ++i) tagbuf[i] = tag[i];

--- a/src/REPLICA/fix_event_hyper.cpp
+++ b/src/REPLICA/fix_event_hyper.cpp
@@ -79,7 +79,7 @@ void FixEventHyper::write_restart(FILE *fp)
 void FixEventHyper::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
 
   event_number = (int) ubuf(list[n++]).i;
   event_timestep = (bigint) ubuf(list[n++]).i;

--- a/src/REPLICA/fix_event_prd.cpp
+++ b/src/REPLICA/fix_event_prd.cpp
@@ -82,7 +82,7 @@ void FixEventPRD::write_restart(FILE *fp)
 void FixEventPRD::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
 
   event_number = static_cast<int> (list[n++]);
   event_timestep = static_cast<bigint> (list[n++]);

--- a/src/REPLICA/fix_event_tad.cpp
+++ b/src/REPLICA/fix_event_tad.cpp
@@ -78,7 +78,7 @@ void FixEventTAD::write_restart(FILE *fp)
 void FixEventTAD::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
 
   event_number = static_cast<int> (list[n++]);
   event_timestep = static_cast<int> (list[n++]);

--- a/src/REPLICA/fix_grem.cpp
+++ b/src/REPLICA/fix_grem.cpp
@@ -172,13 +172,13 @@ void FixGrem::init()
   if (!ifix) {
     error->all(FLERR,"Fix id for nvt or npt fix does not exist");
   } else { // check for correct fix style
-    FixNH *nh = dynamic_cast<FixNH *>(ifix);
+    auto *nh = dynamic_cast<FixNH *>(ifix);
     if (!nh) {
       error->all(FLERR, "Fix ID {} is not a compatible Nose-Hoover fix for fix {}", id_nh, style);
     } else {
       int dummy;
-      auto t_start = (double *)nh->extract("t_start",dummy);
-      auto t_stop = (double *)nh->extract("t_stop",dummy);
+      auto *t_start = (double *)nh->extract("t_start",dummy);
+      auto *t_stop = (double *)nh->extract("t_stop",dummy);
       if ((t_start != nullptr) && (t_stop != nullptr)) {
         tbath = *t_start;
         if (*t_start != *t_stop)
@@ -189,8 +189,8 @@ void FixGrem::init()
       pressref = 0.0;
       if (pressflag) {
         int *p_flag = (int *)nh->extract("p_flag",dummy);
-        auto p_start = (double *) nh->extract("p_start",dummy);
-        auto p_stop = (double *) nh->extract("p_stop",dummy);
+        auto *p_start = (double *) nh->extract("p_start",dummy);
+        auto *p_stop = (double *) nh->extract("p_stop",dummy);
         if ((p_flag != nullptr) && (p_start != nullptr) && (p_stop != nullptr)) {
           int ifix = 0;
           pressref = p_start[0];

--- a/src/REPLICA/fix_hyper_local.cpp
+++ b/src/REPLICA/fix_hyper_local.cpp
@@ -310,7 +310,7 @@ void FixHyperLocal::init()
   // NOTE: what if pair style list cutoff > Dcut
   //   or what if neigh skin is huge?
 
-  auto req = neighbor->add_request(this, NeighConst::REQ_FULL | NeighConst::REQ_OCCASIONAL);
+  auto *req = neighbor->add_request(this, NeighConst::REQ_FULL | NeighConst::REQ_OCCASIONAL);
   req->set_id(1);
   req->set_cutoff(dcut);
 

--- a/src/REPLICA/fix_pimd_langevin.cpp
+++ b/src/REPLICA/fix_pimd_langevin.cpp
@@ -1699,7 +1699,7 @@ int FixPIMDLangevin::pack_restart_data(double *list)
 void FixPIMDLangevin::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
   for (int i = 0; i < 6; i++) vw[i] = list[n++];
 }
 

--- a/src/REPLICA/hyper.cpp
+++ b/src/REPLICA/hyper.cpp
@@ -59,8 +59,8 @@ void Hyper::command(int narg, char **arg)
   int nsteps = utils::inumeric(FLERR,arg[0],false,lmp);
   t_event = utils::inumeric(FLERR,arg[1],false,lmp);
 
-  auto id_fix = utils::strdup(arg[2]);
-  auto id_compute = utils::strdup(arg[3]);
+  auto *id_fix = utils::strdup(arg[2]);
+  auto *id_compute = utils::strdup(arg[3]);
 
   options(narg-4,&arg[4]);
 
@@ -151,10 +151,10 @@ void Hyper::command(int narg, char **arg)
 
   // cannot use hyper with time-dependent fixes or regions
 
-  for (auto &ifix : modify->get_fix_list())
+  for (const auto &ifix : modify->get_fix_list())
     if (ifix->time_depend) error->all(FLERR,"Cannot use hyper with a time-dependent fix defined");
 
-  for (auto &reg : domain->get_region_list())
+  for (const auto &reg : domain->get_region_list())
     if (reg->dynamic_check())
       error->all(FLERR,"Cannot use hyper with a time-dependent region defined");
 
@@ -454,7 +454,7 @@ void Hyper::options(int narg, char **arg)
     } else if (strcmp(arg[iarg],"dump") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal hyper command");
       dumpflag = 1;
-      auto idump = output->get_dump_by_id(arg[iarg+1]);
+      auto *idump = output->get_dump_by_id(arg[iarg+1]);
       if (!idump) error->all(FLERR,"Dump ID {} in hyper command does not exist", arg[iarg+1]);
       dumplist.emplace_back(idump);
       iarg += 2;

--- a/src/REPLICA/neb.cpp
+++ b/src/REPLICA/neb.cpp
@@ -473,7 +473,7 @@ void NEB::readfile(char *file, int flag)
     if (nlines < 0) error->universe_all(FLERR, "Incorrectly formatted NEB file");
   }
 
-  auto buffer = new char[CHUNK * MAXLINE];
+  auto *buffer = new char[CHUNK * MAXLINE];
   double fraction = ireplica / (nreplica - 1.0);
   double **x = atom->x;
   int nlocal = atom->nlocal;

--- a/src/REPLICA/prd.cpp
+++ b/src/REPLICA/prd.cpp
@@ -229,10 +229,10 @@ void PRD::command(int narg, char **arg)
 
   // cannot use PRD with time-dependent fixes or regions
 
-  for (auto &ifix : modify->get_fix_list())
+  for (const auto &ifix : modify->get_fix_list())
     if (ifix->time_depend) error->all(FLERR,"Cannot use PRD with a time-dependent fix defined");
 
-  for (auto &reg : domain->get_region_list())
+  for (const auto &reg : domain->get_region_list())
     if (reg->dynamic_check())
       error->all(FLERR,"Cannot use PRD with a time-dependent region defined");
 

--- a/src/REPLICA/tad.cpp
+++ b/src/REPLICA/tad.cpp
@@ -872,7 +872,7 @@ void TAD::compute_tlo(int ievent)
 
   // update first event
 
-  auto  statstr = (char *) "D ";
+  auto *  statstr = (char *) "D ";
 
   if (ievent == 0) {
     deltfirst = deltlo;

--- a/src/REPLICA/temper_grem.cpp
+++ b/src/REPLICA/temper_grem.cpp
@@ -79,7 +79,7 @@ void TemperGrem::command(int narg, char **arg)
 
   // Get and check if gREM fix exists and is correct style
 
-  auto ifix = modify->get_fix_by_id(arg[3]);
+  auto *ifix = modify->get_fix_by_id(arg[3]);
   if (!ifix) error->universe_all(FLERR,fmt::format("Tempering fix ID {} is not defined", arg[3]));
 
   fix_grem = dynamic_cast<FixGrem*>(ifix);
@@ -107,7 +107,7 @@ void TemperGrem::command(int narg, char **arg)
 
   if (pressflag) {
     int dummy;
-    auto p_start = (double *) nh->extract("p_start",dummy);
+    auto *p_start = (double *) nh->extract("p_start",dummy);
     pressref = p_start[0];
   }
 

--- a/src/RHEO/bond_rheo_shell.cpp
+++ b/src/RHEO/bond_rheo_shell.cpp
@@ -358,7 +358,7 @@ void BondRHEOShell::init_style()
   auto fixes = modify->get_fix_by_style("^rheo$");
   if (fixes.size() == 0)
     error->all(FLERR, Error::NOLASTLINE, "Need to define fix rheo to use bond rheo/shell");
-  class FixRHEO *fix_rheo = dynamic_cast<FixRHEO *>(fixes[0]);
+  auto *fix_rheo = dynamic_cast<FixRHEO *>(fixes[0]);
 
   if (!fix_rheo->surface_flag)
     error->all(FLERR, Error::NOLASTLINE, "Bond rheo/shell requires surface calculation in fix rheo");
@@ -367,7 +367,7 @@ void BondRHEOShell::init_style()
   fixes = modify->get_fix_by_style("^rheo/oxidation$");
   if (fixes.size() == 0)
     error->all(FLERR, Error::NOLASTLINE, "Need to define fix rheo/oxidation to use bond rheo/shell");
-  class FixRHEOOxidation *fix_rheo_oxidation = dynamic_cast<FixRHEOOxidation *>(fixes[0]);
+  auto *fix_rheo_oxidation = dynamic_cast<FixRHEOOxidation *>(fixes[0]);
 
   rsurf = fix_rheo_oxidation->rsurf;
   rmax = fix_rheo_oxidation->cut;
@@ -554,7 +554,7 @@ void BondRHEOShell::process_ineligibility(int i, int j)
         bond_type[i][m] = bond_type[i][n - 1];
         bond_atom[i][m] = bond_atom[i][n - 1];
         for (auto &ihistory : histories) {
-          auto fix_bond_history2 = dynamic_cast<FixBondHistory *>(ihistory);
+          auto *fix_bond_history2 = dynamic_cast<FixBondHistory *>(ihistory);
           fix_bond_history2->shift_history(i, m, n - 1);
           fix_bond_history2->delete_history(i, n - 1);
         }
@@ -572,7 +572,7 @@ void BondRHEOShell::process_ineligibility(int i, int j)
         bond_type[j][m] = bond_type[j][n - 1];
         bond_atom[j][m] = bond_atom[j][n - 1];
         for (auto &ihistory : histories) {
-          auto fix_bond_history2 = dynamic_cast<FixBondHistory *>(ihistory);
+          auto *fix_bond_history2 = dynamic_cast<FixBondHistory *>(ihistory);
           fix_bond_history2->shift_history(j, m, n - 1);
           fix_bond_history2->delete_history(j, n - 1);
         }

--- a/src/RHEO/fix_rheo_thermal.cpp
+++ b/src/RHEO/fix_rheo_thermal.cpp
@@ -293,7 +293,7 @@ void FixRHEOThermal::init()
     if (force->newton_pair) error->all(FLERR, "Need Newton off for reactive bond generation");
 
     // need a half neighbor list, built only when particles freeze
-    auto req = neighbor->add_request(this, NeighConst::REQ_OCCASIONAL);
+    auto *req = neighbor->add_request(this, NeighConst::REQ_OCCASIONAL);
     req->set_cutoff(cut_kernel);
 
     // find instances of bond history to delete/shift data
@@ -547,7 +547,7 @@ void FixRHEOThermal::break_bonds()
         bond_atom[i][m] = bond_atom[i][nmax];
         if (n_histories > 0) {
           for (auto &ihistory : histories) {
-            auto fix_bond_history = dynamic_cast<FixBondHistory *>(ihistory);
+            auto *fix_bond_history = dynamic_cast<FixBondHistory *>(ihistory);
             fix_bond_history->shift_history(i, m, nmax);
             fix_bond_history->delete_history(i, nmax);
           }
@@ -592,7 +592,7 @@ void FixRHEOThermal::break_bonds()
           bond_atom[i][m] = bond_atom[i][nmax];
           if (n_histories > 0)
             for (auto &ihistory : histories) {
-              auto fix_bond_history = dynamic_cast<FixBondHistory *>(ihistory);
+              auto *fix_bond_history = dynamic_cast<FixBondHistory *>(ihistory);
               fix_bond_history->shift_history(i, m, nmax);
               fix_bond_history->delete_history(i, nmax);
             }
@@ -611,7 +611,7 @@ void FixRHEOThermal::break_bonds()
           bond_atom[j][m] = bond_atom[j][nmax];
           if (n_histories > 0)
             for (auto &ihistory : histories) {
-              auto fix_bond_history = dynamic_cast<FixBondHistory *>(ihistory);
+              auto *fix_bond_history = dynamic_cast<FixBondHistory *>(ihistory);
               fix_bond_history->shift_history(j, m, nmax);
               fix_bond_history->delete_history(j, nmax);
             }

--- a/src/RIGID/compute_rigid_local.cpp
+++ b/src/RIGID/compute_rigid_local.cpp
@@ -110,7 +110,7 @@ void ComputeRigidLocal::init()
 {
   // set fixrigid
 
-  auto ifix = modify->get_fix_by_id(idrigid);
+  auto *ifix = modify->get_fix_by_id(idrigid);
   if (!ifix) error->all(FLERR,"FixRigidSmall ID {} for compute rigid/local does not exist", idrigid);
   fixrigid = dynamic_cast<FixRigidSmall *>(ifix);
   if (!fixrigid)

--- a/src/RIGID/fix_rigid.cpp
+++ b/src/RIGID/fix_rigid.cpp
@@ -151,7 +151,7 @@ FixRigid::FixRigid(LAMMPS *lmp, int narg, char **arg) :
         if (input->variable->atomstyle(ivariable) == 0)
           error->all(FLERR, "Fix {} custom variable {} is not atom-style variable", style,
                      arg[4] + 2);
-        auto value = new double[nlocal];
+        auto *value = new double[nlocal];
         input->variable->compute_atom(ivariable, 0, value, 1, 0);
         int minval = INT_MAX;
         for (i = 0; i < nlocal; i++)
@@ -705,14 +705,14 @@ void FixRigid::init()
   // if earlyflag, warn if any post-force fixes come after a rigid fix
 
   int count = 0;
-  for (auto &ifix : modify->get_fix_list())
+  for (const auto &ifix : modify->get_fix_list())
     if (ifix->rigid_flag) count++;
   if (count > 1 && comm->me == 0)
     error->warning(FLERR,"More than one fix rigid");
 
   if (earlyflag) {
     bool rflag = false;
-    for (auto &ifix : modify->get_fix_list()) {
+    for (const auto &ifix : modify->get_fix_list()) {
       if (ifix->rigid_flag) rflag = true;
       if ((comm->me == 0) && rflag && (ifix->setmask() & POST_FORCE) && !ifix->rigid_flag)
         error->warning(FLERR, "Fix {} with ID {} alters forces after fix rigid",
@@ -735,7 +735,7 @@ void FixRigid::init()
   //  error if a fix changing the box comes before rigid fix
 
   bool boxflag = false;
-  for (auto &ifix : modify->get_fix_list()) {
+  for (const auto &ifix : modify->get_fix_list()) {
     if (boxflag && utils::strmatch(ifix->style,"^rigid"))
         error->all(FLERR,"Rigid fixes must come before any box changing fix");
     if (ifix->box_change) boxflag = true;
@@ -744,7 +744,7 @@ void FixRigid::init()
   // add gravity forces based on gravity vector from fix
 
   if (id_gravity) {
-    auto ifix = modify->get_fix_by_id(id_gravity);
+    auto *ifix = modify->get_fix_by_id(id_gravity);
     if (!ifix) error->all(FLERR,"Fix rigid cannot find fix gravity ID {}", id_gravity);
     if (!utils::strmatch(ifix->style,"^gravity"))
       error->all(FLERR,"Fix rigid gravity fix ID {} is not a gravity fix style", id_gravity);
@@ -2352,7 +2352,7 @@ void FixRigid::readfile(int which, double *vec, double **array1, double **array2
   if (nlines == 0) return;
   else if (nlines < 0) error->all(FLERR,"Fix rigid infile has incorrect format");
 
-  auto buffer = new char[CHUNK*MAXLINE];
+  auto *buffer = new char[CHUNK*MAXLINE];
   int nread = 0;
   int me = comm->me;
   while (nread < nlines) {

--- a/src/RIGID/fix_rigid_nh.cpp
+++ b/src/RIGID/fix_rigid_nh.cpp
@@ -260,8 +260,8 @@ void FixRigidNH::init()
 
     // ensure no conflict with fix deform
 
-    for (auto &ifix : modify->get_fix_by_style("^deform")) {
-      auto deform = dynamic_cast<FixDeform *>(ifix);
+    for (const auto &ifix : modify->get_fix_by_style("^deform")) {
+      auto *deform = dynamic_cast<FixDeform *>(ifix);
       if (deform) {
         int *dimflag = deform->dimflag;
         if ((p_flag[0] && dimflag[0]) || (p_flag[1] && dimflag[1]) || (p_flag[2] && dimflag[2]))
@@ -299,7 +299,7 @@ void FixRigidNH::init()
     // this will include self
 
     rfix.clear();
-    for (auto &ifix : modify->get_fix_list())
+    for (const auto &ifix : modify->get_fix_list())
       if (ifix->rigid_flag) rfix.push_back(ifix);
   }
 }
@@ -1146,7 +1146,7 @@ void FixRigidNH::write_restart(FILE *fp)
 void FixRigidNH::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
   int flag = static_cast<int> (list[n++]);
 
   if (flag) {

--- a/src/RIGID/fix_rigid_nh_small.cpp
+++ b/src/RIGID/fix_rigid_nh_small.cpp
@@ -235,8 +235,8 @@ void FixRigidNHSmall::init()
 
     // ensure no conflict with fix deform
 
-    for (auto &ifix : modify->get_fix_by_style("^deform")) {
-      auto deform = dynamic_cast<FixDeform *>(ifix);
+    for (const auto &ifix : modify->get_fix_by_style("^deform")) {
+      auto *deform = dynamic_cast<FixDeform *>(ifix);
       if (deform) {
         int *dimflag = deform->dimflag;
         if ((p_flag[0] && dimflag[0]) || (p_flag[1] && dimflag[1]) ||
@@ -275,7 +275,7 @@ void FixRigidNHSmall::init()
     // this will include self
 
     rfix.clear();
-    for (auto &ifix : modify->get_fix_list())
+    for (const auto &ifix : modify->get_fix_list())
       if (ifix->rigid_flag) rfix.push_back(ifix);
   }
 }
@@ -1235,7 +1235,7 @@ void FixRigidNHSmall::write_restart(FILE *fp)
 void FixRigidNHSmall::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
   int flag = static_cast<int> (list[n++]);
 
   if (flag) {

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -134,7 +134,7 @@ FixRigidSmall::FixRigidSmall(LAMMPS *lmp, int narg, char **arg) :
           error->all(FLERR,"Variable {} for fix {} custom does not exist", arg[4]+2, style);
         if (input->variable->atomstyle(ivariable) == 0)
           error->all(FLERR,"Fix {} custom variable {} is not atom-style variable", style, arg[4]+2);
-        auto value = new double[nlocal];
+        auto *value = new double[nlocal];
         input->variable->compute_atom(ivariable,0,value,1,0);
         int minval = INT_MAX;
         for (i = 0; i < nlocal; i++)
@@ -523,14 +523,14 @@ void FixRigidSmall::init()
   // if earlyflag, warn if any post-force fixes come after a rigid fix
 
   int count = 0;
-  for (auto &ifix : modify->get_fix_list())
+  for (const auto &ifix : modify->get_fix_list())
     if (ifix->rigid_flag) count++;
   if (count > 1 && comm->me == 0)
     error->warning(FLERR, "More than one fix rigid command");
 
   if (earlyflag) {
     bool rflag = false;
-    for (auto &ifix : modify->get_fix_list()) {
+    for (const auto &ifix : modify->get_fix_list()) {
       if (ifix->rigid_flag) rflag = true;
       if ((comm->me == 0) && rflag && (ifix->setmask() & POST_FORCE) && !ifix->rigid_flag)
         error->warning(FLERR,"Fix {} with ID {} alters forces after fix {}",
@@ -553,7 +553,7 @@ void FixRigidSmall::init()
   // error if a fix changing the box comes before rigid fix
 
   bool boxflag = false;
-  for (auto &ifix : modify->get_fix_list()) {
+  for (const auto &ifix : modify->get_fix_list()) {
     if (boxflag && utils::strmatch(ifix->style,"^rigid"))
         error->all(FLERR,"Rigid fixes must come before any box changing fix");
     if (ifix->box_change) boxflag = true;
@@ -562,7 +562,7 @@ void FixRigidSmall::init()
   // add gravity forces based on gravity vector from fix
 
   if (id_gravity) {
-    auto ifix = modify->get_fix_by_id(id_gravity);
+    auto *ifix = modify->get_fix_by_id(id_gravity);
     if (!ifix) error->all(FLERR,"Fix {} cannot find fix gravity ID {}", style, id_gravity);
     if (!utils::strmatch(ifix->style,"^gravity"))
       error->all(FLERR,"Fix {} gravity fix ID {} is not a gravity fix style", style, id_gravity);
@@ -1582,7 +1582,7 @@ void FixRigidSmall::create_bodies(tagint *bodyID)
 
   int *proclist;
   memory->create(proclist,ncount,"rigid/small:proclist");
-  auto inbuf = (InRvous *) memory->smalloc(ncount*sizeof(InRvous),"rigid/small:inbuf");
+  auto *inbuf = (InRvous *) memory->smalloc(ncount*sizeof(InRvous),"rigid/small:inbuf");
 
   // setup buf to pass to rendezvous comm
   // one BodyMsg datum for each constituent atom
@@ -1617,7 +1617,7 @@ void FixRigidSmall::create_bodies(tagint *bodyID)
                                  0,proclist,
                                  rendezvous_body,0,buf,sizeof(OutRvous),
                                  (void *) this);
-  auto outbuf = (OutRvous *) buf;
+  auto *outbuf = (OutRvous *) buf;
 
   memory->destroy(proclist);
   memory->sfree(inbuf);
@@ -1659,7 +1659,7 @@ int FixRigidSmall::rendezvous_body(int n, char *inbuf,
   double *x,*xown,*rsqclose;
   double **bbox,**ctr;
 
-  auto frsptr = (FixRigidSmall *) ptr;
+  auto *frsptr = (FixRigidSmall *) ptr;
   Memory *memory = frsptr->memory;
   Error *error = frsptr->error;
   MPI_Comm world = frsptr->world;
@@ -1671,7 +1671,7 @@ int FixRigidSmall::rendezvous_body(int n, char *inbuf,
   // key = body ID
   // value = index into Ncount-length data structure
 
-  auto in = (InRvous *) inbuf;
+  auto *in = (InRvous *) inbuf;
   std::map<tagint,int> hash;
   tagint id;
 
@@ -1766,7 +1766,7 @@ int FixRigidSmall::rendezvous_body(int n, char *inbuf,
 
   int nout = n;
   memory->create(proclist,nout,"rigid/small:proclist");
-  auto out = (OutRvous *) memory->smalloc(nout*sizeof(OutRvous),"rigid/small:out");
+  auto *out = (OutRvous *) memory->smalloc(nout*sizeof(OutRvous),"rigid/small:out");
 
   for (i = 0; i < nout; i++) {
     proclist[i] = in[i].me;
@@ -2532,7 +2532,7 @@ void FixRigidSmall::readfile(int which, double **array, int *inbody)
   if (nlines == 0) return;
   else if (nlines < 0) error->all(FLERR,"Fix {} infile has incorrect format", style);
 
-  auto buffer = new char[CHUNK*MAXLINE];
+  auto *buffer = new char[CHUNK*MAXLINE];
   int nread = 0;
   int me = comm->me;
 

--- a/src/RIGID/fix_shake.cpp
+++ b/src/RIGID/fix_shake.cpp
@@ -388,7 +388,7 @@ void FixShake::init()
 
   // error if a fix changing the box comes before shake fix
   bool boxflag = false;
-  for (auto &ifix : modify->get_fix_list()) {
+  for (const auto &ifix : modify->get_fix_list()) {
    if (boxflag && utils::strmatch(ifix->style,pattern))
      error->all(FLERR,"Fix {} must come before any box changing fix", style);
     if (ifix->box_change) boxflag = true;
@@ -407,7 +407,7 @@ void FixShake::init()
       if (fixes.size() > 0) fix_respa = dynamic_cast<FixRespa *>(fixes.front());
       else error->all(FLERR,"Run style respa did not create fix RESPA");
     }
-    auto respa_ptr = dynamic_cast<Respa *>(update->integrate);
+    auto *respa_ptr = dynamic_cast<Respa *>(update->integrate);
     if (!respa_ptr) error->all(FLERR, "Failure to access Respa style {}", update->integrate_style);
     respa = 1;
     nlevels_respa = respa_ptr->nlevels;
@@ -508,7 +508,7 @@ void FixShake::setup(int vflag)
     dtfsq   = 0.5 * update->dt * update->dt * force->ftm2v;
     if (!rattle) dtfsq = update->dt * update->dt * force->ftm2v;
   } else {
-    auto respa_ptr = dynamic_cast<Respa *>(update->integrate);
+    auto *respa_ptr = dynamic_cast<Respa *>(update->integrate);
     if (!respa_ptr) error->all(FLERR, "Failure to access Respa style {}", update->integrate_style);
     if (update->whichflag > 0) {
       auto fixes = modify->get_fix_by_style("^RESPA");
@@ -1171,7 +1171,7 @@ void FixShake::atom_owners()
 
   int *proclist;
   memory->create(proclist,nlocal,"shake:proclist");
-  auto idbuf = (IDRvous *) memory->smalloc((bigint) nlocal*sizeof(IDRvous),"shake:idbuf");
+  auto *idbuf = (IDRvous *) memory->smalloc((bigint) nlocal*sizeof(IDRvous),"shake:idbuf");
 
   // setup input buf to rendezvous comm
   // input datums = pairs of bonded atoms
@@ -1220,7 +1220,7 @@ void FixShake::partner_info(int *npartner, tagint **partner_tag,
 
   int *proclist;
   memory->create(proclist,nsend,"special:proclist");
-  auto inbuf = (PartnerInfo *) memory->smalloc((bigint) nsend*sizeof(PartnerInfo),"special:inbuf");
+  auto *inbuf = (PartnerInfo *) memory->smalloc((bigint) nsend*sizeof(PartnerInfo),"special:inbuf");
 
   // set values in 4 partner arrays for all partner atoms I own
   // also setup input buf to rendezvous comm
@@ -1298,7 +1298,7 @@ void FixShake::partner_info(int *npartner, tagint **partner_tag,
                                  rendezvous_partners_info,
                                  0,buf,sizeof(PartnerInfo),
                                  (void *) this);
-  auto outbuf = (PartnerInfo *) buf;
+  auto *outbuf = (PartnerInfo *) buf;
 
   memory->destroy(proclist);
   memory->sfree(inbuf);
@@ -1348,7 +1348,7 @@ void FixShake::nshake_info(int *npartner, tagint **partner_tag,
 
   int *proclist;
   memory->create(proclist,nsend,"special:proclist");
-  auto inbuf = (NShakeInfo *) memory->smalloc((bigint) nsend*sizeof(NShakeInfo),"special:inbuf");
+  auto *inbuf = (NShakeInfo *) memory->smalloc((bigint) nsend*sizeof(NShakeInfo),"special:inbuf");
 
   // set partner_nshake for all partner atoms I own
   // also setup input buf to rendezvous comm
@@ -1385,7 +1385,7 @@ void FixShake::nshake_info(int *npartner, tagint **partner_tag,
                                  0,proclist,
                                  rendezvous_nshake,0,buf,sizeof(NShakeInfo),
                                  (void *) this);
-  auto outbuf = (NShakeInfo *) buf;
+  auto *outbuf = (NShakeInfo *) buf;
 
   memory->destroy(proclist);
   memory->sfree(inbuf);
@@ -1426,7 +1426,7 @@ void FixShake::shake_info(int *npartner, tagint **partner_tag,
 
   int *proclist;
   memory->create(proclist,nsend,"special:proclist");
-  auto inbuf = (ShakeInfo *) memory->smalloc((bigint) nsend*sizeof(ShakeInfo),"special:inbuf");
+  auto *inbuf = (ShakeInfo *) memory->smalloc((bigint) nsend*sizeof(ShakeInfo),"special:inbuf");
 
   // set 3 shake arrays for all partner atoms I own
   // also setup input buf to rendezvous comm
@@ -1477,7 +1477,7 @@ void FixShake::shake_info(int *npartner, tagint **partner_tag,
                                  0,proclist,
                                  rendezvous_shake,0,buf,sizeof(ShakeInfo),
                                  (void *) this);
-  auto outbuf = (ShakeInfo *) buf;
+  auto *outbuf = (ShakeInfo *) buf;
 
   memory->destroy(proclist);
   memory->sfree(inbuf);
@@ -1509,7 +1509,7 @@ int FixShake::rendezvous_ids(int n, char *inbuf,
                              int &flag, int *& /*proclist*/, char *& /*outbuf*/,
                              void *ptr)
 {
-  auto fsptr = (FixShake *) ptr;
+  auto *fsptr = (FixShake *) ptr;
   Memory *memory = fsptr->memory;
 
   tagint *atomIDs;
@@ -1518,7 +1518,7 @@ int FixShake::rendezvous_ids(int n, char *inbuf,
   memory->create(atomIDs,n,"special:atomIDs");
   memory->create(procowner,n,"special:procowner");
 
-  auto in = (IDRvous *) inbuf;
+  auto *in = (IDRvous *) inbuf;
 
   for (int i = 0; i < n; i++) {
     atomIDs[i] = in[i].atomID;
@@ -1549,7 +1549,7 @@ int FixShake::rendezvous_partners_info(int n, char *inbuf,
 {
   int i,m;
 
-  auto fsptr = (FixShake *) ptr;
+  auto *fsptr = (FixShake *) ptr;
   Atom *atom = fsptr->atom;
   Memory *memory = fsptr->memory;
 
@@ -1569,7 +1569,7 @@ int FixShake::rendezvous_partners_info(int n, char *inbuf,
   // proclist = owner of atomID in caller decomposition
   // outbuf = info about owned atomID = 4 values
 
-  auto in = (PartnerInfo *) inbuf;
+  auto *in = (PartnerInfo *) inbuf;
   int *procowner = fsptr->procowner;
   memory->create(proclist,n,"shake:proclist");
 
@@ -1604,7 +1604,7 @@ int FixShake::rendezvous_nshake(int n, char *inbuf,
 {
   int i,m;
 
-  auto fsptr = (FixShake *) ptr;
+  auto *fsptr = (FixShake *) ptr;
   Atom *atom = fsptr->atom;
   Memory *memory = fsptr->memory;
 
@@ -1624,7 +1624,7 @@ int FixShake::rendezvous_nshake(int n, char *inbuf,
   // proclist = owner of atomID in caller decomposition
   // outbuf = info about owned atomID
 
-  auto in = (NShakeInfo *) inbuf;
+  auto *in = (NShakeInfo *) inbuf;
   int *procowner = fsptr->procowner;
   memory->create(proclist,n,"shake:proclist");
 
@@ -1658,7 +1658,7 @@ int FixShake::rendezvous_shake(int n, char *inbuf,
 {
   int i,m;
 
-  auto fsptr = (FixShake *) ptr;
+  auto *fsptr = (FixShake *) ptr;
   Atom *atom = fsptr->atom;
   Memory *memory = fsptr->memory;
 
@@ -1678,7 +1678,7 @@ int FixShake::rendezvous_shake(int n, char *inbuf,
   // proclist = owner of atomID in caller decomposition
   // outbuf = info about owned atomID
 
-  auto in = (ShakeInfo *) inbuf;
+  auto *in = (ShakeInfo *) inbuf;
   int *procowner = fsptr->procowner;
   memory->create(proclist,n,"shake:proclist");
 
@@ -3159,7 +3159,7 @@ void FixShake::reset_dt()
     else dtfsq = update->dt * update->dt * force->ftm2v;
     respa = 0;
   } else {
-    auto respa_ptr = dynamic_cast<Respa *>(update->integrate);
+    auto *respa_ptr = dynamic_cast<Respa *>(update->integrate);
     if (!respa_ptr) error->all(FLERR, "Failure to access Respa style {}", update->integrate_style);
     respa = 1;
     nlevels_respa = respa_ptr->nlevels;

--- a/src/SHOCK/fix_append_atoms.cpp
+++ b/src/SHOCK/fix_append_atoms.cpp
@@ -272,8 +272,8 @@ int FixAppendAtoms::get_spatial()
       else failed = 0;
       count++;
     }
-    auto pos = new double[count-2];
-    auto val = new double[count-2];
+    auto *pos = new double[count-2];
+    auto *val = new double[count-2];
     for (int loop=0; loop < count-2; loop++) {
       pos[loop] = fix->compute_vector(2*loop);
       val[loop] = fix->compute_vector(2*loop+1);

--- a/src/SHOCK/fix_msst.cpp
+++ b/src/SHOCK/fix_msst.cpp
@@ -291,7 +291,7 @@ void FixMSST::init()
   // detect if any fix rigid exist so rigid bodies move when box is dilated
 
   rfix.clear();
-  for (auto &ifix : modify->get_fix_list())
+  for (const auto &ifix : modify->get_fix_list())
     if (ifix->rigid_flag) rfix.push_back(ifix);
 
   // find fix external being used to drive LAMMPS from DFTB+
@@ -786,7 +786,7 @@ void FixMSST::write_restart(FILE *fp)
 void FixMSST::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
   omega[direction] = list[n++];
   e0 = list[n++];
   v0 = list[n++];

--- a/src/SHOCK/fix_nphug.cpp
+++ b/src/SHOCK/fix_nphug.cpp
@@ -398,7 +398,7 @@ int FixNPHug::size_restart_global()
 void FixNPHug::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
   e0 = list[n++];
   v0 = list[n++];
   p0 = list[n++];

--- a/src/SPIN/neb_spin.cpp
+++ b/src/SPIN/neb_spin.cpp
@@ -422,7 +422,7 @@ void NEBSpin::readfile(char *file, int flag)
       error->all(FLERR,"Incorrectly formatted NEB file");
   }
 
-  auto buffer = new char[CHUNK*MAXLINE];
+  auto *buffer = new char[CHUNK*MAXLINE];
   double fraction = ireplica/(nreplica-1.0);
   double **x = atom->x;
   double **sp = atom->sp;

--- a/src/SRD/fix_srd.cpp
+++ b/src/SRD/fix_srd.cpp
@@ -395,7 +395,7 @@ void FixSRD::init()
     if (fixes[i]->box_change & BOX_CHANGE_SHAPE) change_shape = 1;
     if (strcmp(fixes[i]->style, "deform") == 0) {
       deformflag = 1;
-      auto deform = dynamic_cast<FixDeform *>(modify->fix[i]);
+      auto *deform = dynamic_cast<FixDeform *>(modify->fix[i]);
       if ((deform->box_change & BOX_CHANGE_SHAPE) && deform->remapflag != Domain::V_REMAP)
         error->all(FLERR, "Using fix srd with inconsistent fix deform remap option");
     }

--- a/src/UEF/fix_nh_uef.cpp
+++ b/src/UEF/fix_nh_uef.cpp
@@ -228,7 +228,7 @@ void FixNHUef::init()
 
 
   // find conflict with fix/deform or other box chaging fixes
-  for (auto &ifix : modify->get_fix_list()) {
+  for (const auto &ifix : modify->get_fix_list()) {
     if (strcmp(ifix->id, id) != 0)
       if ((ifix->box_change & BOX_CHANGE_SHAPE) != 0)
         error->all(FLERR,"Can't use another fix which changes box shape with fix {}", style);
@@ -710,7 +710,7 @@ void FixNHUef::restart(char *buf)
 {
   int n = size_restart_global();
   FixNH::restart(buf);
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
   strain[0] = list[n-2];
   strain[1] = list[n-1];
   uefbox->set_strain(strain[0],strain[1]);

--- a/src/angle_deprecated.cpp
+++ b/src/angle_deprecated.cpp
@@ -33,7 +33,7 @@ void AngleDeprecated::settings(int, char **)
   // called, our style was just added at the end of the list of substyles
 
   if (utils::strmatch(my_style, "^hybrid")) {
-    auto hybrid = dynamic_cast<AngleHybrid *>(force->angle);
+    auto *hybrid = dynamic_cast<AngleHybrid *>(force->angle);
     my_style = hybrid->keywords[hybrid->nstyles];
   }
 

--- a/src/angle_write.cpp
+++ b/src/angle_write.cpp
@@ -46,7 +46,7 @@ void AngleWrite::command(int narg, char **arg)
     error->all(FLERR, "Angle_write command before simulation box is defined" + utils::errorurl(33));
   if (atom->avec->angles_allow == 0)
     error->all(FLERR, "Angle_write command when no angles allowed");
-  auto angle = force->angle;
+  auto *angle = force->angle;
   if (angle == nullptr) error->all(FLERR, "Angle_write command before an angle_style is defined" + utils::errorurl(33));
   if (angle && (force->angle->writedata == 0))
     error->all(FLERR, "Angle style must support writing coeffs to data file for angle_write");
@@ -124,7 +124,7 @@ void AngleWrite::command(int narg, char **arg)
     // set up new LAMMPS instance with dummy system to evaluate angle potential
     LAMMPS::argv args = {"AngleWrite", "-nocite", "-echo",   "none",
                          "-log",       "none",    "-screen", "none"};
-    LAMMPS *writer = new LAMMPS(args, singlecomm);
+    auto *writer = new LAMMPS(args, singlecomm);
 
     // create dummy system replicating angle style settings
     writer->input->one(fmt::format("units {}", update->unit_style));
@@ -167,7 +167,7 @@ void AngleWrite::command(int narg, char **arg)
     i1 = writer->atom->map(1);
     i2 = writer->atom->map(2);
     i3 = writer->atom->map(3);
-    auto atom3 = writer->atom->x[i3];
+    auto *atom3 = writer->atom->x[i3];
 
     // evaluate energy and force at each of N distances
 

--- a/src/arg_info.cpp
+++ b/src/arg_info.cpp
@@ -103,7 +103,7 @@ ArgInfo::ArgInfo(const std::string &arg, int allowed) : type(NONE), dim(0), inde
 
 char *ArgInfo::copy_name()
 {
-  auto dest = new char[name.size() + 1];
+  auto *dest = new char[name.size() + 1];
   strcpy(dest, name.c_str());    // NOLINT
   return dest;
 }

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -810,7 +810,7 @@ std::string Atom::get_style()
 {
   std::string retval = atom_style;
   if (retval == "hybrid") {
-    auto avec_hybrid = dynamic_cast<AtomVecHybrid *>(avec);
+    auto *avec_hybrid = dynamic_cast<AtomVecHybrid *>(avec);
     if (avec_hybrid) {
       for (int i = 0; i < avec_hybrid->nstyles; i++) {
         retval += ' ';
@@ -830,7 +830,7 @@ AtomVec *Atom::style_match(const char *style)
 {
   if (strcmp(atom_style,style) == 0) return avec;
   else if (strcmp(atom_style,"hybrid") == 0) {
-    auto avec_hybrid = dynamic_cast<AtomVecHybrid *>(avec);
+    auto *avec_hybrid = dynamic_cast<AtomVecHybrid *>(avec);
     for (int i = 0; i < avec_hybrid->nstyles; i++)
       if (strcmp(avec_hybrid->keywords[i],style) == 0)
         return avec_hybrid->styles[i];
@@ -1092,7 +1092,7 @@ void Atom::data_atoms(int n, char *buf, tagint id_offset, tagint mol_offset,
   double *coord;
   char *next;
   std::string typestr;
-  auto location = "Atoms section of data file";
+  const auto *location = "Atoms section of data file";
 
   // use the first line to detect and validate the number of words/tokens per line
 
@@ -1348,7 +1348,7 @@ void Atom::data_bonds(int n, char *buf, int *count, tagint id_offset,
   char *next;
   std::string typestr;
   int newton_bond = force->newton_bond;
-  auto location = "Bonds section of data file";
+  const auto *location = "Bonds section of data file";
 
   for (int i = 0; i < n; i++) {
     next = strchr(buf,'\n');
@@ -1441,7 +1441,7 @@ void Atom::data_angles(int n, char *buf, int *count, tagint id_offset,
   char *next;
   std::string typestr;
   int newton_bond = force->newton_bond;
-  auto location = "Angles section of data file";
+  const auto *location = "Angles section of data file";
 
   for (int i = 0; i < n; i++) {
     next = strchr(buf,'\n');
@@ -1550,7 +1550,7 @@ void Atom::data_dihedrals(int n, char *buf, int *count, tagint id_offset,
   char *next;
   std::string typestr;
   int newton_bond = force->newton_bond;
-  auto location = "Dihedrals section of data file";
+  const auto *location = "Dihedrals section of data file";
 
   for (int i = 0; i < n; i++) {
     next = strchr(buf,'\n');
@@ -1678,7 +1678,7 @@ void Atom::data_impropers(int n, char *buf, int *count, tagint id_offset,
   char *next;
   std::string typestr;
   int newton_bond = force->newton_bond;
-  auto location = "Impropers section of data file";
+  const auto *location = "Impropers section of data file";
 
   for (int i = 0; i < n; i++) {
     next = strchr(buf,'\n');
@@ -1956,7 +1956,7 @@ void Atom::set_mass(const char *file, int line, const char *str, int type_offset
 
   int itype;
   double mass_one;
-  auto location = "Masses section of data file";
+  const auto *location = "Masses section of data file";
   auto values = Tokenizer(str).as_vector();
   int nwords = values.size();
   for (std::size_t i = 0; i < values.size(); ++i) {
@@ -2113,8 +2113,8 @@ int Atom::shape_consistency(int itype, double &shapex, double &shapey, double &s
   double one[3] = {-1.0, -1.0, -1.0};
   double *shape;
 
-  auto avec_ellipsoid = dynamic_cast<AtomVecEllipsoid *>(style_match("ellipsoid"));
-  auto bonus = avec_ellipsoid->bonus;
+  auto *avec_ellipsoid = dynamic_cast<AtomVecEllipsoid *>(style_match("ellipsoid"));
+  auto *bonus = avec_ellipsoid->bonus;
 
   int flag = 0;
   for (int i = 0; i < nlocal; i++) {
@@ -2489,7 +2489,7 @@ void Atom::setup_sort_bins()
 
 #ifdef LMP_GPU
   if (userbinsize == 0.0) {
-    auto ifix = dynamic_cast<FixGPU *>(modify->get_fix_by_id("package_gpu"));
+    auto *ifix = dynamic_cast<FixGPU *>(modify->get_fix_by_id("package_gpu"));
     if (ifix) {
       const double subx = domain->subhi[0] - domain->sublo[0];
       const double suby = domain->subhi[1] - domain->sublo[1];

--- a/src/balance.cpp
+++ b/src/balance.cpp
@@ -353,7 +353,7 @@ void Balance::command(int narg, char **arg)
   // set disable = 0, so weights migrate with atoms for imbfinal calculation
 
   if (domain->triclinic) domain->x2lamda(atom->nlocal);
-  auto irregular = new Irregular(lmp);
+  auto *irregular = new Irregular(lmp);
   if (wtflag) fixstore->disable = 0;
   if (style == BISECTION) irregular->migrate_atoms(sortflag,1,rcb->sendproc);
   else irregular->migrate_atoms(sortflag);

--- a/src/bond_deprecated.cpp
+++ b/src/bond_deprecated.cpp
@@ -34,7 +34,7 @@ void BondDeprecated::settings(int, char **)
   // called, our style was just added at the end of the list of substyles
 
   if (utils::strmatch(my_style, "^hybrid")) {
-    auto hybrid = dynamic_cast<BondHybrid *>(force->bond);
+    auto *hybrid = dynamic_cast<BondHybrid *>(force->bond);
     my_style = hybrid->keywords[hybrid->nstyles];
   }
 

--- a/src/change_box.cpp
+++ b/src/change_box.cpp
@@ -367,7 +367,7 @@ void ChangeBox::command(int narg, char **arg)
 
   if (domain->triclinic) domain->x2lamda(atom->nlocal);
   domain->reset_box();
-  auto irregular = new Irregular(lmp);
+  auto *irregular = new Irregular(lmp);
   irregular->migrate_atoms(1);
   delete irregular;
   if (domain->triclinic) domain->lamda2x(atom->nlocal);

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -570,7 +570,7 @@ void Comm::set_proc_grid(int outflag)
 
   // create ProcMap class to create 3d grid and map procs to it
 
-  auto pmap = new ProcMap(lmp);
+  auto *pmap = new ProcMap(lmp);
 
   // create 3d grid of processors
   // produces procgrid and coregrid (if relevant)
@@ -934,7 +934,7 @@ rendezvous_irregular(int n, char *inbuf, int insize, int inorder, int *procs,
 {
   // irregular comm of inbuf from caller decomp to rendezvous decomp
 
-  auto irregular = new Irregular(lmp);
+  auto *irregular = new Irregular(lmp);
 
   int nrvous;
   if (inorder) nrvous = irregular->create_data_grouped(n,procs);
@@ -942,7 +942,7 @@ rendezvous_irregular(int n, char *inbuf, int insize, int inorder, int *procs,
 
   // add 1 item to the allocated buffer size, so the returned pointer is not a null pointer
 
-  auto inbuf_rvous = (char *) memory->smalloc((bigint) nrvous*insize+1, "rendezvous:inbuf");
+  auto *inbuf_rvous = (char *) memory->smalloc((bigint) nrvous*insize+1, "rendezvous:inbuf");
   irregular->exchange_data(inbuf,insize,inbuf_rvous);
 
   bigint irregular1_bytes = irregular->memory_usage();
@@ -1082,7 +1082,7 @@ rendezvous_all2all(int n, char *inbuf, int insize, int inorder, int *procs,
   // all2all comm of inbuf from caller decomp to rendezvous decomp
   // add 1 item to the allocated buffer size, so the returned pointer is not a null pointer
 
-  auto inbuf_rvous = (char *) memory->smalloc((bigint) nrvous*insize+1, "rendezvous:inbuf");
+  auto *inbuf_rvous = (char *) memory->smalloc((bigint) nrvous*insize+1, "rendezvous:inbuf");
   memset(inbuf_rvous,0,(bigint) nrvous*insize*sizeof(char));
 
   MPI_Alltoallv(inbuf_a2a,sendcount,sdispls,MPI_CHAR,

--- a/src/compute.cpp
+++ b/src/compute.cpp
@@ -165,7 +165,7 @@ void Compute::modify_params(int narg, char **arg)
 void Compute::adjust_dof_fix()
 {
   fix_dof = 0;
-  for (auto &ifix : modify->get_fix_list())
+  for (const auto &ifix : modify->get_fix_list())
     if (ifix->dof_flag)
       fix_dof += ifix->dof(igroup);
 }

--- a/src/compute_centro_atom.cpp
+++ b/src/compute_centro_atom.cpp
@@ -150,7 +150,7 @@ void ComputeCentroAtom::compute_peratom()
 
   int nhalf = nnn / 2;
   int npairs = nnn * (nnn - 1) / 2;
-  auto pairs = new double[npairs];
+  auto *pairs = new double[npairs];
 
   // compute centro-symmetry parameter for each atom in group
   // use full neighbor list

--- a/src/compute_centroid_stress_atom.cpp
+++ b/src/compute_centroid_stress_atom.cpp
@@ -87,7 +87,7 @@ ComputeCentroidStressAtom::ComputeCentroidStressAtom(LAMMPS *lmp, int narg, char
   else {
     id_temp = utils::strdup(arg[3]);
 
-    auto compute = modify->get_compute_by_id(id_temp);
+    auto *compute = modify->get_compute_by_id(id_temp);
     if (!compute)
       error->all(FLERR, "Could not find compute centroid/stress/atom temperature ID {}", id_temp);
     if (compute->tempflag == 0)
@@ -195,7 +195,7 @@ void ComputeCentroidStressAtom::init()
       error->all(FLERR, "KSpace style does not support compute centroid/stress/atom");
 
   if (fixflag) {
-    for (auto &ifix : modify->get_fix_list())
+    for (const auto &ifix : modify->get_fix_list())
       if (ifix->virial_peratom_flag && (ifix->centroidstressflag == CENTROID_NOTAVAIL))
         error->all(FLERR, "Fix {} does not support compute centroid/stress/atom", ifix->style);
   }
@@ -308,7 +308,7 @@ void ComputeCentroidStressAtom::compute_peratom()
   // fix styles are CENTROID_SAME, CENTROID_AVAIL or CENTROID_NOTAVAIL
 
   if (fixflag) {
-    for (auto &ifix : modify->get_fix_list())
+    for (const auto &ifix : modify->get_fix_list())
       if (ifix->virial_peratom_flag && ifix->thermo_virial) {
         if (ifix->centroidstressflag == CENTROID_AVAIL) {
           double **cvatom = ifix->cvatom;

--- a/src/compute_chunk_atom.cpp
+++ b/src/compute_chunk_atom.cpp
@@ -1157,8 +1157,8 @@ void ComputeChunkAtom::compress_chunk_ids()
 
 void ComputeChunkAtom::idring(int n, char *cbuf, void *ptr)
 {
-  auto cptr = (ComputeChunkAtom *) ptr;
-  auto list = (tagint *) cbuf;
+  auto *cptr = (ComputeChunkAtom *) ptr;
+  auto *list = (tagint *) cbuf;
   std::map<tagint, int> *hash = cptr->hash;
   for (int i = 0; i < n; i++) (*hash)[list[i]] = 0;
 }

--- a/src/compute_chunk_spread_atom.cpp
+++ b/src/compute_chunk_spread_atom.cpp
@@ -87,7 +87,7 @@ ComputeChunkSpreadAtom(LAMMPS *lmp, int narg, char **arg) :
 
   for (auto &val : values) {
     if (val.which == ArgInfo::COMPUTE) {
-      auto icompute = modify->get_compute_by_id(val.id);
+      auto *icompute = modify->get_compute_by_id(val.id);
       if (!icompute)
         error->all(FLERR, val.iarg, "Compute ID {} for compute chunk/spread/atom does not exist",
                    val.id);
@@ -115,7 +115,7 @@ ComputeChunkSpreadAtom(LAMMPS *lmp, int narg, char **arg) :
       val.val.c = icompute;
 
     } else if (val.which == ArgInfo::FIX) {
-      auto ifix = modify->get_fix_by_id(val.id);
+      auto *ifix = modify->get_fix_by_id(val.id);
       if (!ifix)
         error->all(FLERR, val.iarg,
                    "Fix ID {} for compute chunk/spread/atom does not exist", val.id);

--- a/src/compute_coord_atom.cpp
+++ b/src/compute_coord_atom.cpp
@@ -80,7 +80,7 @@ ComputeCoordAtom::ComputeCoordAtom(LAMMPS *lmp, int narg, char **arg) :
 
     id_orientorder = utils::strdup(arg[4]);
 
-    auto iorientorder = modify->get_compute_by_id(id_orientorder);
+    auto *iorientorder = modify->get_compute_by_id(id_orientorder);
     if (!iorientorder)
       error->all(FLERR, "Could not find compute coord/atom compute ID {}", id_orientorder);
     if (!utils::strmatch(iorientorder->style, "^orientorder/atom"))

--- a/src/compute_dipole.cpp
+++ b/src/compute_dipole.cpp
@@ -64,14 +64,14 @@ void ComputeDipole::compute_vector()
 {
   invoked_vector = update->ntimestep;
 
-  const auto x = atom->x;
-  const auto mask = atom->mask;
-  const auto type = atom->type;
-  const auto image = atom->image;
-  const auto mass = atom->mass;
-  const auto rmass = atom->rmass;
-  const auto q = atom->q;
-  const auto mu = atom->mu;
+  auto *const x = atom->x;
+  auto *const mask = atom->mask;
+  auto *const type = atom->type;
+  auto *const image = atom->image;
+  auto *const mass = atom->mass;
+  auto *const rmass = atom->rmass;
+  auto *const q = atom->q;
+  auto *const mu = atom->mu;
   const auto nlocal = atom->nlocal;
 
   double dipole[3] = {0.0, 0.0, 0.0};

--- a/src/compute_heat_flux.cpp
+++ b/src/compute_heat_flux.cpp
@@ -44,19 +44,19 @@ ComputeHeatFlux::ComputeHeatFlux(LAMMPS *lmp, int narg, char **arg) :
   // ensure they are valid for these computations
 
   id_ke = utils::strdup(arg[3]);
-  auto ike = modify->get_compute_by_id(id_ke);
+  auto *ike = modify->get_compute_by_id(id_ke);
   if (!ike) error->all(FLERR,"Could not find compute heat/flux compute ID {}", id_ke);
   if (!utils::strmatch(ike->style,"^ke/atom"))
     error->all(FLERR,"Compute heat/flux compute ID {} does not compute ke/atom", id_ke);
 
   id_pe = utils::strdup(arg[4]);
-  auto ipe = modify->get_compute_by_id(id_pe);
+  auto *ipe = modify->get_compute_by_id(id_pe);
   if (!ipe) error->all(FLERR,"Could not find compute heat/flux compute ID {}", id_pe);
   if (ipe->peatomflag == 0)
     error->all(FLERR,"Compute heat/flux compute ID {} does not compute pe/atom", id_pe);
 
   id_stress = utils::strdup(arg[5]);
-  auto istress = modify->get_compute_by_id(id_stress);
+  auto *istress = modify->get_compute_by_id(id_stress);
   if (!istress) error->all(FLERR,"Could not find compute heat/flux compute ID {}", id_stress);
   if ((istress->pressatomflag != 1) && (istress->pressatomflag != 2))
     error->all(FLERR,

--- a/src/compute_pair_local.cpp
+++ b/src/compute_pair_local.cpp
@@ -143,7 +143,7 @@ void ComputePairLocal::init()
   // this should enable it to always be a copy list (e.g. for granular pstyle)
 
   int neighflags = NeighConst::REQ_OCCASIONAL;
-  auto pairrequest = neighbor->find_request(force->pair);
+  auto *pairrequest = neighbor->find_request(force->pair);
   if (pairrequest && pairrequest->get_size()) neighflags |= NeighConst::REQ_SIZE;
   neighbor->add_request(this, neighflags);
 }

--- a/src/compute_pressure.cpp
+++ b/src/compute_pressure.cpp
@@ -56,7 +56,7 @@ ComputePressure::ComputePressure(LAMMPS *lmp, int narg, char **arg) :
     id_temp = nullptr;
   } else {
     id_temp = utils::strdup(arg[3]);
-    auto icompute = modify->get_compute_by_id(id_temp);
+    auto *icompute = modify->get_compute_by_id(id_temp);
     if (!icompute)
       error->all(FLERR, 3, "Could not find compute pressure temperature ID {}", id_temp);
     if (!icompute->tempflag)
@@ -201,14 +201,14 @@ void ComputePressure::init()
     if (improperflag && force->improper) nvirial++;
   }
   if (fixflag)
-    for (auto &ifix : modify->get_fix_list())
+    for (const auto &ifix : modify->get_fix_list())
       if (ifix->thermo_virial) nvirial++;
 
   if (nvirial) {
     vptr = new double*[nvirial];
     nvirial = 0;
     if (pairhybridflag && force->pair) {
-      auto ph = dynamic_cast<PairHybrid *>(force->pair);
+      auto *ph = dynamic_cast<PairHybrid *>(force->pair);
       ph->no_virial_fdotr_compute = 1;
       vptr[nvirial++] = pairhybrid->virial;
     }
@@ -220,7 +220,7 @@ void ComputePressure::init()
     if (improperflag && force->improper)
       vptr[nvirial++] = force->improper->virial;
     if (fixflag)
-    for (auto &ifix : modify->get_fix_list())
+    for (const auto &ifix : modify->get_fix_list())
       if (ifix->virial_global_flag && ifix->thermo_virial)
           vptr[nvirial++] = ifix->virial;
   }

--- a/src/compute_property_local.cpp
+++ b/src/compute_property_local.cpp
@@ -261,7 +261,7 @@ void ComputePropertyLocal::init()
 
   if (kindflag == NEIGH || kindflag == PAIR) {
     int neighflags = NeighConst::REQ_OCCASIONAL;
-    auto pairrequest = neighbor->find_request(force->pair);
+    auto *pairrequest = neighbor->find_request(force->pair);
     if (pairrequest && pairrequest->get_size()) neighflags |= NeighConst::REQ_SIZE;
     neighbor->add_request(this, neighflags);
   }

--- a/src/compute_rdf.cpp
+++ b/src/compute_rdf.cpp
@@ -214,7 +214,7 @@ void ComputeRDF::init()
   //   (until next reneighbor), so it needs to contain atoms further
   //   than cutoff_user apart, just like a normal neighbor list does
 
-  auto req = neighbor->add_request(this, NeighConst::REQ_OCCASIONAL);
+  auto *req = neighbor->add_request(this, NeighConst::REQ_OCCASIONAL);
   if (cutflag) {
     if ((neighbor->style == Neighbor::MULTI) || (neighbor->style == Neighbor::MULTI_OLD))
       error->all(FLERR, Error::NOLASTLINE,

--- a/src/compute_stress_atom.cpp
+++ b/src/compute_stress_atom.cpp
@@ -54,7 +54,7 @@ ComputeStressAtom::ComputeStressAtom(LAMMPS *lmp, int narg, char **arg) :
     id_temp = nullptr;
   else {
     id_temp = utils::strdup(arg[3]);
-    auto icompute = modify->get_compute_by_id(id_temp);
+    auto *icompute = modify->get_compute_by_id(id_temp);
     if (!icompute)
       error->all(FLERR, "Could not find compute stress/atom temperature compute {}", id_temp);
     if (icompute->tempflag == 0)
@@ -220,7 +220,7 @@ void ComputeStressAtom::compute_peratom()
   //   and fix ave/chunk uses a per-atom stress from this compute as input
 
   if (fixflag) {
-    for (auto &ifix : modify->get_fix_list())
+    for (const auto &ifix : modify->get_fix_list())
       if (ifix->virial_peratom_flag && ifix->thermo_virial) {
         double **vatom = ifix->vatom;
         if (vatom)

--- a/src/create_box.cpp
+++ b/src/create_box.cpp
@@ -86,7 +86,7 @@ void CreateBox::command(int narg, char **arg)
 
     } else {
       domain->triclinic = 1;
-      auto prism = dynamic_cast<RegPrism *>(region);
+      auto *prism = dynamic_cast<RegPrism *>(region);
       domain->boxlo[0] = prism->xlo;
       domain->boxhi[0] = prism->xhi;
       domain->boxlo[1] = prism->ylo;

--- a/src/delete_atoms.cpp
+++ b/src/delete_atoms.cpp
@@ -148,10 +148,10 @@ void DeleteAtoms::command(int narg, char **arg)
 
   // reset bonus data counts
 
-  auto avec_ellipsoid = dynamic_cast<AtomVecEllipsoid *>(atom->style_match("ellipsoid"));
-  auto avec_line = dynamic_cast<AtomVecLine *>(atom->style_match("line"));
-  auto avec_tri = dynamic_cast<AtomVecTri *>(atom->style_match("tri"));
-  auto avec_body = dynamic_cast<AtomVecBody *>(atom->style_match("body"));
+  auto *avec_ellipsoid = dynamic_cast<AtomVecEllipsoid *>(atom->style_match("ellipsoid"));
+  auto *avec_line = dynamic_cast<AtomVecLine *>(atom->style_match("line"));
+  auto *avec_tri = dynamic_cast<AtomVecTri *>(atom->style_match("tri"));
+  auto *avec_body = dynamic_cast<AtomVecBody *>(atom->style_match("body"));
   bigint nlocal_bonus;
 
   if (atom->nellipsoids > 0) {
@@ -245,7 +245,7 @@ void DeleteAtoms::delete_region(int narg, char **arg)
 {
   if (narg < 2) utils::missing_cmd_args(FLERR, "delete_atoms region", error);
 
-  auto iregion = domain->get_region_by_id(arg[1]);
+  auto *iregion = domain->get_region_by_id(arg[1]);
   if (!iregion) error->all(FLERR, "Could not find delete_atoms region ID {}", arg[1]);
   iregion->prematch();
 
@@ -317,7 +317,7 @@ void DeleteAtoms::delete_overlap(int narg, char **arg)
 
   // build neighbor list this command needs based on the earlier request
 
-  auto list = neighbor->find_list(this);
+  auto *list = neighbor->find_list(this);
   neighbor->build_one(list);
 
   // allocate and initialize deletion list
@@ -445,14 +445,14 @@ void DeleteAtoms::delete_random(int narg, char **arg)
   }
 
   int groupbit = group->get_bitmask_by_id(FLERR, arg[4], "delete_atoms");
-  auto region = domain->get_region_by_id(arg[5]);
+  auto *region = domain->get_region_by_id(arg[5]);
   if (!region && (strcmp(arg[5], "NULL") != 0))
     error->all(FLERR, "Could not find delete_atoms random region ID {}", arg[5]);
 
   int seed = utils::inumeric(FLERR, arg[6], false, lmp);
   options(narg - 7, &arg[7]);
 
-  auto ranmars = new RanMars(lmp, seed + comm->me);
+  auto *ranmars = new RanMars(lmp, seed + comm->me);
 
   // allocate and initialize deletion list
 
@@ -711,8 +711,8 @@ void DeleteAtoms::recount_topology()
 
 void DeleteAtoms::bondring(int nbuf, char *cbuf, void *ptr)
 {
-  auto daptr = (DeleteAtoms *) ptr;
-  auto list = (tagint *) cbuf;
+  auto *daptr = (DeleteAtoms *) ptr;
+  auto *list = (tagint *) cbuf;
   std::map<tagint, int> *hash = daptr->hash;
 
   int *num_bond = daptr->atom->num_bond;
@@ -841,8 +841,8 @@ void DeleteAtoms::bondring(int nbuf, char *cbuf, void *ptr)
 
 void DeleteAtoms::molring(int n, char *cbuf, void *ptr)
 {
-  auto daptr = (DeleteAtoms *) ptr;
-  auto list = (tagint *) cbuf;
+  auto *daptr = (DeleteAtoms *) ptr;
+  auto *list = (tagint *) cbuf;
   int *dlist = daptr->dlist;
   std::map<tagint, int> *hash = daptr->hash;
   int nlocal = daptr->atom->nlocal;

--- a/src/dihedral.cpp
+++ b/src/dihedral.cpp
@@ -405,7 +405,7 @@ void Dihedral::ev_tally(int i1, int i2, int i3, int i4, int nlocal, int newton_b
 
 void Dihedral::problem(const char *filename, int lineno, int i1, int i2, int i3, int i4)
 {
-  const auto x = atom->x;
+  auto *const x = atom->x;
   auto warn = fmt::format("Dihedral problem: {} {} {} {} {} {}\n", comm->me, update->ntimestep,
                           atom->tag[i1], atom->tag[i2], atom->tag[i3], atom->tag[i4]);
   warn += fmt::format("WARNING:   1st atom: {} {:.8} {:.8} {:.8}\n", comm->me, x[i1][0], x[i1][1],

--- a/src/dihedral_deprecated.cpp
+++ b/src/dihedral_deprecated.cpp
@@ -35,7 +35,7 @@ void DihedralDeprecated::settings(int, char **)
   // of the list of substyles
 
   if (utils::strmatch(my_style, "^hybrid")) {
-    auto hybrid = dynamic_cast<DihedralHybrid *>(force->dihedral);
+    auto *hybrid = dynamic_cast<DihedralHybrid *>(force->dihedral);
     my_style = hybrid->keywords[hybrid->nstyles];
   }
 

--- a/src/dihedral_write.cpp
+++ b/src/dihedral_write.cpp
@@ -45,7 +45,7 @@ void DihedralWrite::command(int narg, char **arg)
     error->all(FLERR, "Dihedral_write command before simulation box is defined" + utils::errorurl(33));
   if (atom->avec->dihedrals_allow == 0)
     error->all(FLERR, "Dihedral_write command when no dihedrals allowed");
-  auto dihedral = force->dihedral;
+  auto *dihedral = force->dihedral;
   if (dihedral == nullptr)
     error->all(FLERR, "Dihedral_write command before an dihedral_style is defined" + utils::errorurl(33));
   if (dihedral && (force->dihedral->writedata == 0))
@@ -124,7 +124,7 @@ void DihedralWrite::command(int narg, char **arg)
   if (comm->me == 0) {
     // set up new LAMMPS instance with dummy system to evaluate dihedral potential
     LAMMPS::argv args = {"DihedralWrite", "-nocite", "-echo", "screen", "-log", "none"};
-    LAMMPS *writer = new LAMMPS(args, singlecomm);
+    auto *writer = new LAMMPS(args, singlecomm);
 
     // create dummy system replicating dihedral style settings
     writer->input->one(fmt::format("units {}", update->unit_style));
@@ -165,7 +165,7 @@ void DihedralWrite::command(int narg, char **arg)
 
     double theta, phi, phi1, phi2, f;
     dihedral = writer->force->dihedral;
-    auto atom4 = writer->atom->x[writer->atom->map(4)];
+    auto *atom4 = writer->atom->x[writer->atom->map(4)];
 
     // evaluate energy and force at each of N distances
 

--- a/src/displace_atoms.cpp
+++ b/src/displace_atoms.cpp
@@ -179,7 +179,7 @@ void DisplaceAtoms::command(int narg, char **arg)
   // makes atom result independent of what proc owns it via random->reset()
 
   if (style == RANDOM) {
-    auto random = new RanPark(lmp,1);
+    auto *random = new RanPark(lmp,1);
 
     double dx = xscale*utils::numeric(FLERR,arg[2],false,lmp);
     double dy = yscale*utils::numeric(FLERR,arg[3],false,lmp);
@@ -269,10 +269,10 @@ void DisplaceAtoms::command(int narg, char **arg)
 
     // AtomVec pointers to retrieve per-atom storage of extra quantities
 
-    auto avec_ellipsoid = dynamic_cast<AtomVecEllipsoid *>(atom->style_match("ellipsoid"));
-    auto avec_line = dynamic_cast<AtomVecLine *>(atom->style_match("line"));
-    auto avec_tri = dynamic_cast<AtomVecTri *>(atom->style_match("tri"));
-    auto avec_body = dynamic_cast<AtomVecBody *>(atom->style_match("body"));
+    auto *avec_ellipsoid = dynamic_cast<AtomVecEllipsoid *>(atom->style_match("ellipsoid"));
+    auto *avec_line = dynamic_cast<AtomVecLine *>(atom->style_match("line"));
+    auto *avec_tri = dynamic_cast<AtomVecTri *>(atom->style_match("tri"));
+    auto *avec_body = dynamic_cast<AtomVecBody *>(atom->style_match("body"));
 
     double **x = atom->x;
     double **quat_atom = atom->quat;
@@ -357,7 +357,7 @@ void DisplaceAtoms::command(int narg, char **arg)
 
   if (domain->triclinic) domain->x2lamda(atom->nlocal);
   domain->reset_box();
-  auto irregular = new Irregular(lmp);
+  auto *irregular = new Irregular(lmp);
   irregular->migrate_atoms(1);
   delete irregular;
   if (domain->triclinic) domain->lamda2x(atom->nlocal);

--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -100,7 +100,7 @@ Domain::Domain(LAMMPS *lmp) : Pointers(lmp)
   boxhi_lamda[0] = boxhi_lamda[1] = boxhi_lamda[2] = 1.0;
 
   lattice = nullptr;
-  auto args = new char*[2];
+  auto *args = new char*[2];
   args[0] = (char *) "none";
   args[1] = (char *) "1.0";
   set_lattice(2,args);
@@ -125,7 +125,7 @@ Domain::~Domain()
 {
   if (copymode) return;
 
-  for (auto &reg : regions) delete reg;
+  for (const auto &reg : regions) delete reg;
   regions.clear();
   delete lattice;
   delete region_map;
@@ -190,7 +190,7 @@ void Domain::init()
 
   // region inits
 
-  for (auto &reg : regions) reg->init();
+  for (const auto &reg : regions) reg->init();
 }
 
 /* ----------------------------------------------------------------------
@@ -2039,7 +2039,7 @@ void Domain::delete_region(Region *reg)
 
 void Domain::delete_region(const std::string &id)
 {
-  auto reg = get_region_by_id(id);
+  auto *reg = get_region_by_id(id);
   if (!reg) error->all(FLERR,"Delete region {} does not exist", id);
   delete_region(reg);
 }
@@ -2051,7 +2051,7 @@ void Domain::delete_region(const std::string &id)
 
 Region *Domain::get_region_by_id(const std::string &name) const
 {
-  for (auto &reg : regions)
+  for (const auto &reg : regions)
     if (name == reg->id) return reg;
   return nullptr;
 }
@@ -2066,7 +2066,7 @@ const std::vector<Region *> Domain::get_region_by_style(const std::string &name)
   std::vector<Region *> matches;
   if (name.empty()) return matches;
 
-  for (auto &reg : regions)
+  for (const auto &reg : regions)
     if (name == reg->style)  matches.push_back(reg);
 
   return matches;

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -869,7 +869,7 @@ int Dump::idcompare(const int i, const int j, void *ptr)
 
 int Dump::bufcompare(const int i, const int j, void *ptr)
 {
-  auto dptr = (Dump *) ptr;
+  auto *dptr = (Dump *) ptr;
   double *bufsort     = dptr->bufsort;
   const int size_one  = dptr->size_one;
   const int sortcolm1 = dptr->sortcolm1;
@@ -890,7 +890,7 @@ int Dump::bufcompare(const int i, const int j, void *ptr)
 
 int Dump::bufcompare_reverse(const int i, const int j, void *ptr)
 {
-  auto dptr = (Dump *) ptr;
+  auto *dptr = (Dump *) ptr;
   double *bufsort     = dptr->bufsort;
   const int size_one  = dptr->size_one;
   const int sortcolm1 = dptr->sortcolm1;
@@ -966,7 +966,7 @@ void Dump::balance()
   // post recvs first
 
   int nswap = 0;
-  auto request = new MPI_Request[nprocs];
+  auto *request = new MPI_Request[nprocs];
 
   // find which proc starting atom belongs to
 

--- a/src/dump_custom.cpp
+++ b/src/dump_custom.cpp
@@ -778,7 +778,7 @@ int DumpCustom::count()
   // un-choose if not in region
 
   if (idregion) {
-    auto region = domain->get_region_by_id(idregion);
+    auto *region = domain->get_region_by_id(idregion);
     region->prematch();
     double **x = atom->x;
     for (i = 0; i < nlocal; i++)
@@ -1646,7 +1646,7 @@ int DumpCustom::parse_fields(int narg, char **arg)
       ArgInfo argi(arg[iarg], ArgInfo::COMPUTE | ArgInfo::FIX | ArgInfo::VARIABLE |
                    ArgInfo::DNAME | ArgInfo::INAME);
       argindex[iarg] = argi.get_index1();
-      auto name = argi.get_name();
+      const auto *name = argi.get_name();
       Compute *icompute = nullptr;
       Fix *ifix = nullptr;
 
@@ -2110,7 +2110,7 @@ int DumpCustom::modify_param(int narg, char **arg)
       ArgInfo argi(arg[1], ArgInfo::COMPUTE | ArgInfo::FIX | ArgInfo::VARIABLE |
                    ArgInfo::DNAME | ArgInfo::INAME);
       argindex[nfield+nthresh] = argi.get_index1();
-      auto name = argi.get_name();
+      const auto *name = argi.get_name();
       Compute *icompute = nullptr;
       Fix *ifix = nullptr;
 

--- a/src/dump_grid.cpp
+++ b/src/dump_grid.cpp
@@ -669,11 +669,11 @@ int DumpGrid::parse_fields(int narg, char **arg)
     // grid reference is to a compute or fix
 
     if (iflag == ArgInfo::COMPUTE) {
-      auto icompute = lmp->modify->get_compute_by_id(id);
+      auto *icompute = lmp->modify->get_compute_by_id(id);
       field2index[iarg] = add_compute(id,icompute);
       field2source[iarg] = COMPUTE;
     } else if (iflag == ArgInfo::FIX) {
-      auto ifix = modify->get_fix_by_id(id);
+      auto *ifix = modify->get_fix_by_id(id);
       field2index[iarg] = add_fix(id,ifix);
       field2source[iarg] = FIX;
     }

--- a/src/dump_local.cpp
+++ b/src/dump_local.cpp
@@ -471,7 +471,7 @@ void DumpLocal::parse_fields(int narg, char **arg)
       computefixflag = 1;
       vtype[iarg] = Dump::DOUBLE;
       argindex[iarg] = argi.get_index1();
-      auto name = argi.get_name();
+      const auto *name = argi.get_name();
       Compute *icompute = nullptr;
       Fix *ifix = nullptr;
 

--- a/src/fix_adapt.cpp
+++ b/src/fix_adapt.cpp
@@ -455,7 +455,7 @@ void FixAdapt::init()
       // if pair hybrid, test that ilo,ihi,jlo,jhi are valid for sub-style
 
       if (utils::strmatch(force->pair_style,"^hybrid")) {
-        auto pair = dynamic_cast<PairHybrid *>(force->pair);
+        auto *pair = dynamic_cast<PairHybrid *>(force->pair);
         if (pair) {
           for (i = ad->ilo; i <= ad->ihi; i++) {
             for (j = MAX(ad->jlo,i); j <= ad->jhi; j++) {
@@ -492,7 +492,7 @@ void FixAdapt::init()
       if (ad->bdim == 1) ad->vector = (double *) ptr;
 
       if (utils::strmatch(force->bond_style,"^hybrid")) {
-        auto bond = dynamic_cast<BondHybrid *>(force->bond);
+        auto *bond = dynamic_cast<BondHybrid *>(force->bond);
         if (bond) {
           for (i = ad->ilo; i <= ad->ihi; i++) {
             if (!bond->check_itype(i,bstyle))
@@ -527,7 +527,7 @@ void FixAdapt::init()
       if (ad->adim == 1) ad->vector = (double *) ptr;
 
       if (utils::strmatch(force->angle_style,"^hybrid")) {
-        auto angle = dynamic_cast<AngleHybrid *>(force->angle);
+        auto *angle = dynamic_cast<AngleHybrid *>(force->angle);
         if (angle) {
           for (i = ad->ilo; i <= ad->ihi; i++) {
             if (!angle->check_itype(i,astyle))
@@ -561,7 +561,7 @@ void FixAdapt::init()
       if (ad->ddim == 1) ad->vector = (double *) ptr;
 
       if (utils::strmatch(force->dihedral_style,"^hybrid")) {
-        auto dihedral = dynamic_cast<DihedralHybrid *>(force->dihedral);
+        auto *dihedral = dynamic_cast<DihedralHybrid *>(force->dihedral);
         if (dihedral) {
           for (i = ad->ilo; i <= ad->ihi; i++) {
             if (!dihedral->check_itype(i,dstyle))
@@ -595,7 +595,7 @@ void FixAdapt::init()
       if (ad->idim == 1) ad->vector = (double *) ptr;
 
       if (utils::strmatch(force->improper_style,"^hybrid")) {
-        auto improper = dynamic_cast<ImproperHybrid *>(force->improper);
+        auto *improper = dynamic_cast<ImproperHybrid *>(force->improper);
         if (improper) {
           for (i = ad->ilo; i <= ad->ihi; i++) {
             if (!improper->check_itype(i,istyle))
@@ -999,7 +999,7 @@ void FixAdapt::write_restart(FILE *fp)
 
 void FixAdapt::restart(char *buf)
 {
-  auto dbuf = (double *) buf;
+  auto *dbuf = (double *) buf;
 
   previous_diam_scale = dbuf[0];
   previous_chg_scale = dbuf[1];

--- a/src/fix_ave_grid.cpp
+++ b/src/fix_ave_grid.cpp
@@ -296,7 +296,7 @@ FixAveGrid::FixAveGrid(LAMMPS *lmp, int narg, char **arg) :
   if (modeatom) {
     for (int i = 0; i < nvalues; i++) {
       if (which[i] == ArgInfo::COMPUTE) {
-        auto icompute = modify->get_compute_by_id(ids[i]);
+        auto *icompute = modify->get_compute_by_id(ids[i]);
         if (!icompute)
           error->all(FLERR, iarg_orig[i], "Compute {} for fix ave/grid does not exist", ids[i]);
         if (icompute->peratom_flag == 0)
@@ -314,7 +314,7 @@ FixAveGrid::FixAveGrid(LAMMPS *lmp, int narg, char **arg) :
                      utils::errorurl(20));
 
       } else if (which[i] == ArgInfo::FIX) {
-        auto ifix = modify->get_fix_by_id(ids[i]);
+        auto *ifix = modify->get_fix_by_id(ids[i]);
         if (!ifix)
           error->all(FLERR, iarg_orig[i], "Fix {} for fix ave/atom does not exist", ids[i]);
         if (ifix->peratom_flag == 0)
@@ -1488,7 +1488,7 @@ void FixAveGrid::allocate_grid()
 
 FixAveGrid::GridData *FixAveGrid::allocate_one_grid()
 {
-  GridData *grid = new GridData();
+  auto *grid = new GridData();
 
   grid->vec2d = nullptr;
   grid->array2d = nullptr;
@@ -1536,7 +1536,7 @@ FixAveGrid::GridData *FixAveGrid::allocate_one_grid()
 
 FixAveGrid::GridData *FixAveGrid::clone_one_grid(GridData *src)
 {
-  GridData *grid = new GridData();
+  auto *grid = new GridData();
 
   grid->vec2d = src->vec2d;
   grid->array2d = src->array2d;
@@ -1843,7 +1843,7 @@ void FixAveGrid::pack_reverse_grid(int /*which*/, void *vbuf, int nlist, int *li
 {
   int i,j,m;
 
-  auto buf = (double *) vbuf;
+  auto *buf = (double *) vbuf;
   double *count,*data,*values;
   m = 0;
 
@@ -1882,7 +1882,7 @@ void FixAveGrid::unpack_reverse_grid(int /*which*/, void *vbuf, int nlist, int *
 {
   int i,j,m;
 
-  auto buf = (double *) vbuf;
+  auto *buf = (double *) vbuf;
   double *count,*data,*values;
 
   if (dimension == 2) {
@@ -1918,7 +1918,7 @@ void FixAveGrid::unpack_reverse_grid(int /*which*/, void *vbuf, int nlist, int *
 
 void FixAveGrid::pack_remap_grid(int /*which*/, void *vbuf, int nlist, int *list)
 {
-  auto buf = (double *) vbuf;
+  auto *buf = (double *) vbuf;
 
   int running_flag = 0;
   if (aveflag == RUNNING || aveflag == WINDOW) running_flag = 1;
@@ -1943,7 +1943,7 @@ void FixAveGrid::pack_remap_grid(int /*which*/, void *vbuf, int nlist, int *list
 
 void FixAveGrid::unpack_remap_grid(int /*which*/, void *vbuf, int nlist, int *list)
 {
-   auto buf = (double *) vbuf;
+   auto *buf = (double *) vbuf;
 
   int running_flag = 0;
   if (aveflag == RUNNING || aveflag == WINDOW) running_flag = 1;
@@ -2036,7 +2036,7 @@ void FixAveGrid::reset_grid()
 
   if (dimension == 2) {
     int tmp[8];
-    Grid2d *gridnew = new Grid2d(lmp, world, nxgrid, nygrid);
+    auto *gridnew = new Grid2d(lmp, world, nxgrid, nygrid);
     gridnew->set_distance(maxdist);
     gridnew->setup_grid(tmp[0], tmp[1], tmp[2], tmp[3],
                         tmp[4], tmp[5], tmp[6], tmp[7]);
@@ -2049,7 +2049,7 @@ void FixAveGrid::reset_grid()
   } else {
 
     int tmp[12];
-    Grid3d *gridnew = new Grid3d(lmp, world, nxgrid, nygrid, nzgrid);
+    auto *gridnew = new Grid3d(lmp, world, nxgrid, nygrid, nzgrid);
     gridnew->set_distance(maxdist);
     gridnew->setup_grid(tmp[0], tmp[1], tmp[2], tmp[3], tmp[4], tmp[5],
                         tmp[6], tmp[7], tmp[8], tmp[9], tmp[10], tmp[11]);

--- a/src/fix_ave_time.cpp
+++ b/src/fix_ave_time.cpp
@@ -439,7 +439,7 @@ FixAveTime::~FixAveTime()
   if (any_variable_length && ((nrepeat > 1) || (ave == RUNNING) || (ave == WINDOW))) {
     for (auto &val : values) {
       if (val.varlen) {
-        auto icompute = modify->get_compute_by_id(val.id);
+        auto *icompute = modify->get_compute_by_id(val.id);
         if (icompute) {
           if ((ave == RUNNING) || (ave == WINDOW))
             icompute->unlock(this);

--- a/src/fix_bond_history.cpp
+++ b/src/fix_bond_history.cpp
@@ -300,7 +300,7 @@ void FixBondHistory::write_restart(FILE *fp)
 void FixBondHistory::restart(char *buf)
 {
   int n = 0;
-  double *list = (double *) buf;
+  auto *list = (double *) buf;
   stored_flag = static_cast<int>(list[n++]);
 }
 

--- a/src/fix_deform.cpp
+++ b/src/fix_deform.cpp
@@ -623,7 +623,7 @@ void FixDeform::init()
 
   rfix.clear();
 
-  for (auto &ifix : modify->get_fix_list())
+  for (const auto &ifix : modify->get_fix_list())
     if (ifix->rigid_flag) rfix.push_back(ifix);
 }
 

--- a/src/fix_deposit.cpp
+++ b/src/fix_deposit.cpp
@@ -920,7 +920,7 @@ void FixDeposit::write_restart(FILE *fp)
 void FixDeposit::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
 
   seed = static_cast<int>(list[n++]);
   ninserted = static_cast<int>(list[n++]);

--- a/src/fix_dt_reset.cpp
+++ b/src/fix_dt_reset.cpp
@@ -195,7 +195,7 @@ void FixDtReset::end_of_step()
   update->dt_default = 0;
   if (respaflag) update->integrate->reset_dt();
   if (force->pair) force->pair->reset_dt();
-  for (auto &ifix : modify->get_fix_list()) ifix->reset_dt();
+  for (const auto &ifix : modify->get_fix_list()) ifix->reset_dt();
   output->reset_dt();
 }
 

--- a/src/fix_efield.cpp
+++ b/src/fix_efield.cpp
@@ -265,7 +265,7 @@ void FixEfield::init()
 void FixEfield::setup(int vflag)
 {
   if (utils::strmatch(update->integrate_style, "^respa")) {
-    auto respa = dynamic_cast<Respa *>(update->integrate);
+    auto *respa = dynamic_cast<Respa *>(update->integrate);
     respa->copy_flevel_f(ilevel_respa);
     post_force_respa(vflag, ilevel_respa, 0);
     respa->copy_f_flevel(ilevel_respa);

--- a/src/fix_halt.cpp
+++ b/src/fix_halt.cpp
@@ -285,7 +285,7 @@ void FixHalt::end_of_step()
   // send message to all other root processes to trigger exit across universe, if requested
 
   if (uflag && (comm->me == 0)) {
-    MPI_Request *req = new MPI_Request[universe->nworlds];
+    auto *req = new MPI_Request[universe->nworlds];
     for (int i = 0; i < universe->nworlds; ++i) {
       if (universe->me == universe->root_proc[i]) continue;
       MPI_Isend(&eflag, 1, MPI_INT, universe->root_proc[i], UTAG, universe->uworld, req + i);

--- a/src/fix_move.cpp
+++ b/src/fix_move.cpp
@@ -1304,7 +1304,7 @@ void FixMove::write_restart(FILE *fp)
 void FixMove::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
 
   time_origin = static_cast<int>(list[n++]);
 }

--- a/src/fix_nh.cpp
+++ b/src/fix_nh.cpp
@@ -635,8 +635,8 @@ void FixNH::init()
   // ensure no conflict with fix deform
 
   if (pstat_flag)
-    for (auto &ifix : modify->get_fix_by_style("^deform")) {
-      auto deform = dynamic_cast<FixDeform *>(ifix);
+    for (const auto &ifix : modify->get_fix_by_style("^deform")) {
+      auto *deform = dynamic_cast<FixDeform *>(ifix);
       if (deform) {
         int *dimflag = deform->dimflag;
         if ((p_flag[0] && dimflag[0]) || (p_flag[1] && dimflag[1]) ||
@@ -715,7 +715,7 @@ void FixNH::init()
   else kspace_flag = 0;
 
   if (utils::strmatch(update->integrate_style,"^respa")) {
-    auto respa_ptr = dynamic_cast<Respa *>(update->integrate);
+    auto *respa_ptr = dynamic_cast<Respa *>(update->integrate);
     if (!respa_ptr) error->all(FLERR, "Failure to access Respa style {}", update->integrate_style);
     nlevels_respa = respa_ptr->nlevels;
     step_respa = respa_ptr->step;
@@ -725,7 +725,7 @@ void FixNH::init()
   // detect if any rigid fixes exist so rigid bodies move when box is remapped
 
   rfix.clear();
-  for (auto &ifix : modify->get_fix_list())
+  for (const auto &ifix : modify->get_fix_list())
     if (ifix->rigid_flag) rfix.push_back(ifix);
 }
 
@@ -1333,7 +1333,7 @@ int FixNH::pack_restart_data(double *list)
 void FixNH::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
   int flag = static_cast<int> (list[n++]);
   if (flag) {
     int m = static_cast<int> (list[n++]);
@@ -1404,7 +1404,7 @@ int FixNH::modify_param(int narg, char **arg)
     // reset id_temp of pressure to new temperature ID
 
     if (pstat_flag) {
-      auto icompute = modify->get_compute_by_id(id_press);
+      auto *icompute = modify->get_compute_by_id(id_press);
       if (!icompute)
         error->all(FLERR,"Pressure ID {} for fix modify does not exist", id_press);
       icompute->reset_extra_compute_fix(id_temp);
@@ -1698,7 +1698,7 @@ void FixNH::reset_dt()
   // If using respa, then remap is performed in innermost level
 
   if (utils::strmatch(update->integrate_style,"^respa")) {
-    auto respa_ptr = dynamic_cast<Respa *>(update->integrate);
+    auto *respa_ptr = dynamic_cast<Respa *>(update->integrate);
     if (!respa_ptr) error->all(FLERR, "Failure to access Respa style {}", update->integrate_style);
     nlevels_respa = respa_ptr->nlevels;
     step_respa = respa_ptr->step;

--- a/src/fix_nvt_sllod.cpp
+++ b/src/fix_nvt_sllod.cpp
@@ -86,7 +86,7 @@ void FixNVTSllod::init()
   if (deform.size() < 1) error->all(FLERR,"Using fix {} with no fix deform defined", style);
 
   for (auto &ifix : deform) {
-    auto f = dynamic_cast<FixDeform *>(ifix);
+    auto *f = dynamic_cast<FixDeform *>(ifix);
     if (f && (f->remapflag != Domain::V_REMAP))
       error->all(FLERR,"Using fix {} with inconsistent fix deform remap option", style);
   }

--- a/src/fix_pair.cpp
+++ b/src/fix_pair.cpp
@@ -272,7 +272,7 @@ void FixPair::post_force(int /*vflag*/)
       error->one(FLERR, "Fix pair cannot extract property {} from pair style", fieldname[ifield]);
 
     if (columns == 0) {
-      double *pvector = (double *) pvoid;
+      auto *pvector = (double *) pvoid;
       if (ncols == 1) {
         for (int i = 0; i < nlocal; i++)
           vector[i] = pvector[i];
@@ -283,7 +283,7 @@ void FixPair::post_force(int /*vflag*/)
       icol++;
 
     } else {
-      double **parray = (double **) pvoid;
+      auto **parray = (double **) pvoid;
       int icoltmp = icol;
       for (int i = 0; i < nlocal; i++) {
         icol = icoltmp;

--- a/src/fix_press_berendsen.cpp
+++ b/src/fix_press_berendsen.cpp
@@ -294,7 +294,7 @@ void FixPressBerendsen::init()
   // detect if any rigid fixes exist so rigid bodies move when box is remapped
 
   rfix.clear();
-  for (auto &ifix : modify->get_fix_list())
+  for (const auto &ifix : modify->get_fix_list())
     if (ifix->rigid_flag) rfix.push_back(ifix);
 }
 
@@ -454,7 +454,7 @@ int FixPressBerendsen::modify_param(int narg, char **arg)
 
     // reset id_temp of pressure to new temperature ID
 
-    auto icompute = modify->get_compute_by_id(id_press);
+    auto *icompute = modify->get_compute_by_id(id_press);
     if (!icompute)
       error->all(FLERR, "Pressure compute ID {} for fix {} does not exist", id_press, style);
     icompute->reset_extra_compute_fix(id_temp);

--- a/src/fix_spring_chunk.cpp
+++ b/src/fix_spring_chunk.cpp
@@ -256,7 +256,7 @@ void FixSpringChunk::write_restart(FILE *fp)
 
 void FixSpringChunk::restart(char *buf)
 {
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
   int n = list[0];
 
   memory->destroy(com0);

--- a/src/fix_temp_berendsen.cpp
+++ b/src/fix_temp_berendsen.cpp
@@ -259,7 +259,7 @@ void FixTempBerendsen::write_restart(FILE *fp)
 
 void FixTempBerendsen::restart(char *buf)
 {
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
 
   energy = list[0];
 }

--- a/src/fix_temp_rescale.cpp
+++ b/src/fix_temp_rescale.cpp
@@ -260,7 +260,7 @@ void FixTempRescale::write_restart(FILE *fp)
 void FixTempRescale::restart(char *buf)
 {
   int n = 0;
-  auto list = (double *) buf;
+  auto *list = (double *) buf;
 
   energy = list[n++];
 }

--- a/src/fix_vector.cpp
+++ b/src/fix_vector.cpp
@@ -84,7 +84,7 @@ FixVector::FixVector(LAMMPS *lmp, int narg, char **arg) :
   bool first = true;
   for (auto &val : values) {
     if (val.which == ArgInfo::COMPUTE) {
-      auto icompute = modify->get_compute_by_id(val.id);
+      auto *icompute = modify->get_compute_by_id(val.id);
       if (!icompute) error->all(FLERR, "Compute ID {} for fix vector does not exist", val.id);
       if (val.argindex == 0 && icompute->scalar_flag == 0)
         error->all(FLERR, "Fix vector compute {} does not calculate a scalar", val.id);
@@ -103,7 +103,7 @@ FixVector::FixVector(LAMMPS *lmp, int narg, char **arg) :
       val.val.c = icompute;
 
     } else if (val.which == ArgInfo::FIX) {
-      auto ifix = modify->get_fix_by_id(val.id);
+      auto *ifix = modify->get_fix_by_id(val.id);
       if (!ifix) error->all(FLERR, "Fix ID {} for fix vector does not exist", val.id);
       if (val.argindex == 0 && ifix->scalar_flag == 0)
         error->all(FLERR, "Fix vector fix {} does not calculate a scalar", val.id);

--- a/src/fix_wall_region.cpp
+++ b/src/fix_wall_region.cpp
@@ -202,7 +202,7 @@ void FixWallRegion::init()
 void FixWallRegion::setup(int vflag)
 {
   if (utils::strmatch(update->integrate_style, "^respa")) {
-    auto respa = dynamic_cast<Respa *>(update->integrate);
+    auto *respa = dynamic_cast<Respa *>(update->integrate);
     respa->copy_flevel_f(ilevel_respa);
     post_force_respa(vflag, ilevel_respa, 0);
     respa->copy_f_flevel(ilevel_respa);

--- a/src/fix_wall_table.cpp
+++ b/src/fix_wall_table.cpp
@@ -389,7 +389,7 @@ void FixWallTable::spline(double *x, double *y, int n, double yp1, double ypn, d
 {
   int i, k;
   double p, qn, sig, un;
-  auto u = new double[n];
+  auto *u = new double[n];
 
   if (yp1 > BIGNUM)
     y2[0] = u[0] = 0.0;

--- a/src/grid2d.cpp
+++ b/src/grid2d.cpp
@@ -898,9 +898,9 @@ void Grid2d::setup_comm_tiled(int &nbuf1, int &nbuf2)
     }
   }
 
-  auto irregular = new Irregular(lmp);
+  auto *irregular = new Irregular(lmp);
   int nrecv_request = irregular->create_data(nsend_request,proclist,1);
-  auto rrequest = (Request *) memory->smalloc(nrecv_request*sizeof(Request),"grid2d:rrequest");
+  auto *rrequest = (Request *) memory->smalloc(nrecv_request*sizeof(Request),"grid2d:rrequest");
   irregular->exchange_data((char *) srequest,sizeof(Request),(char *) rrequest);
   irregular->destroy_data();
 
@@ -935,7 +935,7 @@ void Grid2d::setup_comm_tiled(int &nbuf1, int &nbuf2)
 
   int nsend_response = nrecv_request;
   int nrecv_response = irregular->create_data(nsend_response,proclist,1);
-  auto rresponse = (Response *) memory->smalloc(nrecv_response*sizeof(Response),"grid2d:rresponse");
+  auto *rresponse = (Response *) memory->smalloc(nrecv_response*sizeof(Response),"grid2d:rresponse");
   irregular->exchange_data((char *) sresponse,sizeof(Response),(char *) rresponse);
   irregular->destroy_data();
   delete irregular;
@@ -1158,7 +1158,7 @@ forward_comm_tiled(T *ptr, int which, int nper, int nbyte,
 {
   int i,m,offset;
 
-  auto buf2 = (char *) vbuf2;
+  auto *buf2 = (char *) vbuf2;
 
   // post all receives
 
@@ -1263,7 +1263,7 @@ reverse_comm_tiled(T *ptr, int which, int nper, int nbyte,
 {
   int i,m,offset;
 
-  auto buf2 = (char *) vbuf2;
+  auto *buf2 = (char *) vbuf2;
 
   // post all receives
 
@@ -1462,7 +1462,7 @@ void Grid2d::remap_style(T *ptr, int which, int nper, int nbyte,
 {
   int i,m,offset;
 
-  auto buf2 = (char *) vbuf2;
+  auto *buf2 = (char *) vbuf2;
 
   // post all receives
 
@@ -1520,7 +1520,7 @@ void Grid2d::read_file(int caller, void *ptr, FILE *fp, int nchunk, int maxline)
 template < class T >
 void Grid2d::read_file_style(T *ptr, FILE *fp, int nchunk, int maxline)
 {
-  auto buffer = new char[nchunk * maxline];
+  auto *buffer = new char[nchunk * maxline];
   bigint ntotal = (bigint) nx * ny;
   bigint nread = 0;
 

--- a/src/grid3d.cpp
+++ b/src/grid3d.cpp
@@ -1055,9 +1055,9 @@ void Grid3d::setup_comm_tiled(int &nbuf1, int &nbuf2)
     }
   }
 
-  auto irregular = new Irregular(lmp);
+  auto *irregular = new Irregular(lmp);
   int nrecv_request = irregular->create_data(nsend_request,proclist,1);
-  auto rrequest = (Request *) memory->smalloc(nrecv_request*sizeof(Request),"grid3d:rrequest");
+  auto *rrequest = (Request *) memory->smalloc(nrecv_request*sizeof(Request),"grid3d:rrequest");
   irregular->exchange_data((char *) srequest,sizeof(Request),(char *) rrequest);
   irregular->destroy_data();
 
@@ -1096,7 +1096,7 @@ void Grid3d::setup_comm_tiled(int &nbuf1, int &nbuf2)
 
   int nsend_response = nrecv_request;
   int nrecv_response = irregular->create_data(nsend_response,proclist,1);
-  auto rresponse = (Response *) memory->smalloc(nrecv_response*sizeof(Response),"grid3d:rresponse");
+  auto *rresponse = (Response *) memory->smalloc(nrecv_response*sizeof(Response),"grid3d:rresponse");
   irregular->exchange_data((char *) sresponse,sizeof(Response),(char *) rresponse);
   irregular->destroy_data();
   delete irregular;
@@ -1329,7 +1329,7 @@ forward_comm_tiled(T *ptr, int which, int nper, int nbyte,
 {
   int i,m,offset;
 
-  auto buf2 = (char *) vbuf2;
+  auto *buf2 = (char *) vbuf2;
 
   // post all receives
 
@@ -1434,7 +1434,7 @@ reverse_comm_tiled(T *ptr, int which, int nper, int nbyte,
 {
   int i,m,offset;
 
-  auto buf2 = (char *) vbuf2;
+  auto *buf2 = (char *) vbuf2;
 
   // post all receives
 
@@ -1636,7 +1636,7 @@ void Grid3d::remap_style(T *ptr, int which, int nper, int nbyte,
 {
   int i,m,offset;
 
-  auto buf2 = (char *) vbuf2;
+  auto *buf2 = (char *) vbuf2;
 
   // post all receives
 
@@ -1694,7 +1694,7 @@ void Grid3d::read_file(int caller, void *ptr, FILE *fp, int nchunk, int maxline)
 template < class T >
 void Grid3d::read_file_style(T *ptr, FILE *fp, int nchunk, int maxline)
 {
-  auto buffer = new char[nchunk * maxline];
+  auto *buffer = new char[nchunk * maxline];
   bigint ntotal = (bigint) nx * ny * nz;
   bigint nread = 0;
 

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -172,7 +172,7 @@ void Group::assign(int narg, char **arg)
 
       if (narg != 3) error->all(FLERR, "Illegal group region command");
 
-      auto region = domain->get_region_by_id(arg[2]);
+      auto *region = domain->get_region_by_id(arg[2]);
       if (!region) error->all(FLERR, "Region {} for group region does not exist", arg[2]);
       region->init();
       region->prematch();
@@ -710,8 +710,8 @@ void Group::add_molecules(int /*igroup*/, int bit)
 
 void Group::molring(int n, char *cbuf, void *ptr)
 {
-  auto gptr = (Group *) ptr;
-  auto list = (tagint *) cbuf;
+  auto *gptr = (Group *) ptr;
+  auto *list = (tagint *) cbuf;
   std::map<tagint, int> *hash = gptr->hash;
   int nlocal = gptr->atom->nlocal;
   tagint *molecule = gptr->atom->molecule;

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -960,7 +960,7 @@ void Image::compute_SSAO()
   int pixelstop = static_cast<int>(1.0*(me+1)/nprocs * npixels);
 
   // file buffer with random numbers to avoid race conditions
-  double *uniform = new double[pixelstop - pixelstart];
+  auto *uniform = new double[pixelstop - pixelstart];
   for (int i = 0; i < pixelstop - pixelstart; ++i) uniform[i] = random->uniform();
 
 #if defined(_OPENMP)
@@ -1151,7 +1151,7 @@ void Image::write_PNG(FILE *fp)
   png_set_text(png_ptr,info_ptr,text_ptr,1);
   png_write_info(png_ptr,info_ptr);
 
-  auto row_pointers = new png_bytep[height/aafactor];
+  auto *row_pointers = new png_bytep[height/aafactor];
   for (int i=0; i < height/aafactor; ++i)
     row_pointers[i] = (png_bytep) &writeBuffer[((height/aafactor)-i-1)*3*(width/aafactor)];
 

--- a/src/improper.cpp
+++ b/src/improper.cpp
@@ -405,7 +405,7 @@ void Improper::ev_tally(int i1, int i2, int i3, int i4, int nlocal, int newton_b
 
 void Improper::problem(const char *filename, int lineno, int i1, int i2, int i3, int i4)
 {
-  const auto x = atom->x;
+  auto *const x = atom->x;
   auto warn = fmt::format("Improper problem: {} {} {} {} {} {}\n", comm->me, update->ntimestep,
                           atom->tag[i1], atom->tag[i2], atom->tag[i3], atom->tag[i4]);
   warn += fmt::format("WARNING:   1st atom: {} {:.8} {:.8} {:.8}\n", comm->me, x[i1][0], x[i1][1],

--- a/src/improper_deprecated.cpp
+++ b/src/improper_deprecated.cpp
@@ -35,7 +35,7 @@ void ImproperDeprecated::settings(int, char **)
   // of the list of substyles
 
   if (utils::strmatch(my_style, "^hybrid")) {
-    auto hybrid = dynamic_cast<ImproperHybrid *>(force->improper);
+    auto *hybrid = dynamic_cast<ImproperHybrid *>(force->improper);
     my_style = hybrid->keywords[hybrid->nstyles];
   }
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -949,7 +949,7 @@ void Input::ifthenelse()
     int ncommands = last-first + 1;
     if (ncommands <= 0) utils::missing_cmd_args(FLERR, "if then", error);
 
-    auto commands = new char*[ncommands];
+    auto *commands = new char*[ncommands];
     ncommands = 0;
     for (int i = first; i <= last; i++) {
       n = strlen(arg[i]) + 1;
@@ -1002,7 +1002,7 @@ void Input::ifthenelse()
     int ncommands = last-first + 1;
     if (ncommands <= 0) utils::missing_cmd_args(FLERR, "if elif/else", error);
 
-    auto commands = new char*[ncommands];
+    auto *commands = new char*[ncommands];
     ncommands = 0;
     for (int i = first; i <= last; i++) {
       n = strlen(arg[i]) + 1;
@@ -1522,7 +1522,7 @@ void Input::dimension()
   // must reset default extra_dof of all computes
   // since some were created before dimension command is encountered
 
-  for (auto &c : modify->get_compute_list()) c->reset_extra_dof();
+  for (const auto &c : modify->get_compute_list()) c->reset_extra_dof();
 }
 
 /* ---------------------------------------------------------------------- */
@@ -1969,7 +1969,7 @@ void Input::timestep()
   if (respaflag) update->integrate->reset_dt();
 
   if (force->pair) force->pair->reset_dt();
-  for (auto &ifix : modify->get_fix_list()) ifix->reset_dt();
+  for (const auto &ifix : modify->get_fix_list()) ifix->reset_dt();
   output->reset_dt();
 }
 

--- a/src/irregular.cpp
+++ b/src/irregular.cpp
@@ -998,7 +998,7 @@ void Irregular::destroy_data()
 void Irregular::init_exchange()
 {
   int maxexchange_fix = 0;
-  for (auto &ifix : modify->get_fix_list())
+  for (const auto &ifix : modify->get_fix_list())
     maxexchange_fix = MAX(maxexchange_fix, ifix->maxexchange);
 
   bufextra = atom->avec->maxexchange + maxexchange_fix + BUFEXTRA;

--- a/src/kspace_zero.cpp
+++ b/src/kspace_zero.cpp
@@ -70,7 +70,7 @@ void KSpaceZero::init()
   two_charge();
 
   int itmp;
-  auto p_cutoff = (double *) force->pair->extract("cut_coul", itmp);
+  auto *p_cutoff = (double *) force->pair->extract("cut_coul", itmp);
   if (p_cutoff == nullptr) error->all(FLERR, "KSpace style is incompatible with Pair style");
   double cutoff = *p_cutoff;
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -1285,7 +1285,7 @@ int lammps_get_mpi_comm(void *handle)
   STORE_ERROR_MESSAGE(lmp, mesg);
   return -1;
 #else
-  LAMMPS *lmp = (LAMMPS *) handle;
+  auto *lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error) {
     const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
@@ -2234,7 +2234,7 @@ void *lammps_extract_global(void *handle, const char *name)
   if (strcmp(name,"atimestep") == 0) return (void *) &lmp->update->atimestep;
 
   if (utils::strmatch(lmp->update->integrate_style,"^respa")) {
-    auto respa = dynamic_cast<Respa *>(lmp->update->integrate);
+    auto *respa = dynamic_cast<Respa *>(lmp->update->integrate);
     if (strcmp(name,"respa_levels") == 0) return (void *) &respa->nlevels;
     if (strcmp(name,"respa_dt") == 0) return (void *) respa->step;
   }
@@ -2428,7 +2428,7 @@ int lammps_map_atom(void *handle, const void *id)
   }
   if (!id) return -1;
 
-  auto tag = (const tagint *) id;
+  const auto *tag = (const tagint *) id;
   if (lmp->atom->map_style > Atom::MAP_NONE)
     return lmp->atom->map(*tag);
   else
@@ -3109,7 +3109,7 @@ void *lammps_extract_variable(void *handle, const char *name, const char *group)
       lmp->error->all(FLERR, Error::NOLASTLINE, "{}(): Variable {} does not exist", FNERR, name);
 
     if (lmp->input->variable->equalstyle(ivar)) {
-      auto dptr = (double *) malloc(sizeof(double));
+      auto *dptr = (double *) malloc(sizeof(double));
       *dptr = lmp->input->variable->compute_equal(ivar);
       return (void *) dptr;
     } else if (lmp->input->variable->atomstyle(ivar)) {
@@ -3118,7 +3118,7 @@ void *lammps_extract_variable(void *handle, const char *name, const char *group)
       if (igroup < 0)
         lmp->error->all(FLERR, Error::NOLASTLINE, "{}(): Group {} does not exist", FNERR, group);
       int nlocal = lmp->atom->nlocal;
-      auto vector = (double *) malloc(nlocal*sizeof(double));
+      auto *vector = (double *) malloc(nlocal*sizeof(double));
       lmp->input->variable->compute_atom(ivar,igroup,vector,1,0);
       return (void *) vector;
     } else if (lmp->input->variable->vectorstyle(ivar)) {
@@ -3461,7 +3461,7 @@ void lammps_addstep_compute_all(void *handle, void *newstep) {
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
-  auto ns = (bigint *) newstep;
+  auto *ns = (bigint *) newstep;
   if (lmp && lmp->modify && ns) lmp->modify->addstep_compute_all(*ns);
 }
 /* ---------------------------------------------------------------------- */
@@ -3492,7 +3492,7 @@ void lammps_addstep_compute(void *handle, void *newstep) {
     STORE_ERROR_MESSAGE(lmp, mesg);
     return;
   }
-  auto ns = (bigint *) newstep;
+  auto *ns = (bigint *) newstep;
   if (lmp && lmp->modify && ns) lmp->modify->addstep_compute(*ns);
 }
 
@@ -4111,7 +4111,7 @@ void lammps_scatter_atoms(void *handle, const char *name, int dtype, int count, 
       double **array = nullptr;
       if (count == 1) vector = (double *) vptr;
       else array = (double **) vptr;
-      auto dptr = (double *) data;
+      auto *dptr = (double *) data;
 
       if (count == 1) {
         for (i = 0; i < natoms; i++)
@@ -4268,7 +4268,7 @@ void lammps_scatter_atoms_subset(void *handle, const char *name, int dtype,
       double **array = nullptr;
       if (count == 1) vector = (double *) vptr;
       else array = (double **) vptr;
-      auto dptr = (double *) data;
+      auto *dptr = (double *) data;
 
       if (count == 1) {
         for (i = 0; i < ndata; i++) {
@@ -5790,7 +5790,7 @@ void lammps_scatter(void *handle, const char *name, int dtype, int count, void *
       double **array = nullptr;
       if (count == 1) vector = (double *) vptr;
       else array = (double **) vptr;
-      auto dptr = (double *) data;
+      auto *dptr = (double *) data;
 
       if (count == 1) {
         for (i = 0; i < natoms; i++)
@@ -6035,7 +6035,7 @@ void lammps_scatter_subset(void *handle, const char *name, int dtype, int count,
       double **array = nullptr;
       if (count == 1) vector = (double *) vptr;
       else array = (double **) vptr;
-      auto dptr = (double *) data;
+      auto *dptr = (double *) data;
 
       if (count == 1) {
         for (i = 0; i < ndata; i++) {
@@ -6432,7 +6432,7 @@ void NeighProxy::command(int narg, char **arg)
 
   // build neighbor list this command needs based on earlier request
 
-  auto list = neighbor->find_list(this);
+  auto *list = neighbor->find_list(this);
   neighbor->build_one(list);
 
   // find neigh list
@@ -6458,7 +6458,7 @@ void NeighProxy::command(int narg, char **arg)
  * \return         return neighbor list index if valid, otherwise -1 */
 
 int lammps_request_single_neighlist(void *handle, const char *id, int flags, double cutoff) {
-  auto lmp = (LAMMPS *)handle;
+  auto *lmp = (LAMMPS *)handle;
   int idx = -1;
   if (!lmp || !lmp->error || !lmp->neighbor) {
     const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
@@ -6490,7 +6490,7 @@ int lammps_request_single_neighlist(void *handle, const char *id, int flags, dou
  *                 not a valid index
  */
 int lammps_neighlist_num_elements(void *handle, int idx) {
-  auto   lmp = (LAMMPS *) handle;
+  auto *   lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->neighbor) {
     const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
@@ -7131,19 +7131,19 @@ int lammps_id_name(void *handle, const char *category, int idx, char *buffer, in
   if (!buffer || !category || (idx < 0)) return 0;
 
   if (strcmp(category,"compute") == 0) {
-    auto icompute = lmp->modify->get_compute_by_index(idx);
+    auto *icompute = lmp->modify->get_compute_by_index(idx);
     if (icompute) {
       strncpy(buffer, icompute->id, buf_size);
       return 1;
     }
   } else if (strcmp(category,"dump") == 0) {
-    auto idump = lmp->output->get_dump_by_index(idx);
+    auto *idump = lmp->output->get_dump_by_index(idx);
     if (idump) {
       strncpy(buffer, idump->id, buf_size);
       return 1;
     }
   } else if (strcmp(category,"fix") == 0) {
-    auto ifix = lmp->modify->get_fix_by_index(idx);
+    auto *ifix = lmp->modify->get_fix_by_index(idx);
     if (ifix) {
       strncpy(buffer, ifix->id, buf_size);
       return 1;
@@ -7826,7 +7826,7 @@ void lammps_free(void *ptr)
 
 int lammps_is_running(void *handle)
 {
-  auto   lmp = (LAMMPS *) handle;
+  auto *   lmp = (LAMMPS *) handle;
   if (!lmp || !lmp->error || !lmp->update) {
     const auto &mesg = fmt::format("ERROR: {}(): Invalid LAMMPS handle\n", FNERR);
     STORE_ERROR_MESSAGE(lmp, mesg);
@@ -7881,7 +7881,7 @@ has thrown a :ref:`C++ exception <exceptions>`.
 int lammps_has_error(void *handle)
 {
   if (handle) {
-    LAMMPS *lmp = (LAMMPS *) handle;
+    auto *lmp = (LAMMPS *) handle;
     Error *error = lmp->error;
     return (error->get_last_error().empty()) ? 0 : 1;
   } else {
@@ -7914,7 +7914,7 @@ temporarily and restore it afterwards.
  */
 int lammps_set_show_error(void *handle, const int flag)
 {
-  LAMMPS *lmp = (LAMMPS *) handle;
+  auto *lmp = (LAMMPS *) handle;
   if (lmp && lmp->error) return lmp->error->set_show_error(flag);
   return 1; // default value
 }
@@ -7961,7 +7961,7 @@ the failing MPI ranks to send messages.
 int lammps_get_last_error_message(void *handle, char *buffer, int buf_size)
 {
   if (handle) {
-    LAMMPS *lmp = (LAMMPS *) handle;
+    auto *lmp = (LAMMPS *) handle;
     Error *error = lmp->error;
     if (buffer) buffer[0] = buffer[buf_size-1] = '\0';
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv)
 #endif
 
   try {
-    auto lammps = new LAMMPS(argc, argv, lammps_comm);
+    auto *lammps = new LAMMPS(argc, argv, lammps_comm);
     lammps->input->file();
     delete lammps;
   } catch (LAMMPSAbortException &ae) {

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -1005,7 +1005,7 @@ Fix *Modify::add_fix(const std::string &fixcmd, int trysuffix)
 
 Fix *Modify::replace_fix(const char *replaceID, int narg, char **arg, int trysuffix)
 {
-  auto oldfix = get_fix_by_id(replaceID);
+  auto *oldfix = get_fix_by_id(replaceID);
   if (!oldfix) error->all(FLERR, Error::NOLASTLINE,
                           "Modify replace_fix ID {} could not be found", replaceID);
 
@@ -1054,7 +1054,7 @@ void Modify::modify_fix(int narg, char **arg)
 {
   if (narg < 2) utils::missing_cmd_args(FLERR, "fix_modify", error);
 
-  auto ifix = get_fix_by_id(arg[0]);
+  auto *ifix = get_fix_by_id(arg[0]);
   if (!ifix) error->all(FLERR, Error::NOLASTLINE, "Could not find fix_modify ID {}", arg[0]);
   ifix->modify_params(narg - 1, &arg[1]);
 }
@@ -1334,7 +1334,7 @@ void Modify::modify_compute(int narg, char **arg)
 
   // lookup Compute ID
 
-  auto icompute = get_compute_by_id(arg[0]);
+  auto *icompute = get_compute_by_id(arg[0]);
   if (!icompute)
     error->all(FLERR, Error::NOLASTLINE, "Could not find compute_modify ID {}", arg[0]);
   icompute->modify_params(narg - 1, &arg[1]);

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -1530,7 +1530,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
                 "JSON data: {}",
                 id, to_string(specialbonds["data"][i][1]));
 
-          tagint ival = tagint(item);
+          auto ival = tagint(item);
           if ((ival <= 0) || (ival > natoms) || (ival == iatom + 1))
             error->all(FLERR, Error::NOLASTLINE,
                        "Molecule template {}: invalid atom index {} in \"special:bonds\" section "

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -928,13 +928,13 @@ int Neighbor::init_pair()
     }
 
     if (requests[i]->pair && i < nrequest_original) {
-      auto pair = (Pair *) requests[i]->requestor;
+      auto *pair = (Pair *) requests[i]->requestor;
       pair->init_list(requests[i]->id,lists[i]);
     } else if (requests[i]->fix && i < nrequest_original) {
       Fix *fix = (Fix *) requests[i]->requestor;
       fix->init_list(requests[i]->id,lists[i]);
     } else if (requests[i]->compute && i < nrequest_original) {
-      auto compute = (Compute *) requests[i]->requestor;
+      auto *compute = (Compute *) requests[i]->requestor;
       compute->init_list(requests[i]->id,lists[i]);
     }
   }
@@ -2893,7 +2893,7 @@ void Neighbor::modify_params(int narg, char **arg)
 void Neighbor::modify_params(const std::string &modcmd)
 {
   auto args = utils::split_words(modcmd);
-  auto newarg = new char*[args.size()];
+  auto *newarg = new char*[args.size()];
   int i=0;
   for (const auto &arg : args) {
     newarg[i++] = (char *)arg.c_str();

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -66,7 +66,7 @@ Output::Output(LAMMPS *lmp) : Pointers(lmp)
 
   // create default Thermo class
 
-  auto newarg = new char*[1];
+  auto *newarg = new char*[1];
   newarg[0] = (char *) "one";
   thermo = new Thermo(lmp,1,newarg);
   delete[] newarg;
@@ -809,7 +809,7 @@ void Output::modify_dump(int narg, char **arg)
 
   // find which dump it is
 
-  auto idump = get_dump_by_id(arg[0]);
+  auto *idump = get_dump_by_id(arg[0]);
   if (!idump) error->all(FLERR,"Could not find dump_modify ID: {}", arg[0]);
   idump->modify_params(narg-1,&arg[1]);
 }

--- a/src/pair_deprecated.cpp
+++ b/src/pair_deprecated.cpp
@@ -34,7 +34,7 @@ void PairDeprecated::settings(int, char **)
   // called, our style was just added at the end of the list of substyles
 
   if (utils::strmatch(my_style, "^hybrid")) {
-    auto hybrid = dynamic_cast<PairHybrid *>(force->pair);
+    auto *hybrid = dynamic_cast<PairHybrid *>(force->pair);
     my_style = hybrid->keywords[hybrid->nstyles];
   }
 

--- a/src/pair_hybrid.cpp
+++ b/src/pair_hybrid.cpp
@@ -647,7 +647,7 @@ void PairHybrid::init_style()
   // create skip lists inside each pair neigh request
   // any kind of list can have its skip flag set in this loop
 
-  for (auto &request : neighbor->get_pair_requests()) {
+  for (const auto &request : neighbor->get_pair_requests()) {
 
     // istyle = associated sub-style for the request
 
@@ -760,7 +760,7 @@ double PairHybrid::init_one(int i, int j)
       if (cut > cutmax_style[istyle]) {
         cutmax_style[istyle] = cut;
 
-        for (auto &request : neighbor->get_pair_requests()) {
+        for (const auto &request : neighbor->get_pair_requests()) {
           if (styles[istyle] == request->get_requestor()) {
             request->set_cutoff(cutmax_style[istyle]);
             break;
@@ -1105,7 +1105,7 @@ void PairHybrid::set_special(int m)
 
 double * PairHybrid::save_special()
 {
-  auto saved = new double[8];
+  auto *saved = new double[8];
 
   for (int i = 0; i < 4; ++i) {
     saved[i] = force->special_lj[i];
@@ -1145,7 +1145,7 @@ void *PairHybrid::extract(const char *str, int &dim)
     if (ptr && strcmp(str,"cut_coul") == 0) {
       if (couldim != -1 && dim != couldim)
         error->all(FLERR, "Coulomb styles of pair hybrid sub-styles do not match");
-      auto p_newvalue = (double *) ptr;
+      auto *p_newvalue = (double *) ptr;
       double newvalue = *p_newvalue;
       if (cutptr && (newvalue != cutvalue))
         error->all(FLERR, "Coulomb cutoffs of pair hybrid sub-styles do not match");

--- a/src/pair_hybrid_molecular.cpp
+++ b/src/pair_hybrid_molecular.cpp
@@ -43,7 +43,7 @@ void PairHybridMolecular::init_style()
   // modify neighbor list requests
 
   bool first = true;
-  for (auto &request : neighbor->get_pair_requests()) {
+  for (const auto &request : neighbor->get_pair_requests()) {
     if (first) {
       request->set_molskip(NeighRequest::INTRA);
       first = false;
@@ -117,7 +117,7 @@ double PairHybridMolecular::init_one(int i, int j)
       if (cut > cutmax_style[istyle]) {
         cutmax_style[istyle] = cut;
 
-        for (auto &request : neighbor->get_pair_requests()) {
+        for (const auto &request : neighbor->get_pair_requests()) {
           if (styles[istyle] == request->get_requestor()) {
             request->set_cutoff(cutmax_style[istyle]);
             break;

--- a/src/pair_hybrid_scaled.cpp
+++ b/src/pair_hybrid_scaled.cpp
@@ -75,8 +75,8 @@ void PairHybridScaled::compute(int eflag, int vflag)
   const int nvars = scalevars.size();
   int atomscaleflag = 0;
   if (nvars > 0) {
-    auto vals = new double[nvars];
-    auto vars = new int[nvars];
+    auto *vals = new double[nvars];
+    auto *vars = new int[nvars];
     for (int k = 0; k < nvars; ++k) {
       int m = input->variable->find(scalevars[k].c_str());
       if (m < 0)
@@ -126,8 +126,8 @@ void PairHybridScaled::compute(int eflag, int vflag)
     if (atomscaleflag) memory->create(atomscale, nmaxfsum, "pair:atomscale");
   }
   const int nall = atom->nlocal + atom->nghost;
-  auto f = atom->f;
-  auto t = atom->torque;
+  auto *f = atom->f;
+  auto *t = atom->torque;
   for (i = 0; i < nall; ++i) {
     fsum[i][0] = f[i][0];
     fsum[i][1] = f[i][1];
@@ -438,8 +438,8 @@ double PairHybridScaled::single(int i, int j, int itype, int jtype, double rsq, 
 
   const int nvars = scalevars.size();
   if (nvars > 0) {
-    auto vals = new double[nvars];
-    auto vars = new int[nvars];
+    auto *vals = new double[nvars];
+    auto *vars = new int[nvars];
     for (int k = 0; k < nvars; ++k) {
       int m = input->variable->find(scalevars[k].c_str());
       if (m < 0)
@@ -471,7 +471,7 @@ double PairHybridScaled::single(int i, int j, int itype, int jtype, double rsq, 
   double esum = 0.0;
 
   for (int m = 0; m < nmap[itype][jtype]; m++) {
-    auto pstyle = styles[map[itype][jtype][m]];
+    auto *pstyle = styles[map[itype][jtype][m]];
     if (rsq < pstyle->cutsq[itype][jtype]) {
       if (pstyle->single_enable == 0)
         error->one(FLERR, "Pair hybrid sub-style does not support single call");
@@ -517,8 +517,8 @@ void PairHybridScaled::born_matrix(int i, int j, int itype, int jtype, double rs
 
   const int nvars = scalevars.size();
   if (nvars > 0) {
-    auto vals = new double[nvars];
-    auto vars = new int[nvars];
+    auto *vals = new double[nvars];
+    auto *vars = new int[nvars];
     for (int k = 0; k < nvars; ++k) {
       int m = input->variable->find(scalevars[k].c_str());
       if (m < 0)
@@ -549,7 +549,7 @@ void PairHybridScaled::born_matrix(int i, int j, int itype, int jtype, double rs
   dupair = du2pair = 0.0;
 
   for (int m = 0; m < nmap[itype][jtype]; m++) {
-    auto pstyle = styles[map[itype][jtype][m]];
+    auto *pstyle = styles[map[itype][jtype][m]];
     if (rsq < pstyle->cutsq[itype][jtype]) {
       if (pstyle->single_enable == 0)
         error->one(FLERR, "Pair hybrid sub-style does not support single call");

--- a/src/pair_lj_cut.cpp
+++ b/src/pair_lj_cut.cpp
@@ -479,7 +479,7 @@ void PairLJCut::init_style()
   int list_style = NeighConst::REQ_DEFAULT;
 
   if (update->whichflag == 1 && utils::strmatch(update->integrate_style, "^respa")) {
-    auto respa = dynamic_cast<Respa *>(update->integrate);
+    auto *respa = dynamic_cast<Respa *>(update->integrate);
     if (respa->level_inner >= 0) list_style = NeighConst::REQ_RESPA_INOUT;
     if (respa->level_middle >= 0) list_style = NeighConst::REQ_RESPA_ALL;
   }

--- a/src/pair_table.cpp
+++ b/src/pair_table.cpp
@@ -869,7 +869,7 @@ void PairTable::spline(double *x, double *y, int n, double yp1, double ypn, doub
 {
   int i, k;
   double p, qn, sig, un;
-  auto u = new double[n];
+  auto *u = new double[n];
 
   if (yp1 > 0.99e30)
     y2[0] = u[0] = 0.0;

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -760,7 +760,7 @@ std::string platform::current_directory()
   char *buf = new char[MAX_PATH];
   if (_getcwd(buf, MAX_PATH)) { cwd = buf; }
 #else
-  auto buf = new char[PATH_MAX];
+  auto *buf = new char[PATH_MAX];
   if (::getcwd(buf, PATH_MAX)) { cwd = buf; }
 #endif
   delete[] buf;

--- a/src/procmap.cpp
+++ b/src/procmap.cpp
@@ -159,7 +159,7 @@ void ProcMap::numa_grid(int numa_nodes, int nprocs, int *user_procgrid,
   char node_name[MPI_MAX_PROCESSOR_NAME];
   MPI_Get_processor_name(node_name,&name_length);
   node_name[name_length] = '\0';
-  auto node_names = new char[MPI_MAX_PROCESSOR_NAME*nprocs];
+  auto *node_names = new char[MPI_MAX_PROCESSOR_NAME*nprocs];
   MPI_Allgather(node_name,MPI_MAX_PROCESSOR_NAME,MPI_CHAR,node_names,
                 MPI_MAX_PROCESSOR_NAME,MPI_CHAR,world);
   std::string node_string = std::string(node_name);

--- a/src/random_park.cpp
+++ b/src/random_park.cpp
@@ -93,7 +93,7 @@ void RanPark::reset(int ibase, double *coord)
 {
   int i;
 
-  auto str = (char *) &ibase;
+  auto *str = (char *) &ibase;
   int n = sizeof(int);
 
   unsigned int hash = 0;

--- a/src/rcb.cpp
+++ b/src/rcb.cpp
@@ -1130,8 +1130,8 @@ void RCB::compute_old(int dimension, int n, double **x, double *wt,
 void box_merge(void *in, void *inout, int * /*len*/, MPI_Datatype * /*dptr*/)
 
 {
-  auto box1 = (RCB::BBox *) in;
-  auto box2 = (RCB::BBox *) inout;
+  auto *box1 = (RCB::BBox *) in;
+  auto *box2 = (RCB::BBox *) inout;
 
   for (int i = 0; i < 3; i++) {
     if (box1->lo[i] < box2->lo[i]) box2->lo[i] = box1->lo[i];
@@ -1160,8 +1160,8 @@ void box_merge(void *in, void *inout, int * /*len*/, MPI_Datatype * /*dptr*/)
 void median_merge(void *in, void *inout, int * /*len*/, MPI_Datatype * /*dptr*/)
 
 {
-  auto med1 = (RCB::Median *) in;
-  auto med2 = (RCB::Median *) inout;
+  auto *med1 = (RCB::Median *) in;
+  auto *med2 = (RCB::Median *) inout;
 
   med2->totallo += med1->totallo;
   if (med1->valuelo > med2->valuelo) {
@@ -1209,7 +1209,7 @@ void RCB::invert(int sortflag)
   int *proclist;
   memory->create(proclist,nsend,"RCB:proclist");
 
-  auto sinvert = (Invert *) memory->smalloc(nsend*sizeof(Invert),"RCB:sinvert");
+  auto *sinvert = (Invert *) memory->smalloc(nsend*sizeof(Invert),"RCB:sinvert");
 
   int m = 0;
   for (int i = nkeep; i < nfinal; i++) {
@@ -1224,7 +1224,7 @@ void RCB::invert(int sortflag)
   // nrecv = # of my dots to send to other procs
 
   int nrecv = irregular->create_data(nsend,proclist,sortflag);
-  auto rinvert = (Invert *) memory->smalloc(nrecv*sizeof(Invert),"RCB:rinvert");
+  auto *rinvert = (Invert *) memory->smalloc(nrecv*sizeof(Invert),"RCB:rinvert");
   irregular->exchange_data((char *) sinvert,sizeof(Invert),(char *) rinvert);
   irregular->destroy_data();
 

--- a/src/read_dump.cpp
+++ b/src/read_dump.cpp
@@ -1071,7 +1071,7 @@ void ReadDump::migrate_old_atoms()
   for (int i = 0; i < nlocal; i++)
     procassign[i] = tag[i] % comm->nprocs;
 
-  auto irregular = new Irregular(lmp);
+  auto *irregular = new Irregular(lmp);
   irregular->migrate_atoms(1,1,procassign);
   delete irregular;
 
@@ -1094,7 +1094,7 @@ void ReadDump::migrate_new_atoms()
     procassign[i] = mtag % comm->nprocs;
   }
 
-  auto irregular = new Irregular(lmp);
+  auto *irregular = new Irregular(lmp);
   int nrecv = irregular->create_data(nnew,procassign,1);
   int newmaxnew = MAX(nrecv,maxnew);
   newmaxnew = MAX(newmaxnew,1);    // avoid null pointer
@@ -1131,7 +1131,7 @@ void ReadDump::migrate_atoms_by_coords()
 
   if (domain->triclinic) domain->x2lamda(atom->nlocal);
   domain->reset_box();
-  auto irregular = new Irregular(lmp);
+  auto *irregular = new Irregular(lmp);
   irregular->migrate_atoms(1);
   delete irregular;
   if (domain->triclinic) domain->lamda2x(atom->nlocal);

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -408,7 +408,7 @@ void ReadRestart::command(int narg, char **arg)
       atom->map_set();
     }
     if (domain->triclinic) domain->x2lamda(atom->nlocal);
-    auto irregular = new Irregular(lmp);
+    auto *irregular = new Irregular(lmp);
     irregular->migrate_atoms(1);
     delete irregular;
     if (domain->triclinic) domain->lamda2x(atom->nlocal);
@@ -419,7 +419,7 @@ void ReadRestart::command(int narg, char **arg)
     if (nextra) {
       memory->destroy(atom->extra);
       memory->create(atom->extra,atom->nmax,nextra,"atom:extra");
-      auto fix = dynamic_cast<FixReadRestart *>(modify->get_fix_by_id("_read_restart"));
+      auto *fix = dynamic_cast<FixReadRestart *>(modify->get_fix_by_id("_read_restart"));
       int *count = fix->count;
       double **extra = fix->extra;
       double **atom_extra = atom->extra;
@@ -732,7 +732,7 @@ void ReadRestart::header()
     } else if (flag == ATOM_STYLE) {
       char *style = read_string();
       int nargcopy = read_int();
-      auto argcopy = new char*[nargcopy];
+      auto *argcopy = new char*[nargcopy];
       for (int i = 0; i < nargcopy; i++)
         argcopy[i] = read_string();
       atom->create_avec(style,nargcopy,argcopy,1);
@@ -869,7 +869,7 @@ void ReadRestart::type_arrays()
 
     if (flag == MASS) {
       read_int();
-      auto mass = new double[atom->ntypes+1];
+      auto *mass = new double[atom->ntypes+1];
       read_double_vec(atom->ntypes,&mass[1]);
       atom->set_mass(mass);
       delete[] mass;
@@ -984,7 +984,7 @@ void ReadRestart::file_layout()
 void ReadRestart::magic_string()
 {
   int n = strlen(MAGIC_STRING) + 1;
-  auto str = new char[n];
+  auto *str = new char[n];
 
   int count;
   if (me == 0) count = fread(str,sizeof(char),n,fp);
@@ -1026,7 +1026,7 @@ void ReadRestart::check_eof_magic()
   if (revision < 1) return;
 
   int n = strlen(MAGIC_STRING) + 1;
-  auto str = new char[n];
+  auto *str = new char[n];
 
   // read magic string at end of file and restore file pointer
 
@@ -1094,7 +1094,7 @@ char *ReadRestart::read_string()
 {
   int n = read_int();
   if (n < 0) error->all(FLERR,"Illegal size string or corrupt restart");
-  auto value = new char[n];
+  auto *value = new char[n];
   if (me == 0) utils::sfread(FLERR,value,sizeof(char),n,fp,nullptr,error);
   MPI_Bcast(value,n,MPI_CHAR,0,world);
   return value;

--- a/src/region_intersect.cpp
+++ b/src/region_intersect.cpp
@@ -160,7 +160,7 @@ int RegIntersect::surface_interior(double *x, double cutoff)
   int n = 0;
   int walloffset = 0;
   for (ilist = 0; ilist < nregion; ilist++) {
-    auto region = reglist[ilist];
+    auto *region = reglist[ilist];
     ncontacts = region->surface(x[0], x[1], x[2], cutoff);
     for (m = 0; m < ncontacts; m++) {
       xs = x[0] - region->contact[m].delx;
@@ -207,7 +207,7 @@ int RegIntersect::surface_exterior(double *x, double cutoff)
   for (ilist = 0; ilist < nregion; ilist++) reglist[ilist]->interior ^= 1;
 
   for (ilist = 0; ilist < nregion; ilist++) {
-    auto region = reglist[ilist];
+    auto *region = reglist[ilist];
     ncontacts = region->surface(x[0], x[1], x[2], cutoff);
     for (m = 0; m < ncontacts; m++) {
       xs = x[0] - region->contact[m].delx;

--- a/src/region_union.cpp
+++ b/src/region_union.cpp
@@ -153,7 +153,7 @@ int RegUnion::surface_interior(double *x, double cutoff)
   int n = 0;
   int walloffset = 0;
   for (ilist = 0; ilist < nregion; ilist++) {
-    auto region = reglist[ilist];
+    auto *region = reglist[ilist];
     ncontacts = region->surface(x[0], x[1], x[2], cutoff);
     for (m = 0; m < ncontacts; m++) {
       xs = x[0] - region->contact[m].delx;
@@ -200,7 +200,7 @@ int RegUnion::surface_exterior(double *x, double cutoff)
   for (ilist = 0; ilist < nregion; ilist++) reglist[ilist]->interior ^= 1;
 
   for (ilist = 0; ilist < nregion; ilist++) {
-    auto region = reglist[ilist];
+    auto *region = reglist[ilist];
     ncontacts = region->surface(x[0], x[1], x[2], cutoff);
     for (m = 0; m < ncontacts; m++) {
       xs = x[0] - region->contact[m].delx;

--- a/src/rerun.cpp
+++ b/src/rerun.cpp
@@ -126,7 +126,7 @@ void Rerun::command(int narg, char **arg)
   // pass list of filenames to ReadDump
   // along with post-"dump" args and post-"format" args
 
-  auto rd = new ReadDump(lmp);
+  auto *rd = new ReadDump(lmp);
 
   rd->store_files(nfile,arg);
   if (nremain)

--- a/src/reset_atoms_id.cpp
+++ b/src/reset_atoms_id.cpp
@@ -418,7 +418,7 @@ void ResetAtomsID::sort()
 
   int *proclist;
   memory->create(proclist, nlocal, "special:proclist");
-  auto atombuf =
+  auto *atombuf =
       (AtomRvous *) memory->smalloc((bigint) nlocal * sizeof(AtomRvous), "resetIDs:idbuf");
 
   int ibinx, ibiny, ibinz, iproc;
@@ -449,7 +449,7 @@ void ResetAtomsID::sort()
   char *buf;
   int nreturn = comm->rendezvous(1, nlocal, (char *) atombuf, sizeof(AtomRvous), 0, proclist,
                                  sort_bins, 0, buf, sizeof(IDRvous), (void *) this);
-  auto outbuf = (IDRvous *) buf;
+  auto *outbuf = (IDRvous *) buf;
 
   memory->destroy(proclist);
   memory->sfree(atombuf);
@@ -476,7 +476,7 @@ int ResetAtomsID::sort_bins(int n, char *inbuf, int &flag, int *&proclist, char 
 {
   int i, ibin, index;
 
-  auto rptr = (ResetAtomsID *) ptr;
+  auto *rptr = (ResetAtomsID *) ptr;
   Memory *memory = rptr->memory;
   Error *error = rptr->error;
   MPI_Comm world = rptr->world;
@@ -504,7 +504,7 @@ int ResetAtomsID::sort_bins(int n, char *inbuf, int &flag, int *&proclist, char 
     count[ibin] = 0;
   }
 
-  auto in = (AtomRvous *) inbuf;
+  auto *in = (AtomRvous *) inbuf;
 
   for (i = 0; i < n; i++) {
     if (in[i].ibin < binlo || in[i].ibin >= binhi) {
@@ -562,7 +562,7 @@ int ResetAtomsID::sort_bins(int n, char *inbuf, int &flag, int *&proclist, char 
 
   int nout = n;
   memory->create(proclist, nout, "resetIDs:proclist");
-  auto out = (IDRvous *) memory->smalloc(nout * sizeof(IDRvous), "resetIDs:out");
+  auto *out = (IDRvous *) memory->smalloc(nout * sizeof(IDRvous), "resetIDs:out");
 
   tagint one = nprev + 1;
   for (ibin = 0; ibin < nbins; ibin++) {
@@ -624,7 +624,7 @@ int compare_coords(const void *iptr, const void *jptr)
 
 int compare_coords(const int i, const int j, void *ptr)
 {
-  auto rvous = (ResetAtomsID::AtomRvous *) ptr;
+  auto *rvous = (ResetAtomsID::AtomRvous *) ptr;
   double *xi = rvous[i].x;
   double *xj = rvous[j].x;
   if (xi[0] < xj[0]) return -1;

--- a/src/reset_atoms_image.cpp
+++ b/src/reset_atoms_image.cpp
@@ -63,17 +63,17 @@ void ResetAtomsImage::command(int narg, char **arg)
   // create computes and variables
   // must come before lmp->init so the computes are properly initialized
 
-  auto frags = modify->add_compute("frags_r_i_f all fragment/atom single yes");
-  auto chunk = modify->add_compute("chunk_r_i_f all chunk/atom c_frags_r_i_f compress yes");
-  auto flags = modify->add_compute("flags_r_i_f all property/atom ix iy iz");
+  auto *frags = modify->add_compute("frags_r_i_f all fragment/atom single yes");
+  auto *chunk = modify->add_compute("chunk_r_i_f all chunk/atom c_frags_r_i_f compress yes");
+  auto *flags = modify->add_compute("flags_r_i_f all property/atom ix iy iz");
   input->variable->set("ix_r_i_f atom c_flags_r_i_f[1]");
   input->variable->set("iy_r_i_f atom c_flags_r_i_f[2]");
   input->variable->set("iz_r_i_f atom c_flags_r_i_f[3]");
-  auto ifmin = modify->add_compute("ifmin_r_i_f all reduce/chunk chunk_r_i_f min "
+  auto *ifmin = modify->add_compute("ifmin_r_i_f all reduce/chunk chunk_r_i_f min "
                                    "v_ix_r_i_f v_iy_r_i_f v_iz_r_i_f");
-  auto ifmax = modify->add_compute("ifmax_r_i_f all reduce/chunk chunk_r_i_f max "
+  auto *ifmax = modify->add_compute("ifmax_r_i_f all reduce/chunk chunk_r_i_f max "
                                    "v_ix_r_i_f v_iy_r_i_f v_iz_r_i_f");
-  auto cdist = modify->add_compute("cdist_r_i_f all chunk/spread/atom chunk_r_i_f "
+  auto *cdist = modify->add_compute("cdist_r_i_f all chunk/spread/atom chunk_r_i_f "
                                    "c_ifmax_r_i_f[*] c_ifmin_r_i_f[*]");
 
   // initialize system since comm->borders() will be invoked

--- a/src/reset_atoms_mol.cpp
+++ b/src/reset_atoms_mol.cpp
@@ -149,7 +149,7 @@ void ResetAtomsMol::create_computes(char *fixid, char *groupid)
   // 'fixid' allows for creating independent instances of the computes
 
   idfrag = fmt::format("{}_reset_atoms_mol_FRAGMENT_ATOM", fixid);
-  auto use_single = singleflag ? "yes" : "no";
+  const auto *use_single = singleflag ? "yes" : "no";
   cfa = dynamic_cast<ComputeFragmentAtom *>(modify->add_compute(
       fmt::format("{} {} fragment/atom single {}", idfrag, groupid, use_single)));
 

--- a/src/respa.cpp
+++ b/src/respa.cpp
@@ -121,7 +121,7 @@ Respa::Respa(LAMMPS *lmp, int narg, char **arg) :
       // the hybrid keyword requires a hybrid pair style
       if (!utils::strmatch(force->pair_style, "^hybrid"))
         error->all(FLERR, "Illegal run_style respa command");
-      auto hybrid = dynamic_cast<PairHybrid *>(force->pair);
+      auto *hybrid = dynamic_cast<PairHybrid *>(force->pair);
       nhybrid_styles = hybrid->nstyles;
       // each hybrid sub-style needs to be assigned to a respa level
       if (iarg + nhybrid_styles > narg) error->all(FLERR, "Illegal run_style respa command");

--- a/src/set.cpp
+++ b/src/set.cpp
@@ -624,10 +624,10 @@ void Set::setrandom(int keyword, Action *action)
 {
   int i;
 
-  auto avec_ellipsoid = dynamic_cast<AtomVecEllipsoid *>(atom->style_match("ellipsoid"));
-  auto avec_line = dynamic_cast<AtomVecLine *>(atom->style_match("line"));
-  auto avec_tri = dynamic_cast<AtomVecTri *>(atom->style_match("tri"));
-  auto avec_body = dynamic_cast<AtomVecBody *>(atom->style_match("body"));
+  auto *avec_ellipsoid = dynamic_cast<AtomVecEllipsoid *>(atom->style_match("ellipsoid"));
+  auto *avec_line = dynamic_cast<AtomVecLine *>(atom->style_match("line"));
+  auto *avec_tri = dynamic_cast<AtomVecTri *>(atom->style_match("tri"));
+  auto *avec_body = dynamic_cast<AtomVecBody *>(atom->style_match("body"));
 
   double **x = atom->x;
 
@@ -635,8 +635,8 @@ void Set::setrandom(int keyword, Action *action)
 
   int seed = action->ivalue1;
 
-  auto ranpark = new RanPark(lmp,1);
-  auto ranmars = new RanMars(lmp,seed + comm->me);
+  auto *ranpark = new RanPark(lmp,1);
+  auto *ranmars = new RanMars(lmp,seed + comm->me);
 
   // set approx fraction of atom types to newtype
 
@@ -1256,9 +1256,9 @@ void Set::invoke_density(Action *action)
   int line_flag = atom->line_flag;
   int tri_flag = atom->tri_flag;
 
-  auto avec_ellipsoid = dynamic_cast<AtomVecEllipsoid *>(atom->style_match("ellipsoid"));
-  auto avec_line = dynamic_cast<AtomVecLine *>(atom->style_match("line"));
-  auto avec_tri = dynamic_cast<AtomVecTri *>(atom->style_match("tri"));
+  auto *avec_ellipsoid = dynamic_cast<AtomVecEllipsoid *>(atom->style_match("ellipsoid"));
+  auto *avec_line = dynamic_cast<AtomVecLine *>(atom->style_match("line"));
+  auto *avec_tri = dynamic_cast<AtomVecTri *>(atom->style_match("tri"));
 
   int varflag = action->varflag;
   double density = 0.0;
@@ -1753,7 +1753,7 @@ void Set::process_length(int &iarg, int narg, char **arg, Action *action)
 void Set::invoke_length(Action *action)
 {
   int nlocal = atom->nlocal;
-  auto avec_line = dynamic_cast<AtomVecLine *>(atom->style_match("line"));
+  auto *avec_line = dynamic_cast<AtomVecLine *>(atom->style_match("line"));
 
   int varflag = action->varflag;
   double length = 0.0;
@@ -1936,9 +1936,9 @@ void Set::invoke_quat(Action *action)
   double **quat = atom->quat;
   int quat_flag = atom->quat_flag;
 
-  auto avec_ellipsoid = dynamic_cast<AtomVecEllipsoid *>(atom->style_match("ellipsoid"));
-  auto avec_tri = dynamic_cast<AtomVecTri *>(atom->style_match("tri"));
-  auto avec_body = dynamic_cast<AtomVecBody *>(atom->style_match("body"));
+  auto *avec_ellipsoid = dynamic_cast<AtomVecEllipsoid *>(atom->style_match("ellipsoid"));
+  auto *avec_tri = dynamic_cast<AtomVecTri *>(atom->style_match("tri"));
+  auto *avec_body = dynamic_cast<AtomVecBody *>(atom->style_match("body"));
 
   int dimension = domain->dimension;
   double *quat_one = nullptr;
@@ -2112,7 +2112,7 @@ void Set::process_shape(int &iarg, int narg, char **arg, Action *action)
 void Set::invoke_shape(Action *action)
 {
   int nlocal = atom->nlocal;
-  auto avec_ellipsoid = dynamic_cast<AtomVecEllipsoid *>(atom->style_match("ellipsoid"));
+  auto *avec_ellipsoid = dynamic_cast<AtomVecEllipsoid *>(atom->style_match("ellipsoid"));
 
   int varflag = action->varflag;
   double xvalue = 0.0, yvalue = 0.0, zvalue = 0.0;
@@ -2498,7 +2498,7 @@ void Set::invoke_theta(Action *action)
   int nlocal = atom->nlocal;
   int *line = atom->line;
 
-  auto avec_line = dynamic_cast<AtomVecLine *>(atom->style_match("line"));
+  auto *avec_line = dynamic_cast<AtomVecLine *>(atom->style_match("line"));
 
   int varflag = action->varflag;
   double theta = 0.0;
@@ -2551,7 +2551,7 @@ void Set::process_tri(int &iarg, int narg, char **arg, Action *action)
 void Set::invoke_tri(Action *action)
 {
   int nlocal = atom->nlocal;
-  auto avec_tri = dynamic_cast<AtomVecTri *>(atom->style_match("tri"));
+  auto *avec_tri = dynamic_cast<AtomVecTri *>(atom->style_match("tri"));
 
   int varflag = action->varflag;
   double trisize = 0.0;

--- a/src/special.cpp
+++ b/src/special.cpp
@@ -187,7 +187,7 @@ void Special::atom_owners()
 
   int *proclist;
   memory->create(proclist,nlocal,"special:proclist");
-  auto idbuf = (IDRvous *) memory->smalloc((bigint) nlocal*sizeof(IDRvous),"special:idbuf");
+  auto *idbuf = (IDRvous *) memory->smalloc((bigint) nlocal*sizeof(IDRvous),"special:idbuf");
 
   // setup input buf for rendezvous comm
   // one datum for each owned atom: datum = owning proc, atomID
@@ -236,7 +236,7 @@ void Special::onetwo_build_newton()
 
   int *proclist;
   memory->create(proclist,nsend,"special:proclist");
-  auto inbuf = (PairRvous *) memory->smalloc((bigint) nsend*sizeof(PairRvous),"special:inbuf");
+  auto *inbuf = (PairRvous *) memory->smalloc((bigint) nsend*sizeof(PairRvous),"special:inbuf");
 
   // setup input buf to rendezvous comm
   // one datum for each unowned bond partner: bond partner ID, atomID
@@ -259,7 +259,7 @@ void Special::onetwo_build_newton()
   char *buf;
   int nreturn = comm->rendezvous(RVOUS,nsend,(char *) inbuf,sizeof(PairRvous), 0,proclist,
                                  rendezvous_pairs,0,buf,sizeof(PairRvous), (void *) this);
-  auto outbuf = (PairRvous *) buf;
+  auto *outbuf = (PairRvous *) buf;
 
   memory->destroy(proclist);
   memory->sfree(inbuf);
@@ -361,7 +361,7 @@ void Special::onethree_build()
 
   int *proclist;
   memory->create(proclist,nsend,"special:proclist");
-  auto inbuf = (PairRvous *) memory->smalloc((bigint) nsend*sizeof(PairRvous),"special:inbuf");
+  auto *inbuf = (PairRvous *) memory->smalloc((bigint) nsend*sizeof(PairRvous),"special:inbuf");
 
   // setup input buf to rendezvous comm
   // datums = pairs of onetwo partners where either is unknown
@@ -390,7 +390,7 @@ void Special::onethree_build()
   char *buf;
   int nreturn = comm->rendezvous(RVOUS,nsend,(char *) inbuf,sizeof(PairRvous), 0,proclist,
                                  rendezvous_pairs,0,buf,sizeof(PairRvous), (void *) this);
-  auto outbuf = (PairRvous *) buf;
+  auto *outbuf = (PairRvous *) buf;
 
   memory->destroy(proclist);
   memory->sfree(inbuf);
@@ -463,7 +463,7 @@ void Special::onefour_build()
 
   int *proclist;
   memory->create(proclist,nsend,"special:proclist");
-  auto inbuf = (PairRvous *) memory->smalloc((bigint) nsend*sizeof(PairRvous),"special:inbuf");
+  auto *inbuf = (PairRvous *) memory->smalloc((bigint) nsend*sizeof(PairRvous),"special:inbuf");
 
   // setup input buf to rendezvous comm
   // datums = pairs of onethree and onetwo partners where onethree is unknown
@@ -491,7 +491,7 @@ void Special::onefour_build()
   char *buf;
   int nreturn = comm->rendezvous(RVOUS,nsend,(char *) inbuf,sizeof(PairRvous), 0,proclist,
                                  rendezvous_pairs,0,buf,sizeof(PairRvous), (void *) this);
-  auto outbuf = (PairRvous *) buf;
+  auto *outbuf = (PairRvous *) buf;
 
   memory->destroy(proclist);
   memory->sfree(inbuf);
@@ -564,7 +564,7 @@ void Special::onefive_build()
 
   int *proclist;
   memory->create(proclist,nsend,"special:proclist");
-  PairRvous *inbuf = (PairRvous *)
+  auto *inbuf = (PairRvous *)
     memory->smalloc((bigint) nsend*sizeof(PairRvous),"special:inbuf");
 
   // setup input buf to rendezvous comm
@@ -595,7 +595,7 @@ void Special::onefive_build()
                                  0,proclist,
                                  rendezvous_pairs,0,buf,sizeof(PairRvous),
                                  (void *) this);
-  PairRvous *outbuf = (PairRvous *) buf;
+  auto *outbuf = (PairRvous *) buf;
 
   memory->destroy(proclist);
   memory->sfree(inbuf);
@@ -856,10 +856,10 @@ void Special::combine()
     utils::logmesg(lmp,"{:>6} = max # of special neighbors\n",atom->maxspecial);
 
   if (lmp->kokkos) {
-    auto  atomKK = dynamic_cast<AtomKokkos*>(atom);
+    auto *  atomKK = dynamic_cast<AtomKokkos*>(atom);
     atomKK->modified(Host,SPECIAL_MASK);
     atomKK->sync(Device,SPECIAL_MASK);
-    auto  memoryKK = dynamic_cast<MemoryKokkos*>(memory);
+    auto *  memoryKK = dynamic_cast<MemoryKokkos*>(memory);
     memoryKK->grow_kokkos(atomKK->k_special,atom->special,
                         atom->nmax,atom->maxspecial,"atom:special");
     atomKK->modified(Device,SPECIAL_MASK);
@@ -1018,7 +1018,7 @@ void Special::angle_trim()
 
     int *proclist;
     memory->create(proclist,nsend,"special:proclist");
-    auto inbuf = (PairRvous *) memory->smalloc((bigint) nsend*sizeof(PairRvous),"special:inbuf");
+    auto *inbuf = (PairRvous *) memory->smalloc((bigint) nsend*sizeof(PairRvous),"special:inbuf");
 
     // setup input buf to rendezvous comm
     // datums = pairs of onetwo partners where either is unknown
@@ -1086,7 +1086,7 @@ void Special::angle_trim()
     char *buf;
     int nreturn = comm->rendezvous(RVOUS,nsend,(char *) inbuf,sizeof(PairRvous), 0,proclist,
                                    rendezvous_pairs,0,buf,sizeof(PairRvous), (void *) this);
-    auto outbuf = (PairRvous *) buf;
+    auto *outbuf = (PairRvous *) buf;
 
     memory->destroy(proclist);
     memory->sfree(inbuf);
@@ -1259,7 +1259,7 @@ void Special::dihedral_trim()
 
     int *proclist;
     memory->create(proclist,nsend,"special:proclist");
-    auto inbuf = (PairRvous *) memory->smalloc((bigint) nsend*sizeof(PairRvous),"special:inbuf");
+    auto *inbuf = (PairRvous *) memory->smalloc((bigint) nsend*sizeof(PairRvous),"special:inbuf");
 
     // setup input buf to rendezvous comm
     // datums = pairs of onefour atom IDs in a dihedral defined for my atoms
@@ -1296,7 +1296,7 @@ void Special::dihedral_trim()
     char *buf;
     int nreturn = comm->rendezvous(RVOUS,nsend,(char *) inbuf,sizeof(PairRvous), 0,proclist,
                                    rendezvous_pairs,0,buf,sizeof(PairRvous), (void *) this);
-    auto outbuf = (PairRvous *) buf;
+    auto *outbuf = (PairRvous *) buf;
 
     memory->destroy(proclist);
     memory->sfree(inbuf);
@@ -1390,7 +1390,7 @@ void Special::dihedral_trim()
 
 int Special::rendezvous_ids(int n, char *inbuf, int &flag, int *& /*proclist*/, char *& /*outbuf*/, void *ptr)
 {
-  auto sptr = (Special *) ptr;
+  auto *sptr = (Special *) ptr;
   Memory *memory = sptr->memory;
 
   int *procowner;
@@ -1399,7 +1399,7 @@ int Special::rendezvous_ids(int n, char *inbuf, int &flag, int *& /*proclist*/, 
   memory->create(procowner,n,"special:procowner");
   memory->create(atomIDs,n,"special:atomIDs");
 
-  auto in = (IDRvous *) inbuf;
+  auto *in = (IDRvous *) inbuf;
 
   for (int i = 0; i < n; i++) {
     procowner[i] = in[i].me;
@@ -1428,7 +1428,7 @@ int Special::rendezvous_ids(int n, char *inbuf, int &flag, int *& /*proclist*/, 
 int Special::rendezvous_pairs(int n, char *inbuf, int &flag, int *&proclist,
                               char *&outbuf, void *ptr)
 {
-  auto sptr = (Special *) ptr;
+  auto *sptr = (Special *) ptr;
   Atom *atom = sptr->atom;
   Memory *memory = sptr->memory;
 
@@ -1447,7 +1447,7 @@ int Special::rendezvous_pairs(int n, char *inbuf, int &flag, int *&proclist,
 
   // proclist = owner of atomID in caller decomposition
 
-  auto in = (PairRvous *) inbuf;
+  auto *in = (PairRvous *) inbuf;
   int *procowner = sptr->procowner;
   memory->create(proclist,n,"special:proclist");
 

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -1089,7 +1089,7 @@ void Thermo::parse_fields(const std::string &str)
       argindex2[nfield] = (argi.get_dim() > 1) ? argi.get_index2() : 0;
 
       if (argi.get_type() == ArgInfo::COMPUTE) {
-        auto icompute = modify->get_compute_by_id(argi.get_name());
+        auto *icompute = modify->get_compute_by_id(argi.get_name());
         if (!icompute)
           error->all(FLERR, nfield + 1, "Could not find thermo custom compute ID: {}",
                      icompute->id);
@@ -1130,7 +1130,7 @@ void Thermo::parse_fields(const std::string &str)
         addfield(word.c_str(), &Thermo::compute_compute, FLOAT);
 
       } else if (argi.get_type() == ArgInfo::FIX) {
-        auto ifix = modify->get_fix_by_id(argi.get_name());
+        auto *ifix = modify->get_fix_by_id(argi.get_name());
         if (!ifix)
           error->all(FLERR, nfield + 1, "Could not find thermo custom fix ID: {}", ifix->id);
         if (argi.get_dim() == 0) {    // scalar

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1220,7 +1220,7 @@ int utils::check_grid_reference(char *errstr, char *ref, int nevery, char *&id, 
 {
   ArgInfo argi(ref, ArgInfo::COMPUTE | ArgInfo::FIX);
   index = argi.get_index1();
-  auto name = argi.get_name();
+  const auto *name = argi.get_name();
 
   switch (argi.get_type()) {
 
@@ -1239,7 +1239,7 @@ int utils::check_grid_reference(char *errstr, char *ref, int nevery, char *&id, 
       const auto &gname = words[1];
       const auto &dname = words[2];
 
-      auto icompute = lmp->modify->get_compute_by_id(idcompute);
+      auto *icompute = lmp->modify->get_compute_by_id(idcompute);
       if (!icompute) lmp->error->all(FLERR, "{} compute ID {} not found", errstr, idcompute);
       if (icompute->pergrid_flag == 0)
         lmp->error->all(FLERR, "{} compute {} does not compute per-grid info", errstr, idcompute);
@@ -1281,7 +1281,7 @@ int utils::check_grid_reference(char *errstr, char *ref, int nevery, char *&id, 
       const auto &gname = words[1];
       const auto &dname = words[2];
 
-      auto ifix = lmp->modify->get_fix_by_id(idfix);
+      auto *ifix = lmp->modify->get_fix_by_id(idfix);
       if (!ifix) lmp->error->all(FLERR, "{} fix ID {} not found", errstr, idfix);
       if (ifix->pergrid_flag == 0)
         lmp->error->all(FLERR, "{} fix {} does not compute per-grid info", errstr, idfix);
@@ -1853,7 +1853,7 @@ double utils::get_conversion_factor(const int property, const int conversion)
 
 FILE *utils::open_potential(const std::string &name, LAMMPS *lmp, int *auto_convert)
 {
-  auto error = lmp->error;
+  auto *error = lmp->error;
   auto me = lmp->comm->me;
 
   std::string filepath = get_potential_file_path(name);

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -327,8 +327,8 @@ void Variable::set(int narg, char **arg)
 
     int maxcopy = strlen(arg[2]) + 1;
     int maxwork = maxcopy;
-    auto scopy = (char *) memory->smalloc(maxcopy, "var:string/copy");
-    auto work = (char *) memory->smalloc(maxwork, "var:string/work");
+    auto *scopy = (char *) memory->smalloc(maxcopy, "var:string/copy");
+    auto *work = (char *) memory->smalloc(maxwork, "var:string/work");
     strcpy(scopy, arg[2]);
     input->substitute(scopy, work, maxcopy, maxwork, 1);
     memory->sfree(work);
@@ -1513,7 +1513,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
       int istop = i - 1;
 
       int n = istop - istart + 1;
-      auto number = new char[n+1];
+      auto *number = new char[n+1];
       strncpy(number,&str[istart],n);
       number[n] = '\0';
 
@@ -1546,7 +1546,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
       int istop = i-1;
 
       int n = istop - istart + 1;
-      auto word = new char[n+1];
+      auto *word = new char[n+1];
       strncpy(word,&str[istart],n);
       word[n] = '\0';
 

--- a/src/velocity.cpp
+++ b/src/velocity.cpp
@@ -184,7 +184,7 @@ void Velocity::create(double t_desired, int seed)
   Compute *temperature_nobias = nullptr;
 
   if (temperature == nullptr || bias_flag) {
-    auto newcompute = modify->add_compute(fmt::format("velocity_temp {} temp",group->names[igroup]));
+    auto *newcompute = modify->add_compute(fmt::format("velocity_temp {} temp",group->names[igroup]));
     if (temperature == nullptr) {
       temperature = newcompute;
       tcreate_flag = 1;

--- a/src/write_data.cpp
+++ b/src/write_data.cpp
@@ -254,7 +254,7 @@ void WriteData::write(const std::string &file)
   // extra sections managed by fixes
 
   if (fixflag)
-    for (auto &ifix : modify->get_fix_list())
+    for (const auto &ifix : modify->get_fix_list())
       if (ifix->wd_section)
         for (int m = 0; m < ifix->wd_section; m++) fix(ifix,m);
 
@@ -313,7 +313,7 @@ void WriteData::header()
   // fix info
 
   if (fixflag)
-    for (auto &ifix : modify->get_fix_list())
+    for (const auto &ifix : modify->get_fix_list())
       if (ifix->wd_header)
         for (int m = 0; m < ifix->wd_header; m++)
           ifix->write_data_header(fp,m);

--- a/src/write_dump.cpp
+++ b/src/write_dump.cpp
@@ -51,7 +51,7 @@ void WriteDump::command(int narg, char **arg)
   dumpfreq += update->ntimestep % dumpfreq;
 
   std::string dump_id = "WRITE_DUMP";
-  auto dumpargs = new char *[modindex + 2];
+  auto *dumpargs = new char *[modindex + 2];
   dumpargs[0] = (char *) dump_id.c_str();                   // dump id
   dumpargs[1] = arg[0];                                     // group
   dumpargs[2] = arg[1];                                     // dump style

--- a/src/write_restart.cpp
+++ b/src/write_restart.cpp
@@ -380,7 +380,7 @@ void WriteRestart::write(const std::string &file)
 
   // invoke any fixes that write their own restart file
 
-  for (auto &fix : modify->get_fix_list())
+  for (const auto &fix : modify->get_fix_list())
     if (fix->restart_file)
       fix->write_restart_file(file.c_str());
 }


### PR DESCRIPTION
**Summary**

This pull request changes the use of "auto" to add qualifiers so it is more obvious if this is a pointer or reference or regular variable. Also, for assignments following a new or a type case, the redundant type on the left is replaced with auto.

These transformations were done semi-automatically with clang-tidy

**Related Issue(s)**

N/A

**Author(s)**

Axel Kohlmeyer, Temple U with assistance from clang-tidy

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

Packages with complex code like INTEL or KOKKOS have been excluded to avoid unintended problems.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
