### PR TITLE
Collected small changes and fixes

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -250,6 +250,15 @@ link_check : $(VENV) html
 		deactivate ;\
 	)
 
+upgrade: $(VENV)
+	@(\
+		. $(VENV)/bin/activate; \
+		pip $(PIP_OPTIONS) install --upgrade pip; \
+		pip $(PIP_OPTIONS) install --upgrade wheel; \
+		pip $(PIP_OPTIONS) install --upgrade -r $(BUILDDIR)/utils/requirements.txt; \
+		deactivate;\
+	)
+
 xmlgen : doxygen/xml/index.xml
 
 doxygen/Doxyfile: doxygen/Doxyfile.in

--- a/doc/src/Build_manual.rst
+++ b/doc/src/Build_manual.rst
@@ -57,6 +57,8 @@ Python interpreter version 3.8 or later, the ``doxygen`` tools and
 internet access to download additional files and tools are required.
 This download is usually only required once or after the documentation
 folder is returned to a pristine state with ``make clean-all``.
+You can also upgrade those packages to their latest available versions
+with ``make upgrade``.
 
 For the documentation build a python virtual environment is set up in
 the folder ``doc/docenv`` and various python packages are installed into
@@ -82,6 +84,7 @@ folder.  The following ``make`` commands are available:
 
    make clean         # remove intermediate RST files created by HTML build
    make clean-all     # remove entire build folder and any cached data
+   make upgrade       # upgrade the python packages in the virtual environment
 
    make anchor_check  # check for duplicate anchor labels
    make style_check   # check for complete and consistent style lists

--- a/doc/src/fix_atom_swap.rst
+++ b/doc/src/fix_atom_swap.rst
@@ -116,7 +116,10 @@ charge would not be conserved. As a consequence, no checks on atomic
 charges are performed, and successful switches update the atom type but
 not the atom charge. While it is possible to use *semi-grand* with
 groups of atoms that have different charges, these charges will not be
-changed when the atom types change.
+changed when the atom types change.  The same applies for systems
+with per-atom masses: non *semi-grand* will swap atom masses, but
+the masses have to be the same each for the atom types.  When using
+*semi-grand* no per-atom masses are changed.
 
 Since this fix computes total potential energies before and after
 proposed swaps, even complicated potential energy calculations are

--- a/doc/src/fix_atom_swap.rst
+++ b/doc/src/fix_atom_swap.rst
@@ -184,11 +184,10 @@ When this fix is used with a :doc:`hybrid pair style <pair_hybrid>`
 system, only swaps between atom types of the same sub-style (or
 combination of sub-styles) are permitted.
 
-This fix cannot be used with systems that do not have per-type masses
-(e.g. atom style sphere) since the implemented algorithm pre-computes
-velocity rescaling factors from per-type masses and ignores any per-atom
-masses, if present.  In case both, per-type and per-atom masses are
-present, a warning is printed.
+This fix can be used with systems that have per-atom masses
+(e.g. atom style sphere) provided all atoms of the types handled
+by this fix have the same mass per type. The fix will check for that.
+In case both, per-type and per-atom masses are present, a warning is printed.
 
 Related commands
 """"""""""""""""

--- a/src/Depend.sh
+++ b/src/Depend.sh
@@ -96,6 +96,10 @@ if (test $1 = "EXTRA-COMPUTE") then
   depend KOKKOS
 fi
 
+if (test $1 = "EXTRA-FIX") then
+  depend KOKKOS
+fi
+
 if (test $1 = "EXTRA-MOLECULE") then
   depend GPU
   depend OPENMP

--- a/src/KOKKOS/Install.sh
+++ b/src/KOKKOS/Install.sh
@@ -139,6 +139,8 @@ action dihedral_class2_kokkos.cpp dihedral_class2.cpp
 action dihedral_class2_kokkos.h dihedral_class2.h
 action dihedral_harmonic_kokkos.cpp dihedral_harmonic.cpp
 action dihedral_harmonic_kokkos.h dihedral_harmonic.h
+action dihedral_multi_harmonic_kokkos.cpp dihedral_multi_harmonic.cpp
+action dihedral_multi_harmonic_kokkos.h dihedral_multi_harmonic.h
 action dihedral_opls_kokkos.cpp dihedral_opls.cpp
 action dihedral_opls_kokkos.h dihedral_opls.h
 action dihedral_hybrid_kokkos.cpp dihedral_hybrid.cpp

--- a/src/KOKKOS/compute_sna_grid_kokkos.h
+++ b/src/KOKKOS/compute_sna_grid_kokkos.h
@@ -206,7 +206,7 @@ class ComputeSNAGridKokkos : public ComputeSNAGrid {
 
   SNAKokkos<DeviceType, real_type, vector_length> snaKK;
 
-  int max_neighs, chunk_size, chunk_offset, nprocs;
+  int max_neighs, chunk_size, chunk_offset;
   int host_flag;
   int ntotal;
   int total_range; // total number of loop iterations in grid

--- a/src/KOKKOS/compute_sna_grid_kokkos_impl.h
+++ b/src/KOKKOS/compute_sna_grid_kokkos_impl.h
@@ -125,7 +125,7 @@ ComputeSNAGridKokkos<DeviceType, real_type, vector_length>::ComputeSNAGridKokkos
   snaKK.init();
 
   if (quadraticflag)
-    error->all(FLERR, "Cannot (yet) use quadratic SNAP with compute sna/grid/kk"); 
+    error->all(FLERR, "Cannot (yet) use quadratic SNAP with compute sna/grid/kk");
 }
 
 // Destructor

--- a/src/KOKKOS/compute_sna_grid_kokkos_impl.h
+++ b/src/KOKKOS/compute_sna_grid_kokkos_impl.h
@@ -123,6 +123,9 @@ ComputeSNAGridKokkos<DeviceType, real_type, vector_length>::ComputeSNAGridKokkos
   snaKK = SNAKokkos<DeviceType, real_type, vector_length>(*this);
   snaKK.grow_rij(0,0);
   snaKK.init();
+
+  if (quadraticflag)
+    error->all(FLERR, "Cannot (yet) use quadratic SNAP with compute sna/grid/kk"); 
 }
 
 // Destructor
@@ -188,10 +191,10 @@ void ComputeSNAGridKokkos<DeviceType, real_type, vector_length>::compute_array()
   type = atomKK->k_type.view<DeviceType>();
   k_cutsq.template sync<DeviceType>();
 
+  Kokkos::deep_copy(d_grid,0.0);
+
   // max_neighs is defined here - think of more elaborate methods.
   max_neighs = 100;
-
-  nprocs = comm->nprocs;
 
   // Pair snap/kk uses grow_ij with some max number of neighs but compute sna/grid uses total
   // number of atoms.
@@ -361,7 +364,7 @@ void ComputeSNAGridKokkos<DeviceType, real_type, vector_length>::operator() (Tag
   if (ii >= chunk_size) return;
 
   // extract grid index
-  int igrid = ii + chunk_offset;
+  int i = ii + chunk_offset;
 
   // get a pointer to scratch memory
   // This is used to cache whether or not an atom is within the cutoff.
@@ -374,8 +377,8 @@ void ComputeSNAGridKokkos<DeviceType, real_type, vector_length>::operator() (Tag
 
   // convert to grid indices
 
-  int iz = igrid/(xlen*ylen);
-  int i2 = igrid - (iz*xlen*ylen);
+  int iz = i/(xlen*ylen);
+  int i2 = i - (iz*xlen*ylen);
   int iy = i2/xlen;
   int ix = i2 % xlen;
   iz += nzlo;
@@ -384,12 +387,6 @@ void ComputeSNAGridKokkos<DeviceType, real_type, vector_length>::operator() (Tag
 
   double xgrid[3];
 
-  // index ii already captures the proper grid point
-  //int igrid = iz * (nx * ny) + iy * nx + ix;
-
-  // grid2x converts igrid to ix,iy,iz like we've done before
-  // multiply grid integers by grid spacing delx, dely, delz
-  //grid2x(igrid, xgrid);
   xgrid[0] = ix * delx;
   xgrid[1] = iy * dely;
   xgrid[2] = iz * delz;
@@ -673,12 +670,12 @@ KOKKOS_INLINE_FUNCTION
 void ComputeSNAGridKokkos<DeviceType, real_type, vector_length>::operator() (TagCSNAGridLocalFill, const int& ii) const {
 
   // extract grid index
-  int igrid = ii + chunk_offset;
+  int i = ii + chunk_offset;
 
   // convert to grid indices
 
-  int iz = igrid/(xlen*ylen);
-  int i2 = igrid - (iz*xlen*ylen);
+  int iz = i/(xlen*ylen);
+  int i2 = i - (iz*xlen*ylen);
   int iy = i2/xlen;
   int ix = i2 % xlen;
   iz += nzlo;
@@ -687,12 +684,8 @@ void ComputeSNAGridKokkos<DeviceType, real_type, vector_length>::operator() (Tag
 
   double xgrid[3];
 
-  // index ii already captures the proper grid point
-  // int igrid = iz * (nx * ny) + iy * nx + ix;
-  // printf("ii igrid: %d %d\n", ii, igrid);
+  int igrid = iz * (nx * ny) + iy * nx + ix;
 
-  // grid2x converts igrid to ix,iy,iz like we've done before
-  //grid2x(igrid, xgrid);
   xgrid[0] = ix * delx;
   xgrid[1] = iy * dely;
   xgrid[2] = iz * delz;
@@ -713,9 +706,9 @@ void ComputeSNAGridKokkos<DeviceType, real_type, vector_length>::operator() (Tag
   const F_FLOAT xtmp = xgrid[0];
   const F_FLOAT ytmp = xgrid[1];
   const F_FLOAT ztmp = xgrid[2];
-  d_grid(igrid,0) = xtmp/nprocs;
-  d_grid(igrid,1) = ytmp/nprocs;
-  d_grid(igrid,2) = ztmp/nprocs;
+  d_grid(igrid,0) = xtmp;
+  d_grid(igrid,1) = ytmp;
+  d_grid(igrid,2) = ztmp;
 
   const auto idxb_max = snaKK.idxb_max;
 

--- a/src/KOKKOS/compute_sna_grid_local_kokkos_impl.h
+++ b/src/KOKKOS/compute_sna_grid_local_kokkos_impl.h
@@ -122,6 +122,9 @@ ComputeSNAGridLocalKokkos<DeviceType, real_type, vector_length>::ComputeSNAGridL
   snaKK = SNAKokkos<DeviceType, real_type, vector_length>(*this);
   snaKK.grow_rij(0,0);
   snaKK.init();
+
+  if (quadraticflag)
+    error->all(FLERR, "Cannot (yet) use quadratic SNAP with compute sna/grid/local/kk");
 }
 
 // Destructor

--- a/src/MC/fix_atom_swap.cpp
+++ b/src/MC/fix_atom_swap.cpp
@@ -52,11 +52,11 @@ using namespace FixConst;
 
 FixAtomSwap::FixAtomSwap(LAMMPS *lmp, int narg, char **arg) :
     Fix(lmp, narg, arg), region(nullptr), idregion(nullptr), type_list(nullptr), mu(nullptr),
-    qtype(nullptr), sqrt_mass_ratio(nullptr), local_swap_iatom_list(nullptr),
+    qtype(nullptr), mtype(nullptr), sqrt_mass_ratio(nullptr), local_swap_iatom_list(nullptr),
     local_swap_jatom_list(nullptr), local_swap_atom_list(nullptr), random_equal(nullptr),
     random_unequal(nullptr), c_pe(nullptr)
 {
-  if (narg < 10) error->all(FLERR, "Illegal fix atom/swap command");
+  if (narg < 10) utils::missing_cmd_args(FLERR, "fix atom/swap", error);
 
   dynamic_group_allow = 1;
 
@@ -129,6 +129,7 @@ FixAtomSwap::~FixAtomSwap()
   memory->destroy(type_list);
   memory->destroy(mu);
   memory->destroy(qtype);
+  memory->destroy(mtype);
   memory->destroy(sqrt_mass_ratio);
   memory->destroy(local_swap_iatom_list);
   memory->destroy(local_swap_jatom_list);
@@ -204,9 +205,8 @@ int FixAtomSwap::setmask()
 
 void FixAtomSwap::init()
 {
-  if (!atom->mass) error->all(FLERR, "Fix atom/swap requires per atom type masses");
-  if (atom->rmass_flag && (comm->me == 0))
-    error->warning(FLERR, "Fix atom/swap will use per-type masses for velocity rescaling");
+  if ((atom->mass != nullptr) && (atom->rmass != nullptr) && (comm->me == 0))
+    error->warning(FLERR, "Fix atom/swap will use per-atom masses for velocity rescaling");
 
   c_pe = modify->get_compute_by_id("thermo_pe");
 
@@ -286,13 +286,62 @@ void FixAtomSwap::init()
       if (first) qtype[iswaptype] = DBL_MAX;
       MPI_Allreduce(&qtype[iswaptype], &qmin, 1, MPI_DOUBLE, MPI_MIN, world);
       if (qmax != qmin) error->all(FLERR, "All atoms of a swapped type must have same charge.");
+      qtype[iswaptype] = qmax;
+    }
+  }
+
+  // if we have per-atom masses, check that rmass is consistent with type,
+  // and set per-type mass to that value
+  if ((atom->rmass !=  nullptr) && !semi_grand_flag) {
+    double mmax, mmin;
+    int firstall, first;
+    memory->create(mtype, nswaptypes, "atom/swap:mtype");
+    for (int iswaptype = 0; iswaptype < nswaptypes; iswaptype++) {
+      first = 1;
+      for (int i = 0; i < atom->nlocal; i++) {
+        if (atom->mask[i] & groupbit) {
+          if (type[i] == type_list[iswaptype]) {
+            if (first > 0) {
+              mtype[iswaptype] = atom->rmass[i];
+              first = 0;
+            } else if (mtype[iswaptype] != atom->rmass[i])
+              first = -1;
+          }
+        }
+      }
+      MPI_Allreduce(&first, &firstall, 1, MPI_INT, MPI_MIN, world);
+      if (firstall < 0)
+        error->all(FLERR, Error::NOLASTLINE,
+                   "All atoms of a swapped type must have the same per-atom mass");
+      if (firstall > 0)
+        error->all(FLERR, Error::NOLASTLINE,
+                   "At least one atom of each swapped type must be present to define masses");
+      if (first) mtype[iswaptype] = -DBL_MAX;
+      MPI_Allreduce(&mtype[iswaptype], &mmax, 1, MPI_DOUBLE, MPI_MAX, world);
+      if (first) mtype[iswaptype] = DBL_MAX;
+      MPI_Allreduce(&mtype[iswaptype], &mmin, 1, MPI_DOUBLE, MPI_MIN, world);
+      if (mmax != mmin)
+        error->all(FLERR, Error::NOLASTLINE, "All atoms of a swapped type must have same mass.");
+      mtype[iswaptype] = mmax;
     }
   }
 
   memory->create(sqrt_mass_ratio, atom->ntypes + 1, atom->ntypes + 1, "atom/swap:sqrt_mass_ratio");
-  for (int itype = 1; itype <= atom->ntypes; itype++)
-    for (int jtype = 1; jtype <= atom->ntypes; jtype++)
-      sqrt_mass_ratio[itype][jtype] = sqrt(atom->mass[itype] / atom->mass[jtype]);
+  if (atom->rmass != nullptr) {
+    for (int itype = 1; itype <= atom->ntypes; itype++)
+      for (int jtype = 1; jtype <= atom->ntypes; jtype++) sqrt_mass_ratio[itype][jtype] = 1.0;
+    for (int iswaptype = 0; iswaptype < nswaptypes; iswaptype++) {
+      int itype = type_list[iswaptype];
+      for (int jswaptype = 0; jswaptype < nswaptypes; jswaptype++) {
+        int jtype = type_list[jswaptype];
+        sqrt_mass_ratio[itype][jtype] = sqrt(mtype[iswaptype] / mtype[jswaptype]);
+      }
+    }
+  } else {
+    for (int itype = 1; itype <= atom->ntypes; itype++)
+      for (int jtype = 1; jtype <= atom->ntypes; jtype++)
+        sqrt_mass_ratio[itype][jtype] = sqrt(atom->mass[itype] / atom->mass[jtype]);
+  }
 
   // check to see if itype and jtype cutoffs are the same
   // if not, reneighboring will be needed between swaps
@@ -479,10 +528,12 @@ int FixAtomSwap::attempt_swap()
   if (i >= 0) {
     atom->type[i] = jtype;
     if (atom->q_flag) atom->q[i] = qtype[1];
+    if (atom->rmass != nullptr) atom->rmass[i] = mtype[1];
   }
   if (j >= 0) {
     atom->type[j] = itype;
     if (atom->q_flag) atom->q[j] = qtype[0];
+    if (atom->rmass != nullptr) atom->rmass[j] = mtype[0];
   }
 
   // if unequal_cutoffs, call comm->borders() and rebuild neighbor list
@@ -534,10 +585,12 @@ int FixAtomSwap::attempt_swap()
   if (i >= 0) {
     atom->type[i] = type_list[0];
     if (atom->q_flag) atom->q[i] = qtype[0];
+    if (atom->rmass != nullptr) atom->rmass[i] = mtype[0];
   }
   if (j >= 0) {
     atom->type[j] = type_list[1];
     if (atom->q_flag) atom->q[j] = qtype[1];
+    if (atom->rmass != nullptr) atom->rmass[j] = mtype[1];
   }
 
   return 0;
@@ -628,10 +681,9 @@ void FixAtomSwap::update_semi_grand_atoms_list()
   double **x = atom->x;
 
   if (atom->nmax > atom_swap_nmax) {
-    memory->sfree(local_swap_atom_list);
+    memory->destroy(local_swap_atom_list);
     atom_swap_nmax = atom->nmax;
-    local_swap_atom_list =
-        (int *) memory->smalloc(atom_swap_nmax * sizeof(int), "MCSWAP:local_swap_atom_list");
+    memory->create(local_swap_atom_list, atom_swap_nmax, "MCSWAP:local_swap_atom_list");
   }
 
   nswap_local = 0;
@@ -681,13 +733,11 @@ void FixAtomSwap::update_swap_atoms_list()
   double **x = atom->x;
 
   if (atom->nmax > atom_swap_nmax) {
-    memory->sfree(local_swap_iatom_list);
-    memory->sfree(local_swap_jatom_list);
+    memory->destroy(local_swap_iatom_list);
+    memory->destroy(local_swap_jatom_list);
     atom_swap_nmax = atom->nmax;
-    local_swap_iatom_list =
-        (int *) memory->smalloc(atom_swap_nmax * sizeof(int), "MCSWAP:local_swap_iatom_list");
-    local_swap_jatom_list =
-        (int *) memory->smalloc(atom_swap_nmax * sizeof(int), "MCSWAP:local_swap_jatom_list");
+    memory->create(local_swap_iatom_list, atom_swap_nmax, "MCSWAP:local_swap_iatom_list");
+    memory->create(local_swap_jatom_list, atom_swap_nmax, "MCSWAP:local_swap_jatom_list");
   }
 
   niswap_local = 0;

--- a/src/MC/fix_atom_swap.h
+++ b/src/MC/fix_atom_swap.h
@@ -53,7 +53,7 @@ class FixAtomSwap : public Fix {
   class Region *region;                // swap region
   char *idregion;                      // swap region id
 
-  int mc_active;              // 1 during MC trials, otherwise 0
+  int mc_active;    // 1 during MC trials, otherwise 0
 
   int nswaptypes, nmutypes;
   int *type_list;
@@ -66,7 +66,7 @@ class FixAtomSwap : public Fix {
 
   int atom_swap_nmax;
   double beta;
-  double *qtype;
+  double *qtype, *mtype;
   double energy_stored;
   double **sqrt_mass_ratio;
   int *local_swap_iatom_list;

--- a/src/MC/fix_hmc.cpp
+++ b/src/MC/fix_hmc.cpp
@@ -69,8 +69,8 @@ FixHMC::FixHMC(LAMMPS *lmp, int narg, char **arg) :
 
   // required arguments
 
-  nevery = utils::numeric(FLERR, arg[3], false, lmp);
-  int seed = utils::numeric(FLERR, arg[4], false, lmp);
+  nevery = utils::inumeric(FLERR, arg[3], false, lmp);
+  int seed = utils::inumeric(FLERR, arg[4], false, lmp);
   double temp = utils::numeric(FLERR, arg[5], false, lmp);
 
   if (seed <= 0) error->all(FLERR, 4, "Fix hmc seed must be > 0");

--- a/src/MC/fix_hmc.cpp
+++ b/src/MC/fix_hmc.cpp
@@ -102,8 +102,9 @@ FixHMC::FixHMC(LAMMPS *lmp, int narg, char **arg) :
       auto *ifix = modify->get_fix_by_id(id_rigid);
       if (!ifix) error->all(FLERR, iarg + 1, "Unknown rigid fix id {} for fix hmc", id_rigid);
       fix_rigid = dynamic_cast<FixRigidSmall *>(ifix);
-      if (!fix_rigid || !utils::strmatch(ifix->style, "^rigid/small") ||
-          !utils::strmatch(ifix->style, "^rigid/nve/small"))
+      if (!fix_rigid ||
+          (!utils::strmatch(ifix->style, "^rigid/small") &&
+           !utils::strmatch(ifix->style, "^rigid/nve/small")))
         error->all(FLERR, Error::NOLASTLINE,
                    "Fix ID {} for fix hmc does not point to fix rigid/small or rigid/nve/small",
                    id_rigid);
@@ -302,8 +303,9 @@ void FixHMC::init()
     if (!ifix)
       error->all(FLERR, Error::NOLASTLINE, "Unknown rigid fix id {} for fix hmc", id_rigid);
     fix_rigid = dynamic_cast<FixRigidSmall *>(ifix);
-    if (!fix_rigid || !utils::strmatch(ifix->style, "^rigid/small") ||
-        !utils::strmatch(ifix->style, "^rigid/nve/small"))
+    if (!fix_rigid ||
+        (!utils::strmatch(ifix->style, "^rigid/small") &&
+         !utils::strmatch(ifix->style, "^rigid/nve/small")))
       error->all(FLERR, Error::NOLASTLINE,
                  "Fix ID {} for fix hmc does not point to fix rigid/small or rigid/nve/small",
                  id_rigid);

--- a/src/ML-IAP/mliap_so3_math.h
+++ b/src/ML-IAP/mliap_so3_math.h
@@ -22,12 +22,12 @@ void LUPSolve(int n, double *A, double *B, int *P);
 
 using namespace MathEigen;
 
-typedef Jacobi<double, double *, double **, double const *const *> Jacobi_v2;
+using Jacobi_v2 = Jacobi<double, double *, double **, double const *const *>;
 inline int SO3Math::jacobin(int n, double const *const *mat, double *eval, double **evec)
 {
-  int *midx = new int[n];
-  double **M = new double *[n];
-  double **mat_cpy = new double *[n];
+  auto *midx = new int[n];
+  auto **M = new double *[n];
+  auto **mat_cpy = new double *[n];
 
   for (int i = 0; i < n; i++) {
     mat_cpy[i] = new double[n];
@@ -55,12 +55,9 @@ inline int SO3Math::invert_matrix(int n, double *A, double *Ainv)
   int i, j;
   double dtol = 1.e-30;
 
-  int *P;
-  double *b, *Atemp;
-
-  P = new int[n];
-  b = new double[n];
-  Atemp = new double[n * n];
+  auto *P = new int[n];
+  auto *b = new double[n];
+  auto *Atemp = new double[n * n];
 
   for (i = 0; i < n * n; i++) Atemp[i] = A[i];
 
@@ -88,12 +85,11 @@ inline int SO3Math::invert_matrix(int n, double *A, double *Ainv)
 
 inline int SO3Math::LUPdecompose(int n, double dtol, double *A, int *P)
 {
-  int i, j, k, maxi;
+  int i, j, k;
   double maxA, Atemp;
-  double *normi;
 
-  maxi = 0;
-  normi = new double[n];
+  int maxi = 0;
+  auto *normi = new double[n];
 
   for (i = 0; i < n; i++) {
     maxA = 0.0;

--- a/src/REAXFF/fix_acks2_reaxff.cpp
+++ b/src/REAXFF/fix_acks2_reaxff.cpp
@@ -412,7 +412,7 @@ void FixACKS2ReaxFF::init_matvec()
 
 /* ---------------------------------------------------------------------- */
 
-void FixACKS2ReaxFF::compute_X()
+void FixACKS2ReaxFF::compute_X() // NOLINT
 {
   int jnum;
   int i, j, ii, jj, flag;

--- a/src/REAXFF/fix_acks2_reaxff.h
+++ b/src/REAXFF/fix_acks2_reaxff.h
@@ -57,7 +57,7 @@ class FixACKS2ReaxFF : public FixQEqReaxFF {
   void deallocate_matrix() override;
 
   void init_matvec() override;
-  void compute_X();
+  void compute_X();    // NOLINT
   double calculate_X(double, double);
   void calculate_Q() override;
 

--- a/src/REAXFF/reaxff_inline.h
+++ b/src/REAXFF/reaxff_inline.h
@@ -29,27 +29,13 @@ struct LR_data {
   double e_vdW, CEvd;
   double e_ele, CEclmb;
 
-  LAMMPS_INLINE
-  LR_data() {}
-
-  LAMMPS_INLINE
-  void operator=(const LR_data &rhs)
-  {
-    H = rhs.H;
-    e_vdW = rhs.e_vdW;
-    CEvd = rhs.CEvd;
-    e_ele = rhs.e_ele;
-    CEclmb = rhs.CEclmb;
-  }
-  LAMMPS_INLINE
-  void operator=(const LR_data &rhs) volatile
-  {
-    H = rhs.H;
-    e_vdW = rhs.e_vdW;
-    CEvd = rhs.CEvd;
-    e_ele = rhs.e_ele;
-    CEclmb = rhs.CEclmb;
-  }
+  LR_data() = default;
+  ~LR_data() = default;
+  LR_data(LR_data &&) = delete;
+  LR_data(const LR_data &) = delete;
+  LR_data &operator=(const LR_data &) = delete;
+  LR_data &operator=(LR_data &&) = delete;
+  void swap(LR_data &) = delete;
 };
 
 struct cubic_spline_coef {

--- a/src/UEF/uef_utils.cpp
+++ b/src/UEF/uef_utils.cpp
@@ -311,7 +311,7 @@ void col_sort(double b[3][3],int r[3][3],int ri[3][3])
 ------------------------------------------------------------------------- */
 void red12(double b[3][3],int r[3][3],int ri[3][3])
 {
-  int y = round(col_prod(b,0,1)/col_prod(b,0,0));
+  int y = round(col_prod(b,0,1)/col_prod(b,0,0)); // NOLINT
   b[0][1] -= y*b[0][0];
   b[1][1] -= y*b[1][0];
   b[2][1] -= y*b[2][0];

--- a/src/accelerator_kokkos.h
+++ b/src/accelerator_kokkos.h
@@ -56,7 +56,7 @@ class KokkosLMP {
   int ngpus;
 
   KokkosLMP(class LAMMPS *, int, char **) { kokkos_exists = 0; }
-  ~KokkosLMP() {}
+  ~KokkosLMP() = default;
   static void finalize() {}
   void accelerator(int, char **) {}
   int neigh_list_kokkos(int) { return 0; }

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -945,7 +945,7 @@ rendezvous_irregular(int n, char *inbuf, int insize, int inorder, int *procs,
   auto *inbuf_rvous = (char *) memory->smalloc((bigint) nrvous*insize+1, "rendezvous:inbuf");
   irregular->exchange_data(inbuf,insize,inbuf_rvous);
 
-  bigint irregular1_bytes = irregular->memory_usage();
+  bigint irregular1_bytes = irregular->memory_usage(); // NOLINT
   irregular->destroy_data();
   delete irregular;
 
@@ -978,7 +978,7 @@ rendezvous_irregular(int n, char *inbuf, int insize, int inorder, int *procs,
   outbuf = (char *) memory->smalloc((bigint) nout*outsize+1, "rendezvous:outbuf");
   irregular->exchange_data(outbuf_rvous,outsize,outbuf);
 
-  bigint irregular2_bytes = irregular->memory_usage();
+  bigint irregular2_bytes = irregular->memory_usage(); // NOLINT
   irregular->destroy_data();
   delete irregular;
 

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -1533,7 +1533,7 @@ int Modify::read_restart(FILE *fp)
 
   // allocate space for each entry
 
-  if (nfix_restart_global) {
+  if (nfix_restart_global > 0) {
     id_restart_global = new char *[nfix_restart_global];
     style_restart_global = new char *[nfix_restart_global];
     state_restart_global = new char *[nfix_restart_global];

--- a/src/reader_native.cpp
+++ b/src/reader_native.cpp
@@ -527,7 +527,7 @@ void ReaderNative::read_buf(void * ptr, size_t size, size_t count)
 std::string ReaderNative::read_binary_str(size_t size)
 {
   std::string str(size, '\0');
-  read_buf(str.data(), sizeof(char), size);
+  read_buf((char *)str.data(), sizeof(char), size);
   return str;
 }
 


### PR DESCRIPTION
**Summary**

This pull request combines multiple small changes and fixes that do not warrant
a pull request of their own.

**Related Issue(s)**

N/A

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

The following individual changes are included:
- use qualified auto and using in ML-IAP header that was overlooked in PR #4649 
- fix more issues with `compute sna/grid/kk`
- Add `make upgrade` target to the documentation makefile, to run `pip install --upgrade`
- replace some cases of typedef with using =
- more use of qualified auto
- make pair styles (like EAM, MEAM, BOP, etc.) that call `atom->set_mass()` compatible with per-atom masses
- remove unneeded assignment operators (with odd return values) from ReaxFF
- silence some clang-tidy warnings with // NOLINT comments
- fix issues in GNU Makefile build system with KOKKOS package


**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
