### PR TITLE
Apply code modernization suggestions from clang-tidy

### DIFF
--- a/src/EXTRA-DUMP/xdr_compat.h
+++ b/src/EXTRA-DUMP/xdr_compat.h
@@ -7,7 +7,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
+// NOLINTBEGIN
 /*
  * This file contains the definitions for Sun External Data Representation (XDR).
  * They have been adapted specifically for the use with the LAMMPS xtc dump style
@@ -130,6 +130,7 @@ extern bool_t xdr_vector(XDR *__xdrs, char *__basep, unsigned int __nelem, unsig
 extern bool_t xdr_float(XDR *__xdrs, float *__fp);
 extern void xdrstdio_create(XDR *__xdrs, FILE *__file, enum xdr_op __xop);
 
+// NOLINTEND
 #ifdef __cplusplus
 }
 #endif

--- a/src/INTEL/nstencil_bin_intel.h
+++ b/src/INTEL/nstencil_bin_intel.h
@@ -13,32 +13,32 @@
 
 #ifdef NSTENCIL_CLASS
 // clang-format off
-typedef NStencilBinIntel<0, 0, 0> NStencilFullBin2dIntel;
+using NStencilFullBin2dIntel = NStencilBinIntel<0, 0, 0>;
 NStencilStyle(full/bin/2d/intel,
               NStencilFullBin2dIntel,
               NS_FULL | NS_BIN | NS_2D | NS_ORTHO | NS_TRI | NS_INTEL);
 
-typedef NStencilBinIntel<0, 1, 0> NStencilFullBin3dIntel;
+using NStencilFullBin3dIntel = NStencilBinIntel<0, 1, 0>;
 NStencilStyle(full/bin/3d/intel,
               NStencilFullBin3dIntel,
               NS_FULL | NS_BIN | NS_3D | NS_ORTHO | NS_TRI | NS_INTEL);
 
-typedef NStencilBinIntel<1, 0, 0> NStencilHalfBin2dIntel;
+using NStencilHalfBin2dIntel = NStencilBinIntel<1, 0, 0>;
 NStencilStyle(half/bin/2d/intel,
               NStencilHalfBin2dIntel,
               NS_HALF | NS_BIN | NS_2D | NS_ORTHO | NS_INTEL);
 
-typedef NStencilBinIntel<1, 0, 1> NStencilHalfBin2dTriIntel;
+using NStencilHalfBin2dTriIntel = NStencilBinIntel<1, 0, 1>;
 NStencilStyle(half/bin/2d/tri/intel,
               NStencilHalfBin2dTriIntel,
               NS_HALF | NS_BIN | NS_2D | NS_TRI | NS_INTEL);
 
-typedef NStencilBinIntel<1, 1, 0> NStencilHalfBin3dIntel;
+using NStencilHalfBin3dIntel = NStencilBinIntel<1, 1, 0>;
 NStencilStyle(half/bin/3d/intel,
               NStencilHalfBin3dIntel,
               NS_HALF | NS_BIN | NS_3D | NS_ORTHO | NS_INTEL);
 
-typedef NStencilBinIntel<1, 1, 1> NStencilHalfBin3dTriIntel;
+using NStencilHalfBin3dTriIntel = NStencilBinIntel<1, 1, 1>;
 NStencilStyle(half/bin/3d/tri/intel,
               NStencilHalfBin3dTriIntel,
               NS_HALF | NS_BIN | NS_3D | NS_TRI | NS_INTEL);

--- a/src/INTEL/nstencil_ghost_bin_intel.h
+++ b/src/INTEL/nstencil_ghost_bin_intel.h
@@ -13,12 +13,12 @@
 
 #ifdef NSTENCIL_CLASS
 // clang-format off
-typedef NStencilGhostBinIntel<0> NStencilFullGhostBin2dIntel;
+using NStencilFullGhostBin2dIntel = NStencilGhostBinIntel<0>;
 NStencilStyle(full/ghost/bin/2d/intel,
               NStencilFullGhostBin2dIntel,
               NS_FULL | NS_GHOST | NS_BIN | NS_2D | NS_ORTHO | NS_TRI | NS_INTEL);
 
-typedef NStencilGhostBinIntel<1> NStencilFullGhostBin3dIntel;
+using NStencilFullGhostBin3dIntel = NStencilGhostBinIntel<1>;
 NStencilStyle(full/ghost/bin/3d/intel,
               NStencilFullGhostBin3dIntel,
               NS_FULL | NS_GHOST | NS_BIN | NS_3D | NS_ORTHO | NS_TRI | NS_INTEL);

--- a/src/KOKKOS/neigh_bond_kokkos.h
+++ b/src/KOKKOS/neigh_bond_kokkos.h
@@ -130,7 +130,7 @@ class NeighBondKokkos : protected Pointers  {
 
   // topology build functions
 
-  typedef void (NeighBondKokkos::*BondPtr)();   // ptrs to topology build functions
+  using BondPtr = void (NeighBondKokkos::*)();   // ptrs to topology build functions
 
   BondPtr bond_build_kk;                 // ptr to bond list functions
   void bond_all();                    // bond list with all bonds

--- a/src/KOKKOS/npair_halffull_kokkos.h
+++ b/src/KOKKOS/npair_halffull_kokkos.h
@@ -18,25 +18,25 @@
 
 // Newton, no triclinic
 
-typedef NPairHalffullKokkos<LMPDeviceType,1,0,0> NPairKokkosHalffullNewtonDevice;
+using NPairKokkosHalffullNewtonDevice = NPairHalffullKokkos<LMPDeviceType,1,0,0>;
 NPairStyle(halffull/newton/kk/device,
            NPairKokkosHalffullNewtonDevice,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,1,0,0> NPairKokkosHalffullNewtonHost;
+using NPairKokkosHalffullNewtonHost = NPairHalffullKokkos<LMPHostType,1,0,0>;
 NPairStyle(halffull/newton/kk/host,
            NPairKokkosHalffullNewtonHost,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_KOKKOS_HOST);
 
-typedef NPairHalffullKokkos<LMPDeviceType,1,0,0> NPairKokkosHalffullNewtonDevice;
+using NPairKokkosHalffullNewtonDevice = NPairHalffullKokkos<LMPDeviceType,1,0,0>;
 NPairStyle(halffull/newton/skip/kk/device,
            NPairKokkosHalffullNewtonDevice,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_SKIP | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,1,0,0> NPairKokkosHalffullNewtonHost;
+using NPairKokkosHalffullNewtonHost = NPairHalffullKokkos<LMPHostType,1,0,0>;
 NPairStyle(halffull/newton/skip/kk/host,
            NPairKokkosHalffullNewtonHost,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
@@ -44,25 +44,25 @@ NPairStyle(halffull/newton/skip/kk/host,
 
 // Newton, triclinic
 
-typedef NPairHalffullKokkos<LMPDeviceType,1,1,0> NPairKokkosHalffullNewtonTriDevice;
+using NPairKokkosHalffullNewtonTriDevice = NPairHalffullKokkos<LMPDeviceType,1,1,0>;
 NPairStyle(halffull/newton/tri/kk/device,
            NPairKokkosHalffullNewtonTriDevice,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,1,1,0> NPairKokkosHalffullNewtonTriHost;
+using NPairKokkosHalffullNewtonTriHost = NPairHalffullKokkos<LMPHostType,1,1,0>;
 NPairStyle(halffull/newton/tri/kk/host,
            NPairKokkosHalffullNewtonTriHost,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_KOKKOS_HOST);
 
-typedef NPairHalffullKokkos<LMPDeviceType,1,1,0> NPairKokkosHalffullNewtonTriDevice;
+using NPairKokkosHalffullNewtonTriDevice = NPairHalffullKokkos<LMPDeviceType,1,1,0>;
 NPairStyle(halffull/newton/tri/skip/kk/device,
            NPairKokkosHalffullNewtonTriDevice,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_SKIP | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,1,1,0> NPairKokkosHalffullNewtonTriHost;
+using NPairKokkosHalffullNewtonTriHost = NPairHalffullKokkos<LMPHostType,1,1,0>;
 NPairStyle(halffull/newton/tri/skip/kk/host,
            NPairKokkosHalffullNewtonTriHost,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
@@ -70,25 +70,25 @@ NPairStyle(halffull/newton/tri/skip/kk/host,
 
 // Newtoff (can be triclinic but template param always set to 0)
 
-typedef NPairHalffullKokkos<LMPDeviceType,0,0,0> NPairKokkosHalffullNewtoffDevice;
+using NPairKokkosHalffullNewtoffDevice = NPairHalffullKokkos<LMPDeviceType,0,0,0>;
 NPairStyle(halffull/newtoff/kk/device,
            NPairKokkosHalffullNewtoffDevice,
            NP_HALF_FULL | NP_NEWTOFF | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,0,0,0> NPairKokkosHalffullNewtoffHost;
+using NPairKokkosHalffullNewtoffHost = NPairHalffullKokkos<LMPHostType,0,0,0>;
 NPairStyle(halffull/newtoff/kk/host,
            NPairKokkosHalffullNewtoffHost,
            NP_HALF_FULL | NP_NEWTOFF | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_KOKKOS_HOST);
 
-typedef NPairHalffullKokkos<LMPDeviceType,0,0,0> NPairKokkosHalffullNewtoffDevice;
+using NPairKokkosHalffullNewtoffDevice = NPairHalffullKokkos<LMPDeviceType,0,0,0>;
 NPairStyle(halffull/newtoff/skip/kk/device,
            NPairKokkosHalffullNewtoffDevice,
            NP_HALF_FULL | NP_NEWTOFF | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_SKIP | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,0,0,0> NPairKokkosHalffullNewtoffHost;
+using NPairKokkosHalffullNewtoffHost = NPairHalffullKokkos<LMPHostType,0,0,0>;
 NPairStyle(halffull/newtoff/skip/kk/host,
            NPairKokkosHalffullNewtoffHost,
            NP_HALF_FULL | NP_NEWTOFF | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
@@ -98,25 +98,25 @@ NPairStyle(halffull/newtoff/skip/kk/host,
 
 // Newton, no triclinic
 
-typedef NPairHalffullKokkos<LMPDeviceType,1,0,0> NPairKokkosHalffullNewtonDevice;
+using NPairKokkosHalffullNewtonDevice = NPairHalffullKokkos<LMPDeviceType,1,0,0>;
 NPairStyle(halffull/newton/ghost/kk/device,
            NPairKokkosHalffullNewtonDevice,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_GHOST | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,1,0,0> NPairKokkosHalffullNewtonHost;
+using NPairKokkosHalffullNewtonHost = NPairHalffullKokkos<LMPHostType,1,0,0>;
 NPairStyle(halffull/newton/ghost/kk/host,
            NPairKokkosHalffullNewtonHost,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_GHOST | NP_KOKKOS_HOST);
 
-typedef NPairHalffullKokkos<LMPDeviceType,1,0,0> NPairKokkosHalffullNewtonDevice;
+using NPairKokkosHalffullNewtonDevice = NPairHalffullKokkos<LMPDeviceType,1,0,0>;
 NPairStyle(halffull/newton/skip/ghost/kk/device,
            NPairKokkosHalffullNewtonDevice,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_GHOST | NP_SKIP | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,1,0,0> NPairKokkosHalffullNewtonHost;
+using NPairKokkosHalffullNewtonHost = NPairHalffullKokkos<LMPHostType,1,0,0>;
 NPairStyle(halffull/newton/skip/ghost/kk/host,
            NPairKokkosHalffullNewtonHost,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
@@ -124,25 +124,25 @@ NPairStyle(halffull/newton/skip/ghost/kk/host,
 
 // Newton, triclinic
 
-typedef NPairHalffullKokkos<LMPDeviceType,1,1,0> NPairKokkosHalffullNewtonTriDevice;
+using NPairKokkosHalffullNewtonTriDevice = NPairHalffullKokkos<LMPDeviceType,1,1,0>;
 NPairStyle(halffull/newton/tri/ghost/kk/device,
            NPairKokkosHalffullNewtonTriDevice,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_GHOST | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,1,1,0> NPairKokkosHalffullNewtonTriHost;
+using NPairKokkosHalffullNewtonTriHost = NPairHalffullKokkos<LMPHostType,1,1,0>;
 NPairStyle(halffull/newton/tri/ghost/kk/host,
            NPairKokkosHalffullNewtonTriHost,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_GHOST | NP_KOKKOS_HOST);
 
-typedef NPairHalffullKokkos<LMPDeviceType,1,1,0> NPairKokkosHalffullNewtonTriDevice;
+using NPairKokkosHalffullNewtonTriDevice = NPairHalffullKokkos<LMPDeviceType,1,1,0>;
 NPairStyle(halffull/newton/tri/skip/ghost/kk/device,
            NPairKokkosHalffullNewtonTriDevice,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_GHOST | NP_SKIP | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,1,1,0> NPairKokkosHalffullNewtonTriHost;
+using NPairKokkosHalffullNewtonTriHost = NPairHalffullKokkos<LMPHostType,1,1,0>;
 NPairStyle(halffull/newton/tri/skip/ghost/kk/host,
            NPairKokkosHalffullNewtonTriHost,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
@@ -150,25 +150,25 @@ NPairStyle(halffull/newton/tri/skip/ghost/kk/host,
 
 // Newtoff (can be triclinic but template param always set to 0)
 
-typedef NPairHalffullKokkos<LMPDeviceType,0,0,0> NPairKokkosHalffullNewtoffDevice;
+using NPairKokkosHalffullNewtoffDevice = NPairHalffullKokkos<LMPDeviceType,0,0,0>;
 NPairStyle(halffull/newtoff/ghost/kk/device,
            NPairKokkosHalffullNewtoffDevice,
            NP_HALF_FULL | NP_NEWTOFF | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_GHOST | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,0,0,0> NPairKokkosHalffullNewtoffHost;
+using NPairKokkosHalffullNewtoffHost = NPairHalffullKokkos<LMPHostType,0,0,0>;
 NPairStyle(halffull/newtoff/ghost/kk/host,
            NPairKokkosHalffullNewtoffHost,
            NP_HALF_FULL | NP_NEWTOFF | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_GHOST | NP_KOKKOS_HOST);
 
-typedef NPairHalffullKokkos<LMPDeviceType,0,0,0> NPairKokkosHalffullNewtoffDevice;
+using NPairKokkosHalffullNewtoffDevice = NPairHalffullKokkos<LMPDeviceType,0,0,0>;
 NPairStyle(halffull/newtoff/skip/ghost/kk/device,
            NPairKokkosHalffullNewtoffDevice,
            NP_HALF_FULL | NP_NEWTOFF | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_GHOST | NP_SKIP | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,0,0,0> NPairKokkosHalffullNewtoffHost;
+using NPairKokkosHalffullNewtoffHost = NPairHalffullKokkos<LMPHostType,0,0,0>;
 NPairStyle(halffull/newtoff/skip/ghost/kk/host,
            NPairKokkosHalffullNewtoffHost,
            NP_HALF_FULL | NP_NEWTOFF | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
@@ -178,25 +178,25 @@ NPairStyle(halffull/newtoff/skip/ghost/kk/host,
 
 // Newton, no triclinic
 
-typedef NPairHalffullKokkos<LMPDeviceType,1,0,1> NPairKokkosHalffullNewtonTrimDevice;
+using NPairKokkosHalffullNewtonTrimDevice = NPairHalffullKokkos<LMPDeviceType,1,0,1>;
 NPairStyle(halffull/newton/trim/kk/device,
            NPairKokkosHalffullNewtonTrimDevice,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRIM | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,1,0,1> NPairKokkosHalffullNewtonTrimHost;
+using NPairKokkosHalffullNewtonTrimHost = NPairHalffullKokkos<LMPHostType,1,0,1>;
 NPairStyle(halffull/newton/trim/kk/host,
            NPairKokkosHalffullNewtonTrimHost,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRIM | NP_KOKKOS_HOST);
 
-typedef NPairHalffullKokkos<LMPDeviceType,1,0,1> NPairKokkosHalffullNewtonTrimDevice;
+using NPairKokkosHalffullNewtonTrimDevice = NPairHalffullKokkos<LMPDeviceType,1,0,1>;
 NPairStyle(halffull/newton/trim/skip/kk/device,
            NPairKokkosHalffullNewtonTrimDevice,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_SKIP | NP_TRIM | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,1,0,1> NPairKokkosHalffullNewtonTrimHost;
+using NPairKokkosHalffullNewtonTrimHost = NPairHalffullKokkos<LMPHostType,1,0,1>;
 NPairStyle(halffull/newton/trim/skip/kk/host,
            NPairKokkosHalffullNewtonTrimHost,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
@@ -204,25 +204,25 @@ NPairStyle(halffull/newton/trim/skip/kk/host,
 
 // Newton, triclinic
 
-typedef NPairHalffullKokkos<LMPDeviceType,1,1,1> NPairKokkosHalffullNewtonTriTrimDevice;
+using NPairKokkosHalffullNewtonTriTrimDevice = NPairHalffullKokkos<LMPDeviceType,1,1,1>;
 NPairStyle(halffull/newton/tri/trim/kk/device,
            NPairKokkosHalffullNewtonTriTrimDevice,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_TRIM | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,1,1,1> NPairKokkosHalffullNewtonTriTrimHost;
+using NPairKokkosHalffullNewtonTriTrimHost = NPairHalffullKokkos<LMPHostType,1,1,1>;
 NPairStyle(halffull/newton/tri/trim/kk/host,
            NPairKokkosHalffullNewtonTriTrimHost,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_TRIM | NP_KOKKOS_HOST);
 
-typedef NPairHalffullKokkos<LMPDeviceType,1,1,1> NPairKokkosHalffullNewtonTriTrimDevice;
+using NPairKokkosHalffullNewtonTriTrimDevice = NPairHalffullKokkos<LMPDeviceType,1,1,1>;
 NPairStyle(halffull/newton/tri/trim/skip/kk/device,
            NPairKokkosHalffullNewtonTrimDevice,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_SKIP | NP_TRIM | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,1,1,1> NPairKokkosHalffullNewtonTriTrimHost;
+using NPairKokkosHalffullNewtonTriTrimHost = NPairHalffullKokkos<LMPHostType,1,1,1>;
 NPairStyle(halffull/newton/tri/trim/skip/kk/host,
            NPairKokkosHalffullNewtonTriTrimHost,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
@@ -230,25 +230,25 @@ NPairStyle(halffull/newton/tri/trim/skip/kk/host,
 
 // Newtoff (can be triclinic but template param always set to 0)
 
-typedef NPairHalffullKokkos<LMPDeviceType,0,0,1> NPairKokkosHalffullNewtoffTrimDevice;
+using NPairKokkosHalffullNewtoffTrimDevice = NPairHalffullKokkos<LMPDeviceType,0,0,1>;
 NPairStyle(halffull/newtoff/trim/kk/device,
            NPairKokkosHalffullNewtoffTrimDevice,
            NP_HALF_FULL | NP_NEWTOFF | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_TRIM | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,0,0,1> NPairKokkosHalffullNewtoffTrimHost;
+using NPairKokkosHalffullNewtoffTrimHost = NPairHalffullKokkos<LMPHostType,0,0,1>;
 NPairStyle(halffull/newtoff/trim/kk/host,
            NPairKokkosHalffullNewtoffTrimHost,
            NP_HALF_FULL | NP_NEWTOFF | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_TRIM | NP_KOKKOS_HOST);
 
-typedef NPairHalffullKokkos<LMPDeviceType,0,0,1> NPairKokkosHalffullNewtoffTrimDevice;
+using NPairKokkosHalffullNewtoffTrimDevice = NPairHalffullKokkos<LMPDeviceType,0,0,1>;
 NPairStyle(halffull/newtoff/trim/skip/kk/device,
            NPairKokkosHalffullNewtoffTrimDevice,
            NP_HALF_FULL | NP_NEWTOFF | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_SKIP | NP_TRIM | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,0,0,1> NPairKokkosHalffullNewtoffTrimHost;
+using NPairKokkosHalffullNewtoffTrimHost = NPairHalffullKokkos<LMPHostType,0,0,1>;
 NPairStyle(halffull/newtoff/trim/skip/kk/host,
            NPairKokkosHalffullNewtoffTrimHost,
            NP_HALF_FULL | NP_NEWTOFF | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
@@ -258,25 +258,25 @@ NPairStyle(halffull/newtoff/trim/skip/kk/host,
 
 // Newton, no triclinic
 
-typedef NPairHalffullKokkos<LMPDeviceType,1,0,1> NPairKokkosHalffullNewtonTrimDevice;
+using NPairKokkosHalffullNewtonTrimDevice = NPairHalffullKokkos<LMPDeviceType,1,0,1>;
 NPairStyle(halffull/newton/tri/trim/ghost/kk/device,
            NPairKokkosHalffullNewtonTrimDevice,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_GHOST | NP_TRIM | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,1,0,1> NPairKokkosHalffullNewtonTrimHost;
+using NPairKokkosHalffullNewtonTrimHost = NPairHalffullKokkos<LMPHostType,1,0,1>;
 NPairStyle(halffull/newton/trim/ghost/kk/host,
            NPairKokkosHalffullNewtonTrimHost,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_GHOST | NP_TRIM | NP_KOKKOS_HOST);
 
-typedef NPairHalffullKokkos<LMPDeviceType,1,0,1> NPairKokkosHalffullNewtonTrimDevice;
+using NPairKokkosHalffullNewtonTrimDevice = NPairHalffullKokkos<LMPDeviceType,1,0,1>;
 NPairStyle(halffull/newton/trim/skip/ghost/kk/device,
            NPairKokkosHalffullNewtonTrimDevice,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_GHOST | NP_SKIP | NP_TRIM | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,1,0,1> NPairKokkosHalffullNewtonTrimHost;
+using NPairKokkosHalffullNewtonTrimHost = NPairHalffullKokkos<LMPHostType,1,0,1>;
 NPairStyle(halffull/newton/trim/skip/ghost/kk/host,
            NPairKokkosHalffullNewtonTrimHost,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
@@ -284,25 +284,25 @@ NPairStyle(halffull/newton/trim/skip/ghost/kk/host,
 
 // Newton, triclinic
 
-typedef NPairHalffullKokkos<LMPDeviceType,1,1,1> NPairKokkosHalffullNewtonTriTrimDevice;
+using NPairKokkosHalffullNewtonTriTrimDevice = NPairHalffullKokkos<LMPDeviceType,1,1,1>;
 NPairStyle(halffull/newton/tri/trim/ghost/kk/device,
            NPairKokkosHalffullNewtonTriTrimDevice,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_GHOST | NP_TRIM | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,1,1,1> NPairKokkosHalffullNewtonTriTrimHost;
+using NPairKokkosHalffullNewtonTriTrimHost = NPairHalffullKokkos<LMPHostType,1,1,1>;
 NPairStyle(halffull/newton/tri/trim/ghost/kk/host,
            NPairKokkosHalffullNewtonTriTrimHost,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_GHOST | NP_TRIM | NP_KOKKOS_HOST);
 
-typedef NPairHalffullKokkos<LMPDeviceType,1,1,1> NPairKokkosHalffullNewtonTriTrimDevice;
+using NPairKokkosHalffullNewtonTriTrimDevice = NPairHalffullKokkos<LMPDeviceType,1,1,1>;
 NPairStyle(halffull/newton/tri/trim/skip/ghost/kk/device,
            NPairKokkosHalffullNewtonTriTrimDevice,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_GHOST | NP_SKIP | NP_TRIM | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,1,1,1> NPairKokkosHalffullNewtonTriTrimHost;
+using NPairKokkosHalffullNewtonTriTrimHost = NPairHalffullKokkos<LMPHostType,1,1,1>;
 NPairStyle(halffull/newton/tri/trim/skip/ghost/kk/host,
            NPairKokkosHalffullNewtonTriTrimHost,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
@@ -310,25 +310,25 @@ NPairStyle(halffull/newton/tri/trim/skip/ghost/kk/host,
 
 // Newtoff (can be triclinic but template param always set to 0)
 
-typedef NPairHalffullKokkos<LMPDeviceType,0,0,1> NPairKokkosHalffullNewtoffTrimDevice;
+using NPairKokkosHalffullNewtoffTrimDevice = NPairHalffullKokkos<LMPDeviceType,0,0,1>;
 NPairStyle(halffull/newtoff/trim/ghost/kk/device,
            NPairKokkosHalffullNewtoffTrimDevice,
            NP_HALF_FULL | NP_NEWTOFF | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_GHOST | NP_TRIM | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,0,0,1> NPairKokkosHalffullNewtoffTrimHost;
+using NPairKokkosHalffullNewtoffTrimHost = NPairHalffullKokkos<LMPHostType,0,0,1>;
 NPairStyle(halffull/newtoff/trim/ghost/kk/host,
            NPairKokkosHalffullNewtoffTrimHost,
            NP_HALF_FULL | NP_NEWTOFF | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_GHOST | NP_TRIM | NP_KOKKOS_HOST);
 
-typedef NPairHalffullKokkos<LMPDeviceType,0,0,1> NPairKokkosHalffullNewtoffTrimDevice;
+using NPairKokkosHalffullNewtoffTrimDevice = NPairHalffullKokkos<LMPDeviceType,0,0,1>;
 NPairStyle(halffull/newtoff/trim/skip/ghost/kk/device,
            NPairKokkosHalffullNewtoffTrimDevice,
            NP_HALF_FULL | NP_NEWTOFF | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |
            NP_ORTHO | NP_TRI | NP_GHOST | NP_SKIP | NP_TRIM | NP_KOKKOS_DEVICE);
 
-typedef NPairHalffullKokkos<LMPHostType,0,0,1> NPairKokkosHalffullNewtoffTrimHost;
+using NPairKokkosHalffullNewtoffTrimHost = NPairHalffullKokkos<LMPHostType,0,0,1>;
 NPairStyle(halffull/newtoff/trim/skip/ghost/kk/host,
            NPairKokkosHalffullNewtoffTrimHost,
            NP_HALF_FULL | NP_NEWTOFF | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI |

--- a/src/KOKKOS/npair_kokkos.h
+++ b/src/KOKKOS/npair_kokkos.h
@@ -13,112 +13,112 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairKokkos<LMPHostType,0,0,0,0,0> NPairKokkosFullBinHost;
+using NPairKokkosFullBinHost = NPairKokkos<LMPHostType,0,0,0,0,0>;
 NPairStyle(full/bin/kk/host,
            NPairKokkosFullBinHost,
            NP_BIN | NP_KOKKOS_HOST | NP_FULL | NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairKokkos<LMPDeviceType,0,0,0,0,0> NPairKokkosFullBinDevice;
+using NPairKokkosFullBinDevice = NPairKokkos<LMPDeviceType,0,0,0,0,0>;
 NPairStyle(full/bin/kk/device,
            NPairKokkosFullBinDevice,
            NP_BIN | NP_KOKKOS_DEVICE | NP_FULL | NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairKokkos<LMPHostType,0,0,1,0,0> NPairKokkosFullBinGhostHost;
+using NPairKokkosFullBinGhostHost = NPairKokkos<LMPHostType,0,0,1,0,0>;
 NPairStyle(full/bin/ghost/kk/host,
            NPairKokkosFullBinGhostHost,
            NP_BIN | NP_KOKKOS_HOST | NP_FULL | NP_NEWTON | NP_NEWTOFF | NP_GHOST | NP_ORTHO | NP_TRI);
 
-typedef NPairKokkos<LMPDeviceType,0,0,1,0,0> NPairKokkosFullBinGhostDevice;
+using NPairKokkosFullBinGhostDevice = NPairKokkos<LMPDeviceType,0,0,1,0,0>;
 NPairStyle(full/bin/ghost/kk/device,
            NPairKokkosFullBinGhostDevice,
            NP_BIN | NP_KOKKOS_DEVICE | NP_FULL | NP_NEWTON | NP_NEWTOFF | NP_GHOST | NP_ORTHO | NP_TRI);
 
-typedef NPairKokkos<LMPHostType,1,1,0,0,0> NPairKokkosHalfBinNewtonHost;
+using NPairKokkosHalfBinNewtonHost = NPairKokkos<LMPHostType,1,1,0,0,0>;
 NPairStyle(half/bin/newton/kk/host,
            NPairKokkosHalfBinNewtonHost,
            NP_BIN | NP_KOKKOS_HOST | NP_HALF | NP_NEWTON | NP_ORTHO);
 
-typedef NPairKokkos<LMPHostType,1,0,0,0,0> NPairKokkosHalfBinNewtoffHost;
+using NPairKokkosHalfBinNewtoffHost = NPairKokkos<LMPHostType,1,0,0,0,0>;
 NPairStyle(half/bin/newtoff/kk/host,
            NPairKokkosHalfBinNewtoffHost,
            NP_BIN | NP_KOKKOS_HOST | NP_HALF | NP_NEWTOFF | NP_ORTHO);
 
-typedef NPairKokkos<LMPDeviceType,1,1,0,0,0> NPairKokkosHalfBinNewtonDevice;
+using NPairKokkosHalfBinNewtonDevice = NPairKokkos<LMPDeviceType,1,1,0,0,0>;
 NPairStyle(half/bin/newton/kk/device,
            NPairKokkosHalfBinNewtonDevice,
            NP_KOKKOS_DEVICE | NP_HALF | NP_BIN | NP_NEWTON | NP_ORTHO);
 
-typedef NPairKokkos<LMPDeviceType,1,0,0,0,0> NPairKokkosHalfBinNewtoffDevice;
+using NPairKokkosHalfBinNewtoffDevice = NPairKokkos<LMPDeviceType,1,0,0,0,0>;
 NPairStyle(half/bin/newtoff/kk/device,
            NPairKokkosHalfBinNewtoffDevice,
            NP_KOKKOS_DEVICE | NP_HALF | NP_BIN | NP_NEWTOFF | NP_ORTHO);
 
-typedef NPairKokkos<LMPHostType,1,1,0,1,0> NPairKokkosHalfBinNewtonTriHost;
+using NPairKokkosHalfBinNewtonTriHost = NPairKokkos<LMPHostType,1,1,0,1,0>;
 NPairStyle(half/bin/newton/kk/host,
            NPairKokkosHalfBinNewtonTriHost,
            NP_BIN | NP_KOKKOS_HOST | NP_HALF | NP_NEWTON | NP_TRI);
 
-typedef NPairKokkos<LMPHostType,1,0,0,1,0> NPairKokkosHalfBinNewtoffTriHost;
+using NPairKokkosHalfBinNewtoffTriHost = NPairKokkos<LMPHostType,1,0,0,1,0>;
 NPairStyle(half/bin/newtoff/kk/host,
            NPairKokkosHalfBinNewtoffTriHost,
            NP_BIN | NP_KOKKOS_HOST | NP_HALF | NP_NEWTOFF | NP_TRI);
 
-typedef NPairKokkos<LMPDeviceType,1,1,0,1,0> NPairKokkosHalfBinNewtonTriDevice;
+using NPairKokkosHalfBinNewtonTriDevice = NPairKokkos<LMPDeviceType,1,1,0,1,0>;
 NPairStyle(half/bin/newton/kk/device,
            NPairKokkosHalfBinNewtonTriDevice,
            NP_KOKKOS_DEVICE | NP_HALF | NP_BIN | NP_NEWTON | NP_TRI);
 
-typedef NPairKokkos<LMPDeviceType,1,0,0,1,0> NPairKokkosHalfBinNewtoffTriDevice;
+using NPairKokkosHalfBinNewtoffTriDevice = NPairKokkos<LMPDeviceType,1,0,0,1,0>;
 NPairStyle(half/bin/newtoff/kk/device,
            NPairKokkosHalfBinNewtoffTriDevice,
            NP_KOKKOS_DEVICE | NP_HALF | NP_BIN | NP_NEWTOFF | NP_TRI);
 
-typedef NPairKokkos<LMPHostType,1,0,1,0,0> NPairKokkosHalfBinNewtoffGhostHost;
+using NPairKokkosHalfBinNewtoffGhostHost = NPairKokkos<LMPHostType,1,0,1,0,0>;
 NPairStyle(half/bin/newtoff/ghost/kk/host,
            NPairKokkosHalfBinNewtoffGhostHost,
            NP_BIN | NP_KOKKOS_HOST | NP_HALF | NP_NEWTOFF | NP_GHOST | NP_ORTHO | NP_TRI);
 
-typedef NPairKokkos<LMPDeviceType,1,0,1,0,0> NPairKokkosHalfBinNewtoffGhostDevice;
+using NPairKokkosHalfBinNewtoffGhostDevice = NPairKokkos<LMPDeviceType,1,0,1,0,0>;
 NPairStyle(half/bin/newtoff/ghost/kk/device,
            NPairKokkosHalfBinNewtoffGhostDevice,
            NP_KOKKOS_DEVICE | NP_HALF | NP_BIN | NP_NEWTOFF | NP_GHOST | NP_ORTHO | NP_TRI);
 
-typedef NPairKokkos<LMPHostType,1,1,0,0,1> NPairKokkosHalfBinNewtonSizeHost;
+using NPairKokkosHalfBinNewtonSizeHost = NPairKokkos<LMPHostType,1,1,0,0,1>;
 NPairStyle(half/bin/newton/size/kk/host,
            NPairKokkosHalfBinNewtonSizeHost,
            NP_BIN | NP_KOKKOS_HOST | NP_HALF | NP_NEWTON | NP_SIZE | NP_ORTHO);
 
-typedef NPairKokkos<LMPHostType,1,0,0,0,1> NPairKokkosHalfBinNewtoffSizeHost;
+using NPairKokkosHalfBinNewtoffSizeHost = NPairKokkos<LMPHostType,1,0,0,0,1>;
 NPairStyle(half/bin/newtoff/size/kk/host,
            NPairKokkosHalfBinNewtoffSizeHost,
            NP_BIN | NP_KOKKOS_HOST | NP_HALF | NP_NEWTOFF | NP_SIZE | NP_ORTHO);
 
-typedef NPairKokkos<LMPDeviceType,1,1,0,0,1> NPairKokkosHalfBinNewtonSizeDevice;
+using NPairKokkosHalfBinNewtonSizeDevice = NPairKokkos<LMPDeviceType,1,1,0,0,1>;
 NPairStyle(half/bin/newton/size/kk/device,
            NPairKokkosHalfBinNewtonSizeDevice,
            NP_KOKKOS_DEVICE | NP_HALF | NP_BIN | NP_NEWTON | NP_SIZE | NP_ORTHO);
 
-typedef NPairKokkos<LMPDeviceType,1,0,0,0,1> NPairKokkosHalfBinNewtoffSizeDevice;
+using NPairKokkosHalfBinNewtoffSizeDevice = NPairKokkos<LMPDeviceType,1,0,0,0,1>;
 NPairStyle(half/bin/newtoff/size/kk/device,
            NPairKokkosHalfBinNewtoffSizeDevice,
            NP_KOKKOS_DEVICE | NP_HALF | NP_BIN | NP_NEWTOFF | NP_SIZE | NP_ORTHO);
 
-typedef NPairKokkos<LMPHostType,1,1,0,1,1> NPairKokkosHalfBinNewtonSizeTriHost;
+using NPairKokkosHalfBinNewtonSizeTriHost = NPairKokkos<LMPHostType,1,1,0,1,1>;
 NPairStyle(half/bin/newton/size/kk/host,
            NPairKokkosHalfBinNewtonSizeTriHost,
            NP_BIN | NP_KOKKOS_HOST | NP_HALF | NP_NEWTON | NP_SIZE | NP_TRI);
 
-typedef NPairKokkos<LMPHostType,1,0,0,1,1> NPairKokkosHalfBinNewtoffSizeTriHost;
+using NPairKokkosHalfBinNewtoffSizeTriHost = NPairKokkos<LMPHostType,1,0,0,1,1>;
 NPairStyle(half/bin/newtoff/size/kk/host,
            NPairKokkosHalfBinNewtoffSizeTriHost,
            NP_BIN | NP_KOKKOS_HOST | NP_HALF | NP_NEWTOFF | NP_SIZE | NP_TRI);
 
-typedef NPairKokkos<LMPDeviceType,1,1,0,1,1> NPairKokkosHalfBinNewtonSizeTriDevice;
+using NPairKokkosHalfBinNewtonSizeTriDevice = NPairKokkos<LMPDeviceType,1,1,0,1,1>;
 NPairStyle(half/bin/newton/size/kk/device,
            NPairKokkosHalfBinNewtonSizeTriDevice,
            NP_KOKKOS_DEVICE | NP_HALF | NP_BIN | NP_NEWTON | NP_SIZE | NP_TRI);
 
-typedef NPairKokkos<LMPDeviceType,1,0,0,1,1> NPairKokkosHalfBinNewtoffSizeTriDevice;
+using NPairKokkosHalfBinNewtoffSizeTriDevice = NPairKokkos<LMPDeviceType,1,0,0,1,1>;
 NPairStyle(half/bin/newtoff/size/kk/device,
            NPairKokkosHalfBinNewtoffSizeTriDevice,
            NP_KOKKOS_DEVICE | NP_HALF | NP_BIN | NP_NEWTOFF | NP_SIZE | NP_TRI);

--- a/src/KOKKOS/npair_skip_kokkos.h
+++ b/src/KOKKOS/npair_skip_kokkos.h
@@ -13,56 +13,56 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairSkipKokkos<LMPDeviceType,0> NPairKokkosSkipDevice;
+using NPairKokkosSkipDevice = NPairSkipKokkos<LMPDeviceType,0>;
 NPairStyle(skip/kk/device,
            NPairKokkosSkipDevice,
            NP_SKIP | NP_HALF | NP_FULL |
            NP_NSQ | NP_BIN | NP_MULTI |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI | NP_KOKKOS_DEVICE);
 
-typedef NPairSkipKokkos<LMPDeviceType,0> NPairKokkosSkipGhostDevice;
+using NPairKokkosSkipGhostDevice = NPairSkipKokkos<LMPDeviceType,0>;
 NPairStyle(skip/ghost/kk/device,
            NPairKokkosSkipGhostDevice,
            NP_SKIP | NP_HALF | NP_FULL |
            NP_NSQ | NP_BIN | NP_MULTI |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI | NP_GHOST | NP_KOKKOS_DEVICE);
 
-typedef NPairSkipKokkos<LMPHostType,0> NPairKokkosSkipHost;
+using NPairKokkosSkipHost = NPairSkipKokkos<LMPHostType,0>;
 NPairStyle(skip/kk/host,
            NPairKokkosSkipHost,
            NP_SKIP | NP_HALF | NP_FULL |
            NP_NSQ | NP_BIN | NP_MULTI |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI | NP_KOKKOS_HOST);
 
-typedef NPairSkipKokkos<LMPHostType,0> NPairKokkosSkipGhostHost;
+using NPairKokkosSkipGhostHost = NPairSkipKokkos<LMPHostType,0>;
 NPairStyle(skip/ghost/kk/host,
            NPairKokkosSkipGhostHost,
            NP_SKIP | NP_HALF | NP_FULL |
            NP_NSQ | NP_BIN | NP_MULTI |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI | NP_GHOST | NP_KOKKOS_HOST);
 
-typedef NPairSkipKokkos<LMPDeviceType,1> NPairKokkosSkipTrimDevice;
+using NPairKokkosSkipTrimDevice = NPairSkipKokkos<LMPDeviceType,1>;
 NPairStyle(skip/trim/kk/device,
            NPairKokkosSkipTrimDevice,
            NP_SKIP | NP_HALF | NP_FULL |
            NP_NSQ | NP_BIN | NP_MULTI |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI | NP_TRIM |NP_KOKKOS_DEVICE);
 
-typedef NPairSkipKokkos<LMPDeviceType,1> NPairKokkosSkipTrimGhostDevice;
+using NPairKokkosSkipTrimGhostDevice = NPairSkipKokkos<LMPDeviceType,1>;
 NPairStyle(skip/trim/ghost/kk/device,
            NPairKokkosSkipTrimGhostDevice,
            NP_SKIP | NP_HALF | NP_FULL |
            NP_NSQ | NP_BIN | NP_MULTI |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI | NP_TRIM | NP_GHOST | NP_KOKKOS_DEVICE);
 
-typedef NPairSkipKokkos<LMPHostType,1> NPairKokkosSkipTrimHost;
+using NPairKokkosSkipTrimHost = NPairSkipKokkos<LMPHostType,1>;
 NPairStyle(skip/trim/kk/host,
            NPairKokkosSkipTrimHost,
            NP_SKIP | NP_HALF | NP_FULL |
            NP_NSQ | NP_BIN | NP_MULTI |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI | NP_TRIM | NP_KOKKOS_HOST);
 
-typedef NPairSkipKokkos<LMPHostType,1> NPairKokkosSkipTrimGhostHost;
+using NPairKokkosSkipTrimGhostHost = NPairSkipKokkos<LMPHostType,1>;
 NPairStyle(skip/trim/ghost/kk/host,
            NPairKokkosSkipTrimGhostHost,
            NP_SKIP | NP_HALF | NP_FULL |

--- a/src/KOKKOS/npair_ssa_kokkos.h
+++ b/src/KOKKOS/npair_ssa_kokkos.h
@@ -13,12 +13,12 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairSSAKokkos<LMPHostType> NPairSSAKokkosHost;
+using NPairSSAKokkosHost = NPairSSAKokkos<LMPHostType>;
 NPairStyle(half/bin/newton/ssa/kk/host,
            NPairSSAKokkosHost,
            NP_HALF | NP_BIN | NP_NEWTON | NP_ORTHO | NP_SSA | NP_GHOST | NP_KOKKOS_HOST);
 
-typedef NPairSSAKokkos<LMPDeviceType> NPairSSAKokkosDevice;
+using NPairSSAKokkosDevice = NPairSSAKokkos<LMPDeviceType>;
 NPairStyle(half/bin/newton/ssa/kk/device,
            NPairSSAKokkosDevice,
            NP_HALF | NP_BIN | NP_NEWTON | NP_ORTHO | NP_SSA | NP_GHOST | NP_KOKKOS_DEVICE);

--- a/src/KSPACE/fft3d.h
+++ b/src/KSPACE/fft3d.h
@@ -43,6 +43,7 @@ typedef fftwf_complex FFT_DATA;
 #define FFT_KISS
 #endif
 #define kiss_fft_scalar float
+// NOLINTBEGIN
 typedef struct {
   kiss_fft_scalar re;
   kiss_fft_scalar im;
@@ -50,6 +51,7 @@ typedef struct {
 
 struct kiss_fft_state;
 typedef struct kiss_fft_state *kiss_fft_cfg;
+// NOLINTEND
 #endif
 
 // -------------------------------------------------------------------------
@@ -80,6 +82,7 @@ typedef fftw_complex FFT_DATA;
 #define FFT_KISS
 #endif
 #define kiss_fft_scalar double
+// NOLINTBEGIN
 typedef struct {
   kiss_fft_scalar re;
   kiss_fft_scalar im;
@@ -87,6 +90,7 @@ typedef struct {
 
 struct kiss_fft_state;
 typedef struct kiss_fft_state *kiss_fft_cfg;
+// NOLINTEND
 #endif
 
 #else

--- a/src/KSPACE/fft3d.h
+++ b/src/KSPACE/fft3d.h
@@ -23,17 +23,17 @@
 
 #if defined(FFT_MKL)
 #include "mkl_dfti.h"
-typedef MKL_Complex8 FFT_DATA;
+using FFT_DATA = MKL_Complex8;
 #define FFT_MKL_PREC DFTI_SINGLE
 
 #elif defined(FFT_FFTW3)
 #include "fftw3.h"
-typedef fftwf_complex FFT_DATA;
+using FFT_DATA = fftwf_complex;
 #define FFTW_API(function) fftwf_##function
 
 #elif defined(FFT_NVPL)
 #include "nvpl_fftw.h"
-typedef fftwf_complex FFT_DATA;
+using FFT_DATA = fftwf_complex;
 #define FFTW_API(function) fftwf_##function
 #else
 
@@ -42,7 +42,7 @@ typedef fftwf_complex FFT_DATA;
 #ifndef FFT_KISS
 #define FFT_KISS
 #endif
-#define kiss_fft_scalar float
+using kiss_fft_scalar = float;
 // NOLINTBEGIN
 typedef struct {
   kiss_fft_scalar re;
@@ -62,17 +62,17 @@ typedef struct kiss_fft_state *kiss_fft_cfg;
 
 #if defined(FFT_MKL)
 #include "mkl_dfti.h"
-typedef MKL_Complex16 FFT_DATA;
+using FFT_DATA = MKL_Complex16;
 #define FFT_MKL_PREC DFTI_DOUBLE
 
 #elif defined(FFT_FFTW3)
 #include "fftw3.h"
-typedef fftw_complex FFT_DATA;
+using FFT_DATA = fftw_complex;
 #define FFTW_API(function) fftw_##function
 
 #elif defined(FFT_NVPL)
 #include "nvpl_fftw.h"
-typedef fftw_complex FFT_DATA;
+using FFT_DATA = fftw_complex;
 #define FFTW_API(function) fftw_##function
 
 #else
@@ -81,7 +81,7 @@ typedef fftw_complex FFT_DATA;
 #ifndef FFT_KISS
 #define FFT_KISS
 #endif
-#define kiss_fft_scalar double
+using kiss_fft_scalar = double;
 // NOLINTBEGIN
 typedef struct {
   kiss_fft_scalar re;

--- a/src/MANYBODY/pair_eam_cd.h
+++ b/src/MANYBODY/pair_eam_cd.h
@@ -108,10 +108,12 @@ class PairEAMCD : public PairEAMAlloy {
 
   // This structure specifies an entry in one of the EAM spline tables
   // and the corresponding floating point part.
+  // NOLINTBEGIN
   typedef struct {
     int m;
     double p;
   } EAMTableIndex;
+  // NOLINTEND
 
   // Converts a radius value to an index value to be used in a spline table lookup.
   inline EAMTableIndex radiusToTableIndex(double r) const

--- a/src/MEAM/meam.h
+++ b/src/MEAM/meam.h
@@ -22,7 +22,6 @@ constexpr int MAXELT = 8;
 namespace LAMMPS_NS {
 class Memory;
 
-typedef enum { FCC, BCC, HCP, DIM, DIA, DIA3, B1, C11, L12, B2, CH4, LIN, ZIG, TRI, SC } lattice_t;
 
 class MEAM {
  public:
@@ -31,6 +30,7 @@ class MEAM {
 
   int copymode;
   int msmeamflag;
+  using lattice_t = enum { FCC, BCC, HCP, DIM, DIA, DIA3, B1, C11, L12, B2, CH4, LIN, ZIG, TRI, SC };
 
  protected:
   Memory *memory;

--- a/src/MEAM/meam_funcs.cpp
+++ b/src/MEAM/meam_funcs.cpp
@@ -193,7 +193,7 @@ double MEAM::erose(const double r, const double re, const double alpha, const do
 //-----------------------------------------------------------------------------
 // Shape factors for various configurations
 //
-void MEAM::get_shpfcn(const lattice_t latt, const double sthe, const double cthe, double (&s)[3])
+void MEAM::get_shpfcn(const MEAM::lattice_t latt, const double sthe, const double cthe, double (&s)[3])
 {
   switch (latt) {
     case FCC:
@@ -244,7 +244,7 @@ void MEAM::get_shpfcn(const lattice_t latt, const double sthe, const double cthe
 //-----------------------------------------------------------------------------
 // Number of first neighbors for reference structure
 //
-int MEAM::get_Zij(const lattice_t latt)
+int MEAM::get_Zij(const MEAM::lattice_t latt)
 {
   switch (latt) {
     case FCC:
@@ -284,7 +284,7 @@ int MEAM::get_Zij(const lattice_t latt)
 //   numscr = number of atoms that screen the 2NN bond
 //   S = second neighbor screening function (xfac, a part of b2nn in dynamo)
 //
-int MEAM::get_Zij2(const lattice_t latt, const double cmin, const double cmax, const double stheta,
+int MEAM::get_Zij2(const MEAM::lattice_t latt, const double cmin, const double cmax, const double stheta,
                    double &a, double &S)
 {
 
@@ -389,7 +389,7 @@ int MEAM::get_Zij2(const lattice_t latt, const double cmin, const double cmax, c
   return Zij2;
 }
 
-int MEAM::get_Zij2_b2nn(const lattice_t latt, const double cmin, const double cmax, double &S)
+int MEAM::get_Zij2_b2nn(const MEAM::lattice_t latt, const double cmin, const double cmax, double &S)
 {
 
   double x, sijk, C;

--- a/src/MEAM/meam_setup_done.cpp
+++ b/src/MEAM/meam_setup_done.cpp
@@ -329,7 +329,7 @@ double MEAM::phi_meam(double r, int a, int b)
   double arat, scrn, scrn2;
   int Z12, errorflag;
   int Z1nn, Z2nn;
-  lattice_t latta /*unused:,lattb*/;
+  MEAM::lattice_t latta /*unused:,lattb*/;
   double rho_bkgd1, rho_bkgd2;
   double b11s, b22s;
   // msmeam
@@ -623,7 +623,7 @@ void MEAM::compute_reference_density()
 // Average weighting factors for the reference structure
 void MEAM::get_tavref(double* t11av, double* t21av, double* t31av, double* t12av, double* t22av, double* t32av,
                       double t11, double t21, double t31, double t12, double t22, double t32, double r, int a,
-                      int b, lattice_t latt)
+                      int b, MEAM::lattice_t latt)
 {
   double rhoa01, rhoa02, a1, a2, rho01 /*,rho02*/;
 
@@ -693,7 +693,7 @@ void MEAM::get_densref(double r, int a, int b, double* rho01, double* rho11, dou
 {
   double a1, a2;
   double s[3];
-  lattice_t lat;
+  MEAM::lattice_t lat;
   int Zij,Zij2nn;
   double rhoa01nn, rhoa02nn;
   double rhoa01, rhoa11, rhoa21, rhoa31;

--- a/src/MEAM/meam_setup_global.cpp
+++ b/src/MEAM/meam_setup_global.cpp
@@ -31,7 +31,7 @@ static inline void setall3d(TYPE (&arr)[maxi][maxj][maxk], const TYPE v)
       for (int k = 0; k < maxk; k++) arr[i][j][k] = v;
 }
 
-void MEAM::meam_setup_global(int nelt, lattice_t *lat, int *ielement, double * /*atwt*/,
+void MEAM::meam_setup_global(int nelt, MEAM::lattice_t *lat, int *ielement, double * /*atwt*/,
                              double *alpha, double *b0, double *b1, double *b2, double *b3,
                              double *alat, double *esub, double *asub, double *t0, double *t1,
                              double *t2, double *t3, double *rozero, int *ibar, double *b1m,

--- a/src/MEAM/meam_setup_param.cpp
+++ b/src/MEAM/meam_setup_param.cpp
@@ -78,7 +78,7 @@ void MEAM::meam_setup_param(int which, double value, int nindex, int *index /*in
 {
   //: index[0..2]
   int i1, i2;
-  lattice_t vlat;
+  MEAM::lattice_t vlat;
   *errorflag = 0;
 
   switch (which) {

--- a/src/MEAM/pair_meam.cpp
+++ b/src/MEAM/pair_meam.cpp
@@ -370,7 +370,7 @@ void PairMEAM::read_global_meam_file(const std::string &globalfile)
 
   // allocate parameter arrays
 
-  std::vector<lattice_t> lat(nlibelements);
+  std::vector<MEAM::lattice_t> lat(nlibelements);
   std::vector<int> ielement(nlibelements);
   std::vector<int> ibar(nlibelements);
   std::vector<double> z(nlibelements);
@@ -601,7 +601,7 @@ void PairMEAM::read_user_meam_file(const std::string &userfile, int uidx)
     // map lattce_meam value to an integer
     if (which == 4) {
       std::string lattice_type = values.next_string();
-      lattice_t latt;
+      MEAM::lattice_t latt;
       if (!MEAM::str_to_lat(lattice_type, false, latt))
         error->all(FLERR, uidx, "Unrecognized lattice type {} in MEAM parameter file {}:{}",
                    lattice_type, userfile, lineno);

--- a/src/MISC/fix_imd.cpp
+++ b/src/MISC/fix_imd.cpp
@@ -83,7 +83,7 @@ using namespace FixConst;
 /* ---------------------------------------------------------------------- */
 
 /* re-usable integer hash table code with static linkage. */
-
+// NOLINTBEGIN
 /** hash table top level data structure */
 typedef struct taginthash_t {
   struct taginthash_node_t **bucket; /* array of hash nodes */
@@ -99,7 +99,7 @@ typedef struct taginthash_node_t {
   tagint key;                            /* key for hash lookup */
   struct taginthash_node_t *next;        /* next node in hash chain */
 } taginthash_node_t;
-
+// NOLINTEND
 #define HASH_FAIL  -1
 #define HASH_LIMIT  0.5
 
@@ -348,6 +348,8 @@ static void id_sort(tagint *idmap, tagint left, tagint right)
 
 #include <climits>
 
+// NOLINTBEGIN
+
 #if (INT_MAX == 2147483647)
 typedef int     int32;
 #else
@@ -455,6 +457,7 @@ struct commdata {
 
 static MPI_Datatype MPI_CommData;
 
+// NOLINTEND
 /***************************************************************
  * create class and parse arguments in LAMMPS script.
  ***************************************************************/

--- a/src/MISC/pair_list.cpp
+++ b/src/MISC/pair_list.cpp
@@ -58,9 +58,9 @@ static double mypow(double x, int n)
   return yy;
 }
 
-typedef struct {
+using dbl3_t = struct {
   double x, y, z;
-} dbl3_t;
+};
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/domain_omp.cpp
+++ b/src/OPENMP/domain_omp.cpp
@@ -24,9 +24,9 @@
 
 using namespace LAMMPS_NS;
 
-typedef struct {
+using dbl3_t = struct {
   double x, y, z;
-} dbl3_t;
+};
 
 /* ----------------------------------------------------------------------
    enforce PBC and modify box image flags for each atom

--- a/src/OPENMP/fix_rigid_nh_omp.cpp
+++ b/src/OPENMP/fix_rigid_nh_omp.cpp
@@ -46,7 +46,7 @@ using namespace FixConst;
 using namespace MathConst;
 using namespace RigidConst;
 
-typedef struct { double x,y,z; } dbl3_t;
+using dbl3_t = struct { double x,y,z; };
 
 /* ----------------------------------------------------------------------
    perform preforce velocity Verlet integration

--- a/src/OPENMP/fix_rigid_omp.cpp
+++ b/src/OPENMP/fix_rigid_omp.cpp
@@ -42,9 +42,9 @@ using namespace FixConst;
 using namespace MathConst;
 using namespace RigidConst;
 
-typedef struct {
+using dbl3_t = struct {
   double x, y, z;
-} dbl3_t;
+};
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/OPENMP/fix_rigid_small_omp.cpp
+++ b/src/OPENMP/fix_rigid_small_omp.cpp
@@ -40,9 +40,9 @@ using namespace FixConst;
 using namespace MathConst;
 using namespace RigidConst;
 
-typedef struct {
+using dbl3_t = struct {
   double x, y, z;
-} dbl3_t;
+};
 
 // clang-format off
 /* ---------------------------------------------------------------------- */

--- a/src/OPENMP/npair_bin_ghost_omp.h
+++ b/src/OPENMP/npair_bin_ghost_omp.h
@@ -13,12 +13,12 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairBinGhostOmp<0> NPairFullBinGhostOmp;
+using NPairFullBinGhostOmp = NPairBinGhostOmp<0>;
 NPairStyle(full/bin/ghost/omp,
            NPairFullBinGhostOmp,
            NP_FULL | NP_BIN | NP_GHOST | NP_OMP | NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairBinGhostOmp<1> NPairHalfBinNewtoffGhostOmp;
+using NPairHalfBinNewtoffGhostOmp = NPairBinGhostOmp<1>;
 NPairStyle(half/bin/newtoff/ghost/omp,
            NPairHalfBinNewtoffGhostOmp,
            NP_HALF | NP_BIN | NP_GHOST | NP_OMP | NP_NEWTOFF | NP_ORTHO | NP_TRI);

--- a/src/OPENMP/npair_bin_omp.h
+++ b/src/OPENMP/npair_bin_omp.h
@@ -13,86 +13,86 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairBinOmp<0, 1, 0, 0, 0> NPairFullBinOmp;
+using NPairFullBinOmp = NPairBinOmp<0, 1, 0, 0, 0>;
 NPairStyle(full/bin/omp,
            NPairFullBinOmp,
            NP_FULL | NP_BIN | NP_OMP | NP_MOLONLY |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairBinOmp<1, 0, 0, 0, 0> NPairHalfBinNewtoffOmp;
+using NPairHalfBinNewtoffOmp = NPairBinOmp<1, 0, 0, 0, 0>;
 NPairStyle(half/bin/newtoff/omp,
            NPairHalfBinNewtoffOmp,
            NP_HALF | NP_BIN | NP_OMP | NP_MOLONLY | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairBinOmp<1, 1, 0, 0, 0> NPairHalfBinNewtonOmp;
+using NPairHalfBinNewtonOmp = NPairBinOmp<1, 1, 0, 0, 0>;
 NPairStyle(half/bin/newton/omp,
            NPairHalfBinNewtonOmp,
            NP_HALF | NP_BIN | NP_OMP | NP_MOLONLY | NP_NEWTON | NP_ORTHO);
 
-typedef NPairBinOmp<1, 1, 1, 0, 0> NPairHalfBinNewtonTriOmp;
+using NPairHalfBinNewtonTriOmp = NPairBinOmp<1, 1, 1, 0, 0>;
 NPairStyle(half/bin/newton/tri/omp,
            NPairHalfBinNewtonTriOmp,
            NP_HALF | NP_BIN | NP_OMP | NP_MOLONLY | NP_NEWTON | NP_TRI);
 
-typedef NPairBinOmp<0, 1, 0, 1, 0> NPairFullSizeBinOmp;
+using NPairFullSizeBinOmp = NPairBinOmp<0, 1, 0, 1, 0>;
 NPairStyle(full/size/bin/omp,
            NPairFullSizeBinOmp,
            NP_FULL | NP_SIZE | NP_BIN | NP_OMP | NP_MOLONLY |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairBinOmp<1, 0, 0, 1, 0> NPairHalfSizeBinNewtoffOmp;
+using NPairHalfSizeBinNewtoffOmp = NPairBinOmp<1, 0, 0, 1, 0>;
 NPairStyle(half/size/bin/newtoff/omp,
            NPairHalfSizeBinNewtoffOmp,
            NP_HALF | NP_SIZE | NP_BIN | NP_OMP | NP_MOLONLY | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairBinOmp<1, 1, 0, 1, 0> NPairHalfSizeBinNewtonOmp;
+using NPairHalfSizeBinNewtonOmp = NPairBinOmp<1, 1, 0, 1, 0>;
 NPairStyle(half/size/bin/newton/omp,
            NPairHalfSizeBinNewtonOmp,
            NP_HALF | NP_SIZE | NP_BIN | NP_OMP | NP_MOLONLY | NP_NEWTON | NP_ORTHO);
 
-typedef NPairBinOmp<1, 1, 1, 1, 0> NPairHalfSizeBinNewtonTriOmp;
+using NPairHalfSizeBinNewtonTriOmp = NPairBinOmp<1, 1, 1, 1, 0>;
 NPairStyle(half/size/bin/newton/tri/omp,
            NPairHalfSizeBinNewtonTriOmp,
            NP_HALF | NP_SIZE | NP_BIN | NP_OMP | NP_MOLONLY | NP_NEWTON | NP_TRI);
 
-typedef NPairBinOmp<0, 1, 0, 0, 1> NPairFullBinAtomonlyOmp;
+using NPairFullBinAtomonlyOmp = NPairBinOmp<0, 1, 0, 0, 1>;
 NPairStyle(full/bin/atomonly/omp,
            NPairFullBinAtomonlyOmp,
            NP_FULL | NP_BIN | NP_OMP | NP_ATOMONLY |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairBinOmp<1, 0, 0, 0, 1> NPairHalfBinNewtoffAtomonlyOmp;
+using NPairHalfBinNewtoffAtomonlyOmp = NPairBinOmp<1, 0, 0, 0, 1>;
 NPairStyle(half/bin/newtoff/atomonly/omp,
            NPairHalfBinNewtoffAtomonlyOmp,
            NP_HALF | NP_BIN | NP_OMP | NP_ATOMONLY | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairBinOmp<1, 1, 0, 0, 1> NPairHalfBinNewtonAtomonlyOmp;
+using NPairHalfBinNewtonAtomonlyOmp = NPairBinOmp<1, 1, 0, 0, 1>;
 NPairStyle(half/bin/newton/atomonly/omp,
            NPairHalfBinNewtonAtomonlyOmp,
            NP_HALF | NP_BIN | NP_OMP | NP_ATOMONLY | NP_NEWTON | NP_ORTHO);
 
-typedef NPairBinOmp<1, 1, 1, 0, 1> NPairHalfBinNewtonTriAtomonlyOmp;
+using NPairHalfBinNewtonTriAtomonlyOmp = NPairBinOmp<1, 1, 1, 0, 1>;
 NPairStyle(half/bin/newton/tri/atomonly/omp,
            NPairHalfBinNewtonTriAtomonlyOmp,
            NP_HALF | NP_BIN | NP_OMP | NP_ATOMONLY | NP_NEWTON | NP_TRI);
 
-typedef NPairBinOmp<0, 1, 0, 1, 1> NPairFullSizeBinAtomonlyOmp;
+using NPairFullSizeBinAtomonlyOmp = NPairBinOmp<0, 1, 0, 1, 1>;
 NPairStyle(full/size/bin/atomonly/omp,
            NPairFullSizeBinAtomonlyOmp,
            NP_FULL | NP_SIZE | NP_BIN | NP_OMP | NP_ATOMONLY |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairBinOmp<1, 0, 0, 1, 1> NPairHalfSizeBinNewtoffAtomonlyOmp;
+using NPairHalfSizeBinNewtoffAtomonlyOmp = NPairBinOmp<1, 0, 0, 1, 1>;
 NPairStyle(half/size/bin/newtoff/atomonly/omp,
            NPairHalfSizeBinNewtoffAtomonlyOmp,
            NP_HALF | NP_SIZE | NP_BIN | NP_OMP | NP_ATOMONLY | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairBinOmp<1, 1, 0, 1, 1> NPairHalfSizeBinNewtonAtomonlyOmp;
+using NPairHalfSizeBinNewtonAtomonlyOmp = NPairBinOmp<1, 1, 0, 1, 1>;
 NPairStyle(half/size/bin/newton/atomonly/omp,
            NPairHalfSizeBinNewtonAtomonlyOmp,
            NP_HALF | NP_SIZE | NP_BIN | NP_OMP | NP_ATOMONLY | NP_NEWTON | NP_ORTHO);
 
-typedef NPairBinOmp<1, 1, 1, 1, 1> NPairHalfSizeBinNewtonTriAtomonlyOmp;
+using NPairHalfSizeBinNewtonTriAtomonlyOmp = NPairBinOmp<1, 1, 1, 1, 1>;
 NPairStyle(half/size/bin/newton/tri/atomonly/omp,
            NPairHalfSizeBinNewtonTriAtomonlyOmp,
            NP_HALF | NP_SIZE | NP_BIN | NP_OMP | NP_ATOMONLY | NP_NEWTON | NP_TRI);

--- a/src/OPENMP/npair_halffull_omp.h
+++ b/src/OPENMP/npair_halffull_omp.h
@@ -13,97 +13,97 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairHalffullOmp<0, 0, 0> NPairHalffullNewtoffOmp;
+using NPairHalffullNewtoffOmp = NPairHalffullOmp<0, 0, 0>;
 NPairStyle(halffull/newtoff/omp,
            NPairHalffullNewtoffOmp,
            NP_HALF_FULL | NP_NEWTOFF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD | NP_HALF |
            NP_ORTHO | NP_TRI | NP_OMP);
 
-typedef NPairHalffullOmp<0, 0, 0> NPairHalffullNewtoffOmp;
+using NPairHalffullNewtoffOmp = NPairHalffullOmp<0, 0, 0>;
 NPairStyle(halffull/newtoff/skip/omp,
            NPairHalffullNewtoffOmp,
            NP_HALF_FULL | NP_NEWTOFF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD | NP_HALF |
            NP_ORTHO | NP_TRI | NP_SKIP | NP_OMP);
 
-typedef NPairHalffullOmp<0, 0, 0> NPairHalffullNewtoffOmp;
+using NPairHalffullNewtoffOmp = NPairHalffullOmp<0, 0, 0>;
 NPairStyle(halffull/newtoff/ghost/omp,
            NPairHalffullNewtoffOmp,
            NP_HALF_FULL | NP_NEWTOFF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD | NP_HALF |
            NP_ORTHO | NP_TRI | NP_GHOST | NP_OMP);
 
-typedef NPairHalffullOmp<0, 0, 0> NPairHalffullNewtoffOmp;
+using NPairHalffullNewtoffOmp = NPairHalffullOmp<0, 0, 0>;
 NPairStyle(halffull/newtoff/skip/ghost/omp,
            NPairHalffullNewtoffOmp,
            NP_HALF_FULL | NP_NEWTOFF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD | NP_HALF |
            NP_ORTHO | NP_TRI | NP_SKIP | NP_GHOST | NP_OMP);
 
-typedef NPairHalffullOmp<1, 0, 0> NPairHalffullNewtonOmp;
+using NPairHalffullNewtonOmp = NPairHalffullOmp<1, 0, 0>;
 NPairStyle(halffull/newton/omp,
            NPairHalffullNewtonOmp,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_ORTHO | NP_OMP);
 
-typedef NPairHalffullOmp<1, 1, 0> NPairHalffullNewtonTriOmp;
+using NPairHalffullNewtonTriOmp = NPairHalffullOmp<1, 1, 0>;
 NPairStyle(halffull/newton/tri/omp,
            NPairHalffullNewtonTriOmp,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_TRI | NP_OMP);
 
-typedef NPairHalffullOmp<1, 0, 0> NPairHalffullNewtonOmp;
+using NPairHalffullNewtonOmp = NPairHalffullOmp<1, 0, 0>;
 NPairStyle(halffull/newton/skip/omp,
            NPairHalffullNewtonOmp,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_ORTHO | NP_SKIP | NP_OMP);
 
-typedef NPairHalffullOmp<1, 1, 0> NPairHalffullNewtonTriOmp;
+using NPairHalffullNewtonTriOmp = NPairHalffullOmp<1, 1, 0>;
 NPairStyle(halffull/newton/tri/skip/omp,
            NPairHalffullNewtonTriOmp,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_TRI | NP_SKIP | NP_OMP);
 
-typedef NPairHalffullOmp<0, 0, 1> NPairHalffullTrimNewtoffOmp;
+using NPairHalffullTrimNewtoffOmp = NPairHalffullOmp<0, 0, 1>;
 NPairStyle(halffull/trim/newtoff/omp,
            NPairHalffullTrimNewtoffOmp,
            NP_HALF_FULL | NP_NEWTOFF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD | NP_HALF |
            NP_ORTHO | NP_TRI | NP_TRIM | NP_OMP);
 
-typedef NPairHalffullOmp<0, 0, 1> NPairHalffullTrimNewtoffOmp;
+using NPairHalffullTrimNewtoffOmp = NPairHalffullOmp<0, 0, 1>;
 NPairStyle(halffull/trim/newtoff/skip/omp,
            NPairHalffullTrimNewtoffOmp,
            NP_HALF_FULL | NP_NEWTOFF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD | NP_HALF |
            NP_ORTHO | NP_TRI | NP_SKIP | NP_TRIM | NP_OMP);
 
-typedef NPairHalffullOmp<0, 0, 1> NPairHalffullTrimNewtoffOmp;
+using NPairHalffullTrimNewtoffOmp = NPairHalffullOmp<0, 0, 1>;
 NPairStyle(halffull/trim/newtoff/ghost/omp,
            NPairHalffullTrimNewtoffOmp,
            NP_HALF_FULL | NP_NEWTOFF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD | NP_HALF |
            NP_ORTHO | NP_TRI | NP_GHOST | NP_TRIM | NP_OMP);
 
-typedef NPairHalffullOmp<0, 0, 1> NPairHalffullTrimNewtoffOmp;
+using NPairHalffullTrimNewtoffOmp = NPairHalffullOmp<0, 0, 1>;
 NPairStyle(halffull/trim/newtoff/skip/ghost/omp,
            NPairHalffullTrimNewtoffOmp,
            NP_HALF_FULL | NP_NEWTOFF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD | NP_HALF |
            NP_ORTHO | NP_TRI | NP_SKIP | NP_GHOST | NP_TRIM | NP_OMP);
 
-typedef NPairHalffullOmp<1, 0, 1> NPairHalffullTrimNewtonOmp;
+using NPairHalffullTrimNewtonOmp = NPairHalffullOmp<1, 0, 1>;
 NPairStyle(halffull/trim/newton/omp,
            NPairHalffullTrimNewtonOmp,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_ORTHO | NP_TRIM | NP_OMP);
 
-typedef NPairHalffullOmp<1, 1, 1> NPairHalffullTrimNewtonTriOmp;
+using NPairHalffullTrimNewtonTriOmp = NPairHalffullOmp<1, 1, 1>;
 NPairStyle(halffull/trim/newton/tri/omp,
            NPairHalffullTrimNewtonTriOmp,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_TRI | NP_TRIM | NP_OMP);
 
-typedef NPairHalffullOmp<1, 0, 1> NPairHalffullTrimNewtonOmp;
+using NPairHalffullTrimNewtonOmp = NPairHalffullOmp<1, 0, 1>;
 NPairStyle(halffull/trim/newton/skip/omp,
            NPairHalffullTrimNewtonOmp,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_ORTHO | NP_SKIP | NP_TRIM | NP_OMP);
 
-typedef NPairHalffullOmp<1, 1, 1> NPairHalffullTrimNewtonTriOmp;
+using NPairHalffullTrimNewtonTriOmp = NPairHalffullOmp<1, 1, 1>;
 NPairStyle(halffull/trim/newton/tri/skip/omp,
            NPairHalffullTrimNewtonTriOmp,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |

--- a/src/OPENMP/npair_multi_old_omp.h
+++ b/src/OPENMP/npair_multi_old_omp.h
@@ -13,44 +13,44 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairMultiOldOmp<0, 1, 0, 0> NPairFullMultiOldOmp;
+using NPairFullMultiOldOmp = NPairMultiOldOmp<0, 1, 0, 0>;
 NPairStyle(full/multi/old/omp,
            NPairFullMultiOldOmp,
            NP_FULL | NP_MULTI_OLD | NP_OMP |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMultiOldOmp<1, 0, 0, 0> NPairHalfMultiOldNewtoffOmp;
+using NPairHalfMultiOldNewtoffOmp = NPairMultiOldOmp<1, 0, 0, 0>;
 NPairStyle(half/multi/old/newtoff/omp,
            NPairHalfMultiOldNewtoffOmp,
            NP_HALF | NP_MULTI_OLD | NP_OMP | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMultiOldOmp<1, 1, 0, 0> NPairHalfMultiOldNewtonOmp;
+using NPairHalfMultiOldNewtonOmp = NPairMultiOldOmp<1, 1, 0, 0>;
 NPairStyle(half/multi/old/newton/omp,
            NPairHalfMultiOldNewtonOmp,
            NP_HALF | NP_MULTI_OLD | NP_OMP | NP_NEWTON | NP_ORTHO);
 
-typedef NPairMultiOldOmp<1, 1, 1, 0> NPairHalfMultiOldNewtonTriOmp;
+using NPairHalfMultiOldNewtonTriOmp = NPairMultiOldOmp<1, 1, 1, 0>;
 NPairStyle(half/multi/old/newton/tri/omp,
            NPairHalfMultiOldNewtonTriOmp,
            NP_HALF | NP_MULTI_OLD | NP_OMP | NP_NEWTON | NP_TRI);
 
-typedef NPairMultiOldOmp<0, 1, 0, 1> NPairFullSizeMultiOldOmp;
+using NPairFullSizeMultiOldOmp = NPairMultiOldOmp<0, 1, 0, 1>;
 NPairStyle(full/size/multi/old/omp,
            NPairFullSizeMultiOldOmp,
            NP_FULL | NP_SIZE | NP_MULTI_OLD | NP_OMP |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMultiOldOmp<1, 0, 0, 1> NPairHalfSizeMultiOldNewtoffOmp;
+using NPairHalfSizeMultiOldNewtoffOmp = NPairMultiOldOmp<1, 0, 0, 1>;
 NPairStyle(half/size/multi/old/newtoff/omp,
            NPairHalfSizeMultiOldNewtoffOmp,
            NP_HALF | NP_SIZE | NP_MULTI_OLD | NP_OMP | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMultiOldOmp<1, 1, 0, 1> NPairHalfSizeMultiOldNewtonOmp;
+using NPairHalfSizeMultiOldNewtonOmp = NPairMultiOldOmp<1, 1, 0, 1>;
 NPairStyle(half/size/multi/old/newton/omp,
            NPairHalfSizeMultiOldNewtonOmp,
            NP_HALF | NP_SIZE | NP_MULTI_OLD | NP_OMP | NP_NEWTON | NP_ORTHO);
 
-typedef NPairMultiOldOmp<1, 1, 1, 1> NPairHalfSizeMultiOldNewtonTriOmp;
+using NPairHalfSizeMultiOldNewtonTriOmp = NPairMultiOldOmp<1, 1, 1, 1>;
 NPairStyle(half/size/multi/old/newton/tri/omp,
            NPairHalfSizeMultiOldNewtonTriOmp,
            NP_HALF | NP_SIZE | NP_MULTI_OLD | NP_OMP | NP_NEWTON | NP_TRI);

--- a/src/OPENMP/npair_multi_omp.h
+++ b/src/OPENMP/npair_multi_omp.h
@@ -13,82 +13,82 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairMultiOmp<0, 1, 0, 0, 0> NPairFullMultiOmp;
+using NPairFullMultiOmp = NPairMultiOmp<0, 1, 0, 0, 0>;
 NPairStyle(full/multi/omp,
            NPairFullMultiOmp,
            NP_FULL | NP_MULTI | NP_MOLONLY | NP_OMP | NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMultiOmp<1, 0, 0, 0, 0> NPairHalfMultiNewtoffOmp;
+using NPairHalfMultiNewtoffOmp = NPairMultiOmp<1, 0, 0, 0, 0>;
 NPairStyle(half/multi/newtoff/omp,
            NPairHalfMultiNewtoffOmp,
            NP_HALF | NP_MULTI | NP_MOLONLY | NP_OMP | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMultiOmp<1, 1, 0, 0, 0> NPairHalfMultiNewtonOmp;
+using NPairHalfMultiNewtonOmp = NPairMultiOmp<1, 1, 0, 0, 0>;
 NPairStyle(half/multi/newton/omp,
            NPairHalfMultiNewtonOmp,
            NP_HALF | NP_MULTI | NP_MOLONLY | NP_OMP | NP_NEWTON | NP_ORTHO);
 
-typedef NPairMultiOmp<1, 1, 1, 0, 0> NPairHalfMultiNewtonTriOmp;
+using NPairHalfMultiNewtonTriOmp = NPairMultiOmp<1, 1, 1, 0, 0>;
 NPairStyle(half/multi/newton/tri/omp,
            NPairHalfMultiNewtonTriOmp,
            NP_HALF | NP_MULTI | NP_MOLONLY | NP_OMP | NP_NEWTON | NP_TRI);
 
-typedef NPairMultiOmp<0, 1, 0, 1, 0> NPairFullSizeMultiOmp;
+using NPairFullSizeMultiOmp = NPairMultiOmp<0, 1, 0, 1, 0>;
 NPairStyle(full/size/multi/omp,
            NPairFullSizeMultiOmp,
            NP_FULL | NP_SIZE | NP_MULTI | NP_MOLONLY | NP_OMP | NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMultiOmp<1, 0, 0, 1, 0> NPairHalfSizeMultiNewtoffOmp;
+using NPairHalfSizeMultiNewtoffOmp = NPairMultiOmp<1, 0, 0, 1, 0>;
 NPairStyle(half/size/multi/newtoff/omp,
            NPairHalfSizeMultiNewtoffOmp,
            NP_HALF | NP_SIZE | NP_MULTI | NP_MOLONLY | NP_OMP | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMultiOmp<1, 1, 0, 1, 0> NPairHalfSizeMultiNewtonOmp;
+using NPairHalfSizeMultiNewtonOmp = NPairMultiOmp<1, 1, 0, 1, 0>;
 NPairStyle(half/size/multi/newton/omp,
            NPairHalfSizeMultiNewtonOmp,
            NP_HALF | NP_SIZE | NP_MULTI | NP_MOLONLY | NP_OMP | NP_NEWTON | NP_ORTHO);
 
-typedef NPairMultiOmp<1, 1, 1, 1, 0> NPairHalfSizeMultiNewtonTriOmp;
+using NPairHalfSizeMultiNewtonTriOmp = NPairMultiOmp<1, 1, 1, 1, 0>;
 NPairStyle(half/size/multi/newton/tri/omp,
            NPairHalfSizeMultiNewtonTriOmp,
            NP_HALF | NP_SIZE | NP_MULTI | NP_MOLONLY | NP_OMP | NP_NEWTON | NP_TRI);
 
-typedef NPairMultiOmp<0, 1, 0, 0, 1> NPairFullMultiAtomonlyOmp;
+using NPairFullMultiAtomonlyOmp = NPairMultiOmp<0, 1, 0, 0, 1>;
 NPairStyle(full/multi/atomonly/omp,
            NPairFullMultiAtomonlyOmp,
            NP_FULL | NP_MULTI | NP_ATOMONLY | NP_OMP | NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMultiOmp<1, 0, 0, 0, 1> NPairHalfMultiAtomonlyNewtoffOmp;
+using NPairHalfMultiAtomonlyNewtoffOmp = NPairMultiOmp<1, 0, 0, 0, 1>;
 NPairStyle(half/multi/atomonly/newtoff/omp,
            NPairHalfMultiAtomonlyNewtoffOmp,
            NP_HALF | NP_MULTI | NP_ATOMONLY | NP_OMP | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMultiOmp<1, 1, 0, 0, 1> NPairHalfMultiAtomonlyNewtonOmp;
+using NPairHalfMultiAtomonlyNewtonOmp = NPairMultiOmp<1, 1, 0, 0, 1>;
 NPairStyle(half/multi/atomonly/newton/omp,
            NPairHalfMultiAtomonlyNewtonOmp,
            NP_HALF | NP_MULTI | NP_ATOMONLY | NP_OMP | NP_NEWTON | NP_ORTHO);
 
-typedef NPairMultiOmp<1, 1, 1, 0, 1> NPairHalfMultiAtomonlyNewtonTriOmp;
+using NPairHalfMultiAtomonlyNewtonTriOmp = NPairMultiOmp<1, 1, 1, 0, 1>;
 NPairStyle(half/multi/atomonly/newton/tri/omp,
            NPairHalfMultiAtomonlyNewtonTriOmp,
            NP_HALF | NP_MULTI | NP_ATOMONLY | NP_OMP | NP_NEWTON | NP_TRI);
 
-typedef NPairMultiOmp<0, 1, 0, 1, 1> NPairFullSizeMultiAtomonlyOmp;
+using NPairFullSizeMultiAtomonlyOmp = NPairMultiOmp<0, 1, 0, 1, 1>;
 NPairStyle(full/size/multi/atomonly/omp,
            NPairFullSizeMultiAtomonlyOmp,
            NP_FULL | NP_SIZE | NP_MULTI | NP_ATOMONLY | NP_OMP | NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMultiOmp<1, 0, 0, 1, 1> NPairHalfSizeMultiAtomonlyNewtoffOmp;
+using NPairHalfSizeMultiAtomonlyNewtoffOmp = NPairMultiOmp<1, 0, 0, 1, 1>;
 NPairStyle(half/size/multi/atomonly/newtoff/omp,
            NPairHalfSizeMultiAtomonlyNewtoffOmp,
            NP_HALF | NP_SIZE | NP_MULTI | NP_ATOMONLY | NP_OMP | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMultiOmp<1, 1, 0, 1, 1> NPairHalfSizeMultiAtomonlyNewtonOmp;
+using NPairHalfSizeMultiAtomonlyNewtonOmp = NPairMultiOmp<1, 1, 0, 1, 1>;
 NPairStyle(half/size/multi/atomonly/newton/omp,
            NPairHalfSizeMultiAtomonlyNewtonOmp,
            NP_HALF | NP_SIZE | NP_MULTI | NP_ATOMONLY | NP_OMP | NP_NEWTON | NP_ORTHO);
 
-typedef NPairMultiOmp<1, 1, 1, 1, 1> NPairHalfSizeMultiAtomonlyNewtonTriOmp;
+using NPairHalfSizeMultiAtomonlyNewtonTriOmp = NPairMultiOmp<1, 1, 1, 1, 1>;
 NPairStyle(half/size/multi/atomonly/newton/tri/omp,
            NPairHalfSizeMultiAtomonlyNewtonTriOmp,
            NP_HALF | NP_SIZE | NP_MULTI | NP_ATOMONLY | NP_OMP | NP_NEWTON | NP_TRI);

--- a/src/OPENMP/npair_nsq_ghost_omp.h
+++ b/src/OPENMP/npair_nsq_ghost_omp.h
@@ -13,12 +13,12 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairNsqGhostOmp<0> NPairFullNsqGhostOmp;
+using NPairFullNsqGhostOmp = NPairNsqGhostOmp<0>;
 NPairStyle(full/nsq/ghost/omp,
            NPairFullNsqGhostOmp,
            NP_FULL | NP_NSQ | NP_NEWTON | NP_NEWTOFF | NP_GHOST | NP_OMP | NP_ORTHO | NP_TRI);
 
-typedef NPairNsqGhostOmp<1> NPairHalfNsqNewtoffGhostOmp;
+using NPairHalfNsqNewtoffGhostOmp = NPairNsqGhostOmp<1>;
 NPairStyle(half/nsq/newtoff/ghost/omp,
            NPairHalfNsqNewtoffGhostOmp,
            NP_HALF | NP_NSQ | NP_NEWTOFF | NP_GHOST | NP_OMP | NP_ORTHO | NP_TRI);

--- a/src/OPENMP/npair_nsq_omp.h
+++ b/src/OPENMP/npair_nsq_omp.h
@@ -14,42 +14,42 @@
 #ifdef NPAIR_CLASS
 // clang-format off
 
-typedef NPairNsqOmp<0, 1, 0, 0> NPairFullNsqOmp;
+using NPairFullNsqOmp = NPairNsqOmp<0, 1, 0, 0>;
 NPairStyle(full/nsq/omp,
            NPairFullNsqOmp,
            NP_FULL | NP_NSQ | NP_OMP | NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairNsqOmp<1, 0, 0, 0> NPairHalfNsqNewtoffOmp;
+using NPairHalfNsqNewtoffOmp = NPairNsqOmp<1, 0, 0, 0>;
 NPairStyle(half/nsq/newtoff/omp,
            NPairHalfNsqNewtoffOmp,
            NP_HALF | NP_NSQ | NP_OMP | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairNsqOmp<1, 1, 0, 0> NPairHalfNsqNewtonOmp;
+using NPairHalfNsqNewtonOmp = NPairNsqOmp<1, 1, 0, 0>;
 NPairStyle(half/nsq/newton/omp,
            NPairHalfNsqNewtonOmp,
            NP_HALF | NP_NSQ | NP_OMP | NP_NEWTON | NP_ORTHO);
 
-typedef NPairNsqOmp<1, 1, 1, 0> NPairHalfNsqNewtonTriOmp;
+using NPairHalfNsqNewtonTriOmp = NPairNsqOmp<1, 1, 1, 0>;
 NPairStyle(half/nsq/newton/tri/omp,
            NPairHalfNsqNewtonTriOmp,
            NP_HALF | NP_NSQ | NP_OMP | NP_NEWTON | NP_TRI);
 
-typedef NPairNsqOmp<0, 1, 0, 1> NPairFullSizeNsqOmp;
+using NPairFullSizeNsqOmp = NPairNsqOmp<0, 1, 0, 1>;
 NPairStyle(full/size/nsq/omp,
            NPairFullSizeNsqOmp,
            NP_FULL | NP_SIZE | NP_NSQ | NP_OMP | NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairNsqOmp<1, 0, 0, 1> NPairHalfSizeNsqNewtoffOmp;
+using NPairHalfSizeNsqNewtoffOmp = NPairNsqOmp<1, 0, 0, 1>;
 NPairStyle(half/size/nsq/newtoff/omp,
            NPairHalfSizeNsqNewtoffOmp,
            NP_HALF | NP_SIZE | NP_NSQ | NP_OMP | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairNsqOmp<1, 1, 0, 1> NPairHalfSizeNsqNewtonOmp;
+using NPairHalfSizeNsqNewtonOmp = NPairNsqOmp<1, 1, 0, 1>;
 NPairStyle(half/size/nsq/newton/omp,
            NPairHalfSizeNsqNewtonOmp,
            NP_HALF | NP_SIZE | NP_NSQ | NP_OMP | NP_NEWTON | NP_ORTHO);
 
-typedef NPairNsqOmp<1, 1, 1, 1> NPairHalfSizeNsqNewtonTriOmp;
+using NPairHalfSizeNsqNewtonTriOmp = NPairNsqOmp<1, 1, 1, 1>;
 NPairStyle(half/size/nsq/newton/tri/omp,
            NPairHalfSizeNsqNewtonTriOmp,
            NP_HALF | NP_SIZE | NP_NSQ | NP_OMP | NP_NEWTON | NP_TRI);

--- a/src/OPENMP/npair_respa_bin_omp.h
+++ b/src/OPENMP/npair_respa_bin_omp.h
@@ -13,17 +13,17 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairRespaBinOmp<0, 0> NPairHalfRespaBinNewtoffOmp;
+using NPairHalfRespaBinNewtoffOmp = NPairRespaBinOmp<0, 0>;
 NPairStyle(half/respa/bin/newtoff,
            NPairHalfRespaBinNewtoffOmp,
            NP_HALF | NP_RESPA | NP_BIN | NP_OMP | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairRespaBinOmp<1, 0> NPairHalfRespaBinNewtonOmp;
+using NPairHalfRespaBinNewtonOmp = NPairRespaBinOmp<1, 0>;
 NPairStyle(half/respa/bin/newton/omp,
            NPairHalfRespaBinNewtonOmp,
            NP_HALF | NP_RESPA | NP_BIN | NP_OMP | NP_NEWTON | NP_ORTHO);
 
-typedef NPairRespaBinOmp<1, 1> NPairHalfRespaBinNewtonTriOmp;
+using NPairHalfRespaBinNewtonTriOmp = NPairRespaBinOmp<1, 1>;
 NPairStyle(half/respa/bin/newton/tri/omp,
            NPairHalfRespaBinNewtonTriOmp,
            NP_HALF | NP_RESPA | NP_BIN | NP_OMP | NP_NEWTON | NP_TRI);

--- a/src/OPENMP/npair_respa_nsq_omp.h
+++ b/src/OPENMP/npair_respa_nsq_omp.h
@@ -13,17 +13,17 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairRespaNsqOmp<0,0> NPairHalfRespaNsqNewtoffOmp;
+using NPairHalfRespaNsqNewtoffOmp = NPairRespaNsqOmp<0,0>;
 NPairStyle(half/respa/nsq/newtoff/omp,
            NPairHalfRespaNsqNewtoffOmp,
            NP_HALF | NP_RESPA | NP_NSQ | NP_OMP | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairRespaNsqOmp<1,0> NPairHalfRespaNsqNewtonOmp;
+using NPairHalfRespaNsqNewtonOmp = NPairRespaNsqOmp<1,0>;
 NPairStyle(half/respa/nsq/newton/omp,
            NPairHalfRespaNsqNewtonOmp,
            NP_HALF | NP_RESPA | NP_NSQ | NP_OMP | NP_NEWTON | NP_ORTHO);
 
-typedef NPairRespaNsqOmp<1,1> NPairHalfRespaNsqNewtonTriOmp;
+using NPairHalfRespaNsqNewtonTriOmp = NPairRespaNsqOmp<1,1>;
 NPairStyle(half/respa/nsq/newton/tri/omp,
            NPairHalfRespaNsqNewtonTriOmp,
            NP_HALF | NP_RESPA | NP_NSQ | NP_OMP | NP_NEWTON | NP_TRI);

--- a/src/OPT/pair_eam_opt.cpp
+++ b/src/OPT/pair_eam_opt.cpp
@@ -67,6 +67,7 @@ void PairEAMOpt::compute(int eflag, int vflag)
 
 template <int EVFLAG, int EFLAG, int NEWTON_PAIR> void PairEAMOpt::eval()
 {
+// NOLINTBEGIN
   typedef struct {
     double x, y, z;
   } vec3_t;
@@ -82,6 +83,7 @@ template <int EVFLAG, int EFLAG, int NEWTON_PAIR> void PairEAMOpt::eval()
     double z2r0, z2r1, z2r2, z2r3, z2r4, z2r5, z2r6;
     double _pad[3];
   } fast_gamma_t;
+// NOLINTEND
 
   int i, j, ii, jj, inum, jnum, itype, jtype;
   double evdwl = 0.0;

--- a/src/OPT/pair_lj_charmm_coul_long_opt.cpp
+++ b/src/OPT/pair_lj_charmm_coul_long_opt.cpp
@@ -61,13 +61,14 @@ void PairLJCharmmCoulLongOpt::compute(int eflag, int vflag)
 template < int EVFLAG, int EFLAG, int NEWTON_PAIR >
 void PairLJCharmmCoulLongOpt::eval()
 {
+// NOLINTBEGIN
   typedef struct { double x,y,z; } vec3_t;
 
   typedef struct {
     double cutsq,lj1,lj2,lj3,lj4,offset;
     double _pad[2];
   } fast_alpha_t;
-
+// NOLINTEND
   int i,j,ii,jj,inum,jnum,itype,jtype,itable,sbindex;
   double fraction,table;
   double r,r2inv,r6inv,forcecoul,forcelj,factor_coul,factor_lj;

--- a/src/OPT/pair_lj_cut_opt.cpp
+++ b/src/OPT/pair_lj_cut_opt.cpp
@@ -56,12 +56,14 @@ void PairLJCutOpt::compute(int eflag, int vflag)
 template < int EVFLAG, int EFLAG, int NEWTON_PAIR >
 void PairLJCutOpt::eval()
 {
+// NOLINTBEGIN
   typedef struct { double x,y,z; } vec3_t;
 
   typedef struct {
     double cutsq,lj1,lj2,lj3,lj4,offset;
     double _pad[2];
   } fast_alpha_t;
+// NOLINTEND
 
   int i,j,ii,jj,inum,jnum,itype,jtype,sbindex;
   double factor_lj;

--- a/src/OPT/pair_morse_opt.cpp
+++ b/src/OPT/pair_morse_opt.cpp
@@ -57,12 +57,14 @@ void PairMorseOpt::compute(int eflag, int vflag)
 template < int EVFLAG, int EFLAG, int NEWTON_PAIR >
 void PairMorseOpt::eval()
 {
+// NOLINTBEGIN
   typedef struct { double x,y,z; } vec3_t;
 
   typedef struct {
     double cutsq,r0,alpha,morse1,d0,offset;
     double _pad[2];
   } fast_alpha_t;
+// NOLINTEND
 
   int i,j,ii,jj,inum,jnum,itype,jtype,sbindex;
   double factor_lj;

--- a/src/OPT/pair_ufm_opt.cpp
+++ b/src/OPT/pair_ufm_opt.cpp
@@ -56,12 +56,14 @@ void PairUFMOpt::compute(int eflag, int vflag)
 template < int EVFLAG, int EFLAG, int NEWTON_PAIR >
 void PairUFMOpt::eval()
 {
+// NOLINTBEGIN
   typedef struct { double x,y,z; } vec3_t;
 
   typedef struct {
     double cutsq,uf1,uf2,uf3,scale,offset;
     double _pad[2];
   } fast_alpha_t;
+// NOLINTEND
 
   int i,j,ii,jj,inum,jnum,itype,jtype,sbindex;
   double factor_lj;

--- a/src/lammpsplugin.h
+++ b/src/lammpsplugin.h
@@ -18,6 +18,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+// NOLINTBEGIN
 
 typedef void *(lammpsplugin_factory1) (void *);
 typedef void *(lammpsplugin_factory2) (void *, int, char **);
@@ -42,6 +43,7 @@ typedef void (*lammpsplugin_initfunc)(void *, void *, void *);
 // to load a plugin; uses C bindings
 
 void lammpsplugin_init(void *, void *, void *);
+// NOLINTEND
 
 #ifdef __cplusplus
 }

--- a/src/library.h
+++ b/src/library.h
@@ -38,6 +38,8 @@
 #include <stdint.h> /* for int64_t */
 #endif
 
+// NOLINTBEGIN
+
 /** Data type constants for extracting data from atoms, computes and fixes
  *
  * Must be kept in sync with the equivalent constants in ``python/lammps/constants.py``,
@@ -300,13 +302,11 @@ int64_t lammps_encode_image_flags(int ix, int iy, int iz);
 void lammps_decode_image_flags(int64_t image, int *flags);
 #endif
 
-// BEGIN_NOLINT
 #if defined(LAMMPS_BIGBIG)
 typedef void (*FixExternalFnPtr)(void *, int64_t, int, int64_t *, double **, double **);
 #else
 typedef void (*FixExternalFnPtr)(void *, int64_t, int, int *, double **, double **);
 #endif
-// END_NOLINT
 
 void lammps_set_fix_external_callback(void *handle, const char *id, FixExternalFnPtr funcptr,
                                       void *ptr);
@@ -330,6 +330,7 @@ int lammps_get_last_error_message(void *handle, char *buffer, int buf_size);
 int lammps_set_show_error(void *handle, const int flag);
 
 int lammps_python_api_version();
+// NOLINTBEGIN
 
 #ifdef __cplusplus
 }

--- a/src/npair_bin.h
+++ b/src/npair_bin.h
@@ -13,86 +13,86 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairBin<0, 1, 0, 0, 0> NPairFullBin;
+using NPairFullBin = NPairBin<0, 1, 0, 0, 0>;
 NPairStyle(full/bin,
            NPairFullBin,
            NP_FULL | NP_BIN | NP_MOLONLY |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairBin<1, 0, 0, 0, 0> NPairHalfBinNewtoff;
+using NPairHalfBinNewtoff = NPairBin<1, 0, 0, 0, 0>;
 NPairStyle(half/bin/newtoff,
            NPairHalfBinNewtoff,
            NP_HALF | NP_BIN | NP_MOLONLY | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairBin<1, 1, 0, 0, 0> NPairHalfBinNewton;
+using NPairHalfBinNewton = NPairBin<1, 1, 0, 0, 0>;
 NPairStyle(half/bin/newton,
            NPairHalfBinNewton,
            NP_HALF | NP_BIN | NP_MOLONLY | NP_NEWTON | NP_ORTHO);
 
-typedef NPairBin<1, 1, 1, 0, 0> NPairHalfBinNewtonTri;
+using NPairHalfBinNewtonTri = NPairBin<1, 1, 1, 0, 0>;
 NPairStyle(half/bin/newton/tri,
            NPairHalfBinNewtonTri,
            NP_HALF | NP_BIN | NP_MOLONLY | NP_NEWTON | NP_TRI);
 
-typedef NPairBin<0, 1, 0, 1, 0> NPairFullSizeBin;
+using NPairFullSizeBin = NPairBin<0, 1, 0, 1, 0>;
 NPairStyle(full/size/bin,
            NPairFullSizeBin,
            NP_FULL | NP_SIZE | NP_BIN | NP_MOLONLY |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairBin<1, 0, 0, 1, 0> NPairHalfSizeBinNewtoff;
+using NPairHalfSizeBinNewtoff = NPairBin<1, 0, 0, 1, 0>;
 NPairStyle(half/size/bin/newtoff,
            NPairHalfSizeBinNewtoff,
            NP_HALF | NP_SIZE | NP_BIN | NP_MOLONLY | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairBin<1, 1, 0, 1, 0> NPairHalfSizeBinNewton;
+using NPairHalfSizeBinNewton = NPairBin<1, 1, 0, 1, 0>;
 NPairStyle(half/size/bin/newton,
            NPairHalfSizeBinNewton,
            NP_HALF | NP_SIZE | NP_BIN | NP_MOLONLY | NP_NEWTON | NP_ORTHO);
 
-typedef NPairBin<1, 1, 1, 1, 0> NPairHalfSizeBinNewtonTri;
+using NPairHalfSizeBinNewtonTri = NPairBin<1, 1, 1, 1, 0>;
 NPairStyle(half/size/bin/newton/tri,
            NPairHalfSizeBinNewtonTri,
            NP_HALF | NP_SIZE | NP_BIN | NP_MOLONLY | NP_NEWTON | NP_TRI);
 
-typedef NPairBin<0, 1, 0, 0, 1> NPairFullBinAtomonly;
+using NPairFullBinAtomonly = NPairBin<0, 1, 0, 0, 1>;
 NPairStyle(full/bin/atomonly,
            NPairFullBinAtomonly,
            NP_FULL | NP_BIN | NP_ATOMONLY |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairBin<1, 0, 0, 0, 1> NPairHalfBinAtomonlyNewtoff;
+using NPairHalfBinAtomonlyNewtoff = NPairBin<1, 0, 0, 0, 1>;
 NPairStyle(half/bin/atomonly/newtoff,
            NPairHalfBinAtomonlyNewtoff,
            NP_HALF | NP_BIN | NP_ATOMONLY | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairBin<1, 1, 0, 0, 1> NPairHalfBinAtomonlyNewton;
+using NPairHalfBinAtomonlyNewton = NPairBin<1, 1, 0, 0, 1>;
 NPairStyle(half/bin/atomonly/newton,
            NPairHalfBinAtomonlyNewton,
            NP_HALF | NP_BIN | NP_ATOMONLY | NP_NEWTON | NP_ORTHO);
 
-typedef NPairBin<1, 1, 1, 0, 1> NPairHalfBinAtomonlyNewtonTri;
+using NPairHalfBinAtomonlyNewtonTri = NPairBin<1, 1, 1, 0, 1>;
 NPairStyle(half/bin/atomonly/newton/tri,
            NPairHalfBinAtomonlyNewtonTri,
            NP_HALF | NP_BIN | NP_ATOMONLY | NP_NEWTON | NP_TRI);
 
-typedef NPairBin<0, 1, 0, 1, 1> NPairFullSizeBinAtomonly;
+using NPairFullSizeBinAtomonly = NPairBin<0, 1, 0, 1, 1>;
 NPairStyle(full/size/bin/atomonly,
            NPairFullSizeBinAtomonly,
            NP_FULL | NP_SIZE | NP_BIN | NP_ATOMONLY |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairBin<1, 0, 0, 1, 1> NPairHalfSizeBinAtomonlyNewtoff;
+using NPairHalfSizeBinAtomonlyNewtoff = NPairBin<1, 0, 0, 1, 1>;
 NPairStyle(half/size/bin/atomonly/newtoff,
            NPairHalfSizeBinAtomonlyNewtoff,
            NP_HALF | NP_SIZE | NP_BIN | NP_ATOMONLY | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairBin<1, 1, 0, 1, 1> NPairHalfSizeBinAtomonlyNewton;
+using NPairHalfSizeBinAtomonlyNewton = NPairBin<1, 1, 0, 1, 1>;
 NPairStyle(half/size/bin/atomonly/newton,
            NPairHalfSizeBinAtomonlyNewton,
            NP_HALF | NP_SIZE | NP_BIN | NP_ATOMONLY | NP_NEWTON | NP_ORTHO);
 
-typedef NPairBin<1, 1, 1, 1, 1> NPairHalfSizeBinAtomonlyNewtonTri;
+using NPairHalfSizeBinAtomonlyNewtonTri = NPairBin<1, 1, 1, 1, 1>;
 NPairStyle(half/size/bin/atomonly/newton/tri,
            NPairHalfSizeBinAtomonlyNewtonTri,
            NP_HALF | NP_SIZE | NP_BIN | NP_ATOMONLY | NP_NEWTON | NP_TRI);

--- a/src/npair_bin_ghost.h
+++ b/src/npair_bin_ghost.h
@@ -13,12 +13,12 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairBinGhost<0> NPairFullBinGhost;
+using NPairFullBinGhost = NPairBinGhost<0>;
 NPairStyle(full/bin/ghost,
            NPairFullBinGhost,
            NP_FULL | NP_BIN | NP_NEWTON | NP_NEWTOFF | NP_GHOST | NP_ORTHO | NP_TRI);
 
-typedef NPairBinGhost<1> NPairHalfBinGhostNewtoff;
+using NPairHalfBinGhostNewtoff = NPairBinGhost<1>;
 NPairStyle(half/bin/ghost/newtoff,
            NPairHalfBinGhostNewtoff,
            NP_HALF | NP_BIN | NP_NEWTOFF | NP_GHOST | NP_ORTHO | NP_TRI);

--- a/src/npair_halffull.h
+++ b/src/npair_halffull.h
@@ -13,97 +13,97 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairHalffull<0, 0, 0> NPairHalffullNewtoff;
+using NPairHalffullNewtoff = NPairHalffull<0, 0, 0>;
 NPairStyle(halffull/newtoff,
            NPairHalffullNewtoff,
            NP_HALF_FULL | NP_NEWTOFF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD | NP_HALF |
            NP_ORTHO | NP_TRI);
 
-typedef NPairHalffull<0, 0, 0> NPairHalffullNewtoff;
+using NPairHalffullNewtoff = NPairHalffull<0, 0, 0>;
 NPairStyle(halffull/newtoff/skip,
            NPairHalffullNewtoff,
            NP_HALF_FULL | NP_NEWTOFF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD | NP_HALF |
            NP_ORTHO | NP_TRI | NP_SKIP);
 
-typedef NPairHalffull<0, 0, 0> NPairHalffullNewtoff;
+using NPairHalffullNewtoff = NPairHalffull<0, 0, 0>;
 NPairStyle(halffull/newtoff/ghost,
            NPairHalffullNewtoff,
            NP_HALF_FULL | NP_NEWTOFF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD | NP_HALF |
            NP_ORTHO | NP_TRI | NP_GHOST);
 
-typedef NPairHalffull<0, 0, 0> NPairHalffullNewtoff;
+using NPairHalffullNewtoff = NPairHalffull<0, 0, 0>;
 NPairStyle(halffull/newtoff/skip/ghost,
            NPairHalffullNewtoff,
            NP_HALF_FULL | NP_NEWTOFF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD | NP_HALF |
            NP_ORTHO | NP_TRI | NP_SKIP | NP_GHOST);
 
-typedef NPairHalffull<1, 0, 0> NPairHalffullNewton;
+using NPairHalffullNewton = NPairHalffull<1, 0, 0>;
 NPairStyle(halffull/newton,
            NPairHalffullNewton,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_ORTHO);
 
-typedef NPairHalffull<1, 1, 0> NPairHalffullNewtonTri;
+using NPairHalffullNewtonTri = NPairHalffull<1, 1, 0>;
 NPairStyle(halffull/newton/tri,
            NPairHalffullNewtonTri,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_TRI);
 
-typedef NPairHalffull<1, 0, 0> NPairHalffullNewton;
+using NPairHalffullNewton = NPairHalffull<1, 0, 0>;
 NPairStyle(halffull/newton/skip,
            NPairHalffullNewton,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_ORTHO | NP_SKIP);
 
-typedef NPairHalffull<1, 1, 0> NPairHalffullNewtonTri;
+using NPairHalffullNewtonTri = NPairHalffull<1, 1, 0>;
 NPairStyle(halffull/newton/skip/tri,
            NPairHalffullNewtonTri,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_TRI | NP_SKIP);
 
-typedef NPairHalffull<0, 0, 1> NPairHalffullTrimNewtoff;
+using NPairHalffullTrimNewtoff = NPairHalffull<0, 0, 1>;
 NPairStyle(halffull/trim/newtoff,
            NPairHalffullTrimNewtoff,
            NP_HALF_FULL | NP_NEWTOFF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD | NP_HALF |
            NP_ORTHO | NP_TRI | NP_TRIM);
 
-typedef NPairHalffull<0, 0, 1> NPairHalffullTrimNewtoff;
+using NPairHalffullTrimNewtoff = NPairHalffull<0, 0, 1>;
 NPairStyle(halffull/trim/newtoff/skip,
            NPairHalffullTrimNewtoff,
            NP_HALF_FULL | NP_NEWTOFF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD | NP_HALF |
            NP_ORTHO | NP_TRI | NP_SKIP | NP_TRIM);
 
-typedef NPairHalffull<0, 0, 1> NPairHalffullTrimNewtoff;
+using NPairHalffullTrimNewtoff = NPairHalffull<0, 0, 1>;
 NPairStyle(halffull/trim/newtoff/ghost,
            NPairHalffullTrimNewtoff,
            NP_HALF_FULL | NP_NEWTOFF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD | NP_HALF |
            NP_ORTHO | NP_TRI | NP_GHOST | NP_TRIM);
 
-typedef NPairHalffull<0, 0, 1> NPairHalffullTrimNewtoff;
+using NPairHalffullTrimNewtoff = NPairHalffull<0, 0, 1>;
 NPairStyle(halffull/trim/newtoff/skip/ghost,
            NPairHalffullTrimNewtoff,
            NP_HALF_FULL | NP_NEWTOFF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD | NP_HALF |
            NP_ORTHO | NP_TRI | NP_SKIP | NP_GHOST | NP_TRIM);
 
-typedef NPairHalffull<1, 0, 1> NPairHalffullTrimNewton;
+using NPairHalffullTrimNewton = NPairHalffull<1, 0, 1>;
 NPairStyle(halffull/trim/newton,
            NPairHalffullTrimNewton,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_ORTHO | NP_TRIM);
 
-typedef NPairHalffull<1, 1, 1> NPairHalffullTrimNewtonTri;
+using NPairHalffullTrimNewtonTri = NPairHalffull<1, 1, 1>;
 NPairStyle(halffull/trim/newton/tri,
            NPairHalffullTrimNewtonTri,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_TRI | NP_TRIM);
 
-typedef NPairHalffull<1, 0, 1> NPairHalffullTrimNewton;
+using NPairHalffullTrimNewton = NPairHalffull<1, 0, 1>;
 NPairStyle(halffull/trim/newton/skip,
            NPairHalffullTrimNewton,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_ORTHO | NP_SKIP | NP_TRIM);
 
-typedef NPairHalffull<1, 1, 1> NPairHalffullTrimNewtonTri;
+using NPairHalffullTrimNewtonTri = NPairHalffull<1, 1, 1>;
 NPairStyle(halffull/trim/newton/tri/skip,
            NPairHalffullTrimNewtonTri,
            NP_HALF_FULL | NP_NEWTON | NP_HALF | NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |

--- a/src/npair_multi.h
+++ b/src/npair_multi.h
@@ -13,86 +13,86 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairMulti<0, 1, 0, 0, 0> NPairFullMulti;
+using NPairFullMulti = NPairMulti<0, 1, 0, 0, 0>;
 NPairStyle(full/multi,
            NPairFullMulti,
            NP_FULL | NP_MULTI | NP_MOLONLY |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMulti<1, 0, 0, 0, 0> NPairHalfMultiNewtoff;
+using NPairHalfMultiNewtoff = NPairMulti<1, 0, 0, 0, 0>;
 NPairStyle(half/multi/newtoff,
            NPairHalfMultiNewtoff,
            NP_HALF | NP_MULTI | NP_MOLONLY | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMulti<1, 1, 0, 0, 0> NPairHalfMultiNewton;
+using NPairHalfMultiNewton = NPairMulti<1, 1, 0, 0, 0>;
 NPairStyle(half/multi/newton,
            NPairHalfMultiNewton,
            NP_HALF | NP_MULTI | NP_MOLONLY | NP_NEWTON | NP_ORTHO);
 
-typedef NPairMulti<1, 1, 1, 0, 0> NPairHalfMultiNewtonTri;
+using NPairHalfMultiNewtonTri = NPairMulti<1, 1, 1, 0, 0>;
 NPairStyle(half/multi/newton/tri,
            NPairHalfMultiNewtonTri,
            NP_HALF | NP_MULTI | NP_MOLONLY | NP_NEWTON | NP_TRI);
 
-typedef NPairMulti<0, 1, 0, 1, 0> NPairFullSizeMulti;
+using NPairFullSizeMulti = NPairMulti<0, 1, 0, 1, 0>;
 NPairStyle(full/size/multi,
            NPairFullSizeMulti,
            NP_FULL | NP_SIZE | NP_MULTI | NP_MOLONLY |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMulti<1, 0, 0, 1, 0> NPairHalfSizeMultiNewtoff;
+using NPairHalfSizeMultiNewtoff = NPairMulti<1, 0, 0, 1, 0>;
 NPairStyle(half/size/multi/newtoff,
            NPairHalfSizeMultiNewtoff,
            NP_HALF | NP_SIZE | NP_MULTI | NP_MOLONLY | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMulti<1, 1, 0, 1, 0> NPairHalfSizeMultiNewton;
+using NPairHalfSizeMultiNewton = NPairMulti<1, 1, 0, 1, 0>;
 NPairStyle(half/size/multi/newton,
            NPairHalfSizeMultiNewton,
            NP_HALF | NP_SIZE | NP_MULTI | NP_MOLONLY | NP_NEWTON | NP_ORTHO);
 
-typedef NPairMulti<1, 1, 1, 1, 0> NPairHalfSizeMultiNewtonTri;
+using NPairHalfSizeMultiNewtonTri = NPairMulti<1, 1, 1, 1, 0>;
 NPairStyle(half/size/multi/newton/tri,
            NPairHalfSizeMultiNewtonTri,
            NP_HALF | NP_SIZE | NP_MULTI | NP_MOLONLY | NP_NEWTON | NP_TRI);
 
-typedef NPairMulti<0, 1, 0, 0, 1> NPairFullMultiAtomonly;
+using NPairFullMultiAtomonly = NPairMulti<0, 1, 0, 0, 1>;
 NPairStyle(full/multi/atomonly,
            NPairFullMultiAtomonly,
            NP_FULL | NP_MULTI | NP_ATOMONLY |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMulti<1, 0, 0, 0, 1> NPairHalfMultiAtomonlyNewtoff;
+using NPairHalfMultiAtomonlyNewtoff = NPairMulti<1, 0, 0, 0, 1>;
 NPairStyle(half/multi/atomonly/newtoff,
            NPairHalfMultiAtomonlyNewtoff,
            NP_HALF | NP_MULTI | NP_ATOMONLY | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMulti<1, 1, 0, 0, 1> NPairHalfMultiAtomonlyNewton;
+using NPairHalfMultiAtomonlyNewton = NPairMulti<1, 1, 0, 0, 1>;
 NPairStyle(half/multi/atomonly/newton,
            NPairHalfMultiAtomonlyNewton,
            NP_HALF | NP_MULTI | NP_ATOMONLY | NP_NEWTON | NP_ORTHO);
 
-typedef NPairMulti<1, 1, 1, 0, 1> NPairHalfMultiAtomonlyNewtonTri;
+using NPairHalfMultiAtomonlyNewtonTri = NPairMulti<1, 1, 1, 0, 1>;
 NPairStyle(half/multi/atomonly/newton/tri,
            NPairHalfMultiAtomonlyNewtonTri,
            NP_HALF | NP_MULTI | NP_ATOMONLY | NP_NEWTON | NP_TRI);
 
-typedef NPairMulti<0, 1, 0, 1, 1> NPairFullSizeMultiAtomonly;
+using NPairFullSizeMultiAtomonly = NPairMulti<0, 1, 0, 1, 1>;
 NPairStyle(full/size/multi/atomonly,
            NPairFullSizeMultiAtomonly,
            NP_FULL | NP_SIZE | NP_MULTI | NP_ATOMONLY |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMulti<1, 0, 0, 1, 1> NPairHalfSizeMultiAtomonlyNewtoff;
+using NPairHalfSizeMultiAtomonlyNewtoff = NPairMulti<1, 0, 0, 1, 1>;
 NPairStyle(half/size/multi/atomonly/newtoff,
            NPairHalfSizeMultiAtomonlyNewtoff,
            NP_HALF | NP_SIZE | NP_MULTI | NP_ATOMONLY | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMulti<1, 1, 0, 1, 1> NPairHalfSizeMultiAtomonlyNewton;
+using NPairHalfSizeMultiAtomonlyNewton = NPairMulti<1, 1, 0, 1, 1>;
 NPairStyle(half/size/multi/atomonly/newton,
            NPairHalfSizeMultiAtomonlyNewton,
            NP_HALF | NP_SIZE | NP_MULTI | NP_ATOMONLY | NP_NEWTON | NP_ORTHO);
 
-typedef NPairMulti<1, 1, 1, 1, 1> NPairHalfSizeMultiAtomonlyNewtonTri;
+using NPairHalfSizeMultiAtomonlyNewtonTri = NPairMulti<1, 1, 1, 1, 1>;
 NPairStyle(half/size/multi/atomonly/newton/tri,
            NPairHalfSizeMultiAtomonlyNewtonTri,
            NP_HALF | NP_SIZE | NP_MULTI | NP_ATOMONLY | NP_NEWTON | NP_TRI);

--- a/src/npair_multi_old.h
+++ b/src/npair_multi_old.h
@@ -13,44 +13,44 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairMultiOld<0, 1, 0, 0> NPairFullMultiOld;
+using NPairFullMultiOld = NPairMultiOld<0, 1, 0, 0>;
 NPairStyle(full/multi/old,
            NPairFullMultiOld,
            NP_FULL | NP_MULTI_OLD |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMultiOld<1, 0, 0, 0> NPairHalfMultiOldNewtoff;
+using NPairHalfMultiOldNewtoff = NPairMultiOld<1, 0, 0, 0>;
 NPairStyle(half/multi/old/newtoff,
            NPairHalfMultiOldNewtoff,
            NP_HALF | NP_MULTI_OLD | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMultiOld<1, 1, 0, 0> NPairHalfMultiOldNewton;
+using NPairHalfMultiOldNewton = NPairMultiOld<1, 1, 0, 0>;
 NPairStyle(half/multi/old/newton,
            NPairHalfMultiOldNewton,
            NP_HALF | NP_MULTI_OLD | NP_NEWTON | NP_ORTHO);
 
-typedef NPairMultiOld<1, 1, 1, 0> NPairHalfMultiOldNewtonTri;
+using NPairHalfMultiOldNewtonTri = NPairMultiOld<1, 1, 1, 0>;
 NPairStyle(half/multi/old/newton/tri,
            NPairHalfMultiOldNewtonTri,
            NP_HALF | NP_MULTI_OLD | NP_NEWTON | NP_TRI);
 
-typedef NPairMultiOld<0, 1, 0, 1> NPairFullSizeMultiOld;
+using NPairFullSizeMultiOld = NPairMultiOld<0, 1, 0, 1>;
 NPairStyle(full/size/multi/old,
            NPairFullSizeMultiOld,
            NP_FULL | NP_SIZE | NP_MULTI_OLD |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMultiOld<1, 0, 0, 1> NPairHalfSizeMultiOldNewtoff;
+using NPairHalfSizeMultiOldNewtoff = NPairMultiOld<1, 0, 0, 1>;
 NPairStyle(half/size/multi/old/newtoff,
            NPairHalfSizeMultiOldNewtoff,
            NP_HALF | NP_SIZE | NP_MULTI_OLD | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairMultiOld<1, 1, 0, 1> NPairHalfSizeMultiOldNewton;
+using NPairHalfSizeMultiOldNewton = NPairMultiOld<1, 1, 0, 1>;
 NPairStyle(half/size/multi/old/newton,
            NPairHalfSizeMultiOldNewton,
            NP_HALF | NP_SIZE | NP_MULTI_OLD | NP_NEWTON | NP_ORTHO);
 
-typedef NPairMultiOld<1, 1, 1, 1> NPairHalfSizeMultiOldNewtonTri;
+using NPairHalfSizeMultiOldNewtonTri = NPairMultiOld<1, 1, 1, 1>;
 NPairStyle(half/size/multi/old/newton/tri,
            NPairHalfSizeMultiOldNewtonTri,
            NP_HALF | NP_SIZE | NP_MULTI_OLD | NP_NEWTON | NP_TRI);

--- a/src/npair_nsq.h
+++ b/src/npair_nsq.h
@@ -13,42 +13,42 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairNsq<0, 1, 0, 0> NPairFullNsq;
+using NPairFullNsq = NPairNsq<0, 1, 0, 0>;
 NPairStyle(full/nsq,
            NPairFullNsq,
            NP_FULL | NP_NSQ | NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairNsq<1, 0, 0, 0> NPairHalfNsqNewtoff;
+using NPairHalfNsqNewtoff = NPairNsq<1, 0, 0, 0>;
 NPairStyle(half/nsq/newtoff,
            NPairHalfNsqNewtoff,
            NP_HALF | NP_NSQ | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairNsq<1, 1, 0, 0> NPairHalfNsqNewton;
+using NPairHalfNsqNewton = NPairNsq<1, 1, 0, 0>;
 NPairStyle(half/nsq/newton,
            NPairHalfNsqNewton,
            NP_HALF | NP_NSQ | NP_NEWTON | NP_ORTHO);
 
-typedef NPairNsq<1, 1, 1, 0> NPairHalfNsqNewtonTri;
+using NPairHalfNsqNewtonTri = NPairNsq<1, 1, 1, 0>;
 NPairStyle(half/nsq/newton/tri,
            NPairHalfNsqNewtonTri,
            NP_HALF | NP_NSQ | NP_NEWTON | NP_TRI);
 
-typedef NPairNsq<0, 1, 0, 1> NPairFullSizeNsq;
+using NPairFullSizeNsq = NPairNsq<0, 1, 0, 1>;
 NPairStyle(full/size/nsq,
            NPairFullSizeNsq,
            NP_FULL | NP_SIZE | NP_NSQ | NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairNsq<1, 0, 0, 1> NPairHalfSizeNsqNewtoff;
+using NPairHalfSizeNsqNewtoff = NPairNsq<1, 0, 0, 1>;
 NPairStyle(half/size/nsq/newtoff,
            NPairHalfSizeNsqNewtoff,
            NP_HALF | NP_SIZE | NP_NSQ | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairNsq<1, 1, 0, 1> NPairHalfSizeNsqNewton;
+using NPairHalfSizeNsqNewton = NPairNsq<1, 1, 0, 1>;
 NPairStyle(half/size/nsq/newton,
            NPairHalfSizeNsqNewton,
            NP_HALF | NP_SIZE | NP_NSQ | NP_NEWTON | NP_ORTHO);
 
-typedef NPairNsq<1, 1, 1, 1> NPairHalfSizeNsqNewtonTri;
+using NPairHalfSizeNsqNewtonTri = NPairNsq<1, 1, 1, 1>;
 NPairStyle(half/size/nsq/newton/tri,
            NPairHalfSizeNsqNewtonTri,
            NP_HALF | NP_SIZE | NP_NSQ | NP_NEWTON | NP_TRI);

--- a/src/npair_nsq_ghost.h
+++ b/src/npair_nsq_ghost.h
@@ -13,12 +13,12 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairNsqGhost<0> NPairFullNsqGhost;
+using NPairFullNsqGhost = NPairNsqGhost<0>;
 NPairStyle(full/nsq/ghost,
            NPairFullNsqGhost,
            NP_FULL | NP_NSQ | NP_NEWTON | NP_NEWTOFF | NP_GHOST | NP_ORTHO | NP_TRI);
 
-typedef NPairNsqGhost<1> NPairHalfNsqNewtoffGhost;
+using NPairHalfNsqNewtoffGhost = NPairNsqGhost<1>;
 NPairStyle(half/nsq/newtoff/ghost,
            NPairHalfNsqNewtoffGhost,
            NP_HALF | NP_NSQ | NP_NEWTOFF | NP_GHOST | NP_ORTHO | NP_TRI);

--- a/src/npair_respa_bin.h
+++ b/src/npair_respa_bin.h
@@ -13,17 +13,17 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairRespaBin<0, 0> NPairHalfRespaBinNewtoff;
+using NPairHalfRespaBinNewtoff = NPairRespaBin<0, 0>;
 NPairStyle(half/respa/bin/newtoff,
            NPairHalfRespaBinNewtoff,
            NP_HALF | NP_RESPA | NP_BIN | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairRespaBin<1, 0> NPairHalfRespaBinNewton;
+using NPairHalfRespaBinNewton = NPairRespaBin<1, 0>;
 NPairStyle(half/respa/bin/newton,
            NPairHalfRespaBinNewton,
            NP_HALF | NP_RESPA | NP_BIN | NP_NEWTON | NP_ORTHO);
 
-typedef NPairRespaBin<1, 1> NPairHalfRespaBinNewtonTri;
+using NPairHalfRespaBinNewtonTri = NPairRespaBin<1, 1>;
 NPairStyle(half/respa/bin/newton/tri,
            NPairHalfRespaBinNewtonTri,
            NP_HALF | NP_RESPA | NP_BIN | NP_NEWTON | NP_TRI);

--- a/src/npair_respa_nsq.h
+++ b/src/npair_respa_nsq.h
@@ -13,17 +13,17 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairRespaNsq<0,0> NPairHalfRespaNsqNewtoff;
+using NPairHalfRespaNsqNewtoff = NPairRespaNsq<0,0>;
 NPairStyle(half/respa/nsq/newtoff,
            NPairHalfRespaNsqNewtoff,
            NP_HALF | NP_RESPA | NP_NSQ | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairRespaNsq<1,0> NPairHalfRespaNsqNewton;
+using NPairHalfRespaNsqNewton = NPairRespaNsq<1,0>;
 NPairStyle(half/respa/nsq/newton,
            NPairHalfRespaNsqNewton,
            NP_HALF | NP_RESPA | NP_NSQ | NP_NEWTON | NP_ORTHO);
 
-typedef NPairRespaNsq<1,1> NPairHalfRespaNsqNewtonTri;
+using NPairHalfRespaNsqNewtonTri = NPairRespaNsq<1,1>;
 NPairStyle(half/respa/nsq/newton/tri,
            NPairHalfRespaNsqNewtonTri,
            NP_HALF | NP_RESPA | NP_NSQ | NP_NEWTON | NP_TRI);

--- a/src/npair_skip.h
+++ b/src/npair_skip.h
@@ -13,42 +13,42 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairSkipTemp<0> NPairSkip;
+using NPairSkip = NPairSkipTemp<0>;
 NPairStyle(skip,
            NPairSkip,
            NP_SKIP | NP_HALF | NP_FULL |
            NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairSkipTemp<0> NPairSkip;
+using NPairSkip = NPairSkipTemp<0>;
 NPairStyle(skip/ghost,
            NPairSkip,
            NP_SKIP | NP_HALF | NP_FULL |
            NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI | NP_GHOST);
 
-typedef NPairSkipTemp<0> NPairSkipSize;
+using NPairSkipSize = NPairSkipTemp<0>;
 NPairStyle(skip/half/size,
            NPairSkipSize,
            NP_SKIP | NP_SIZE | NP_HALF | NP_FULL |
            NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairSkipTemp<1> NPairSkipTrim;
+using NPairSkipTrim = NPairSkipTemp<1>;
 NPairStyle(skip/trim,
            NPairSkipTrim,
            NP_SKIP | NP_HALF | NP_FULL |
            NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI | NP_TRIM);
 
-typedef NPairSkipTemp<1> NPairSkipTrim;
+using NPairSkipTrim = NPairSkipTemp<1>;
 NPairStyle(skip/ghost/trim,
            NPairSkipTrim,
            NP_SKIP | NP_HALF | NP_FULL |
            NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI | NP_GHOST | NP_TRIM);
 
-typedef NPairSkipTemp<1> NPairSkipTrimSize;
+using NPairSkipTrimSize = NPairSkipTemp<1>;
 NPairStyle(skip/trim/half/size,
            NPairSkipTrimSize,
            NP_SKIP | NP_SIZE | NP_HALF | NP_FULL |

--- a/src/npair_skip_respa.h
+++ b/src/npair_skip_respa.h
@@ -13,14 +13,14 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairSkipRespaTemp<0> NPairSkipRespa;
+using NPairSkipRespa = NPairSkipRespaTemp<0>;
 NPairStyle(skip/half/respa,
            NPairSkipRespa,
            NP_SKIP | NP_RESPA | NP_HALF | NP_FULL |
            NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairSkipRespaTemp<1> NPairSkipTrimRespa;
+using NPairSkipTrimRespa = NPairSkipRespaTemp<1>;
 NPairStyle(skip/trim/half/respa,
            NPairSkipTrimRespa,
            NP_SKIP | NP_RESPA | NP_HALF | NP_FULL |

--- a/src/npair_skip_size_off2on.h
+++ b/src/npair_skip_size_off2on.h
@@ -13,14 +13,14 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairSkipSizeOff2onTemp<0> NPairSkipSizeOff2on;
+using NPairSkipSizeOff2on = NPairSkipSizeOff2onTemp<0>;
 NPairStyle(skip/size/off2on,
            NPairSkipSizeOff2on,
            NP_SKIP | NP_SIZE | NP_OFF2ON | NP_HALF |
            NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD |
            NP_NEWTON | NP_NEWTOFF | NP_ORTHO | NP_TRI);
 
-typedef NPairSkipSizeOff2onTemp<1> NPairSkipTrimSizeOff2on;
+using NPairSkipTrimSizeOff2on = NPairSkipSizeOff2onTemp<1>;
 NPairStyle(skip/trim/size/off2on,
            NPairSkipTrimSizeOff2on,
            NP_SKIP | NP_SIZE | NP_OFF2ON | NP_HALF |

--- a/src/npair_skip_size_off2on_oneside.h
+++ b/src/npair_skip_size_off2on_oneside.h
@@ -13,14 +13,14 @@
 
 #ifdef NPAIR_CLASS
 // clang-format off
-typedef NPairSkipSizeOff2onOnesideTemp<0> NPairSkipSizeOff2onOneside;
+using NPairSkipSizeOff2onOneside = NPairSkipSizeOff2onOnesideTemp<0>;
 NPairStyle(skip/size/off2on/oneside,
            NPairSkipSizeOff2onOneside,
            NP_SKIP | NP_SIZE | NP_OFF2ON | NP_ONESIDE | NP_HALF |
            NP_NSQ | NP_BIN | NP_MULTI | NP_MULTI_OLD | NP_NEWTON | NP_NEWTOFF |
            NP_ORTHO | NP_TRI);
 
-typedef NPairSkipSizeOff2onOnesideTemp<1> NPairSkipTrimSizeOff2onOneside;
+using NPairSkipTrimSizeOff2onOneside = NPairSkipSizeOff2onOnesideTemp<1>;
 NPairStyle(skip/trim/size/off2on/oneside,
            NPairSkipTrimSizeOff2onOneside,
            NP_SKIP | NP_SIZE | NP_OFF2ON | NP_ONESIDE | NP_HALF |

--- a/src/nstencil_bin.h
+++ b/src/nstencil_bin.h
@@ -13,32 +13,32 @@
 
 #ifdef NSTENCIL_CLASS
 // clang-format off
-typedef NStencilBin<0, 0, 0> NStencilFullBin2d;
+using NStencilFullBin2d = NStencilBin<0, 0, 0>;
 NStencilStyle(full/bin/2d,
               NStencilFullBin2d,
               NS_FULL | NS_BIN | NS_2D | NS_ORTHO | NS_TRI);
 
-typedef NStencilBin<0, 1, 0> NStencilFullBin3d;
+using NStencilFullBin3d = NStencilBin<0, 1, 0>;
 NStencilStyle(full/bin/3d,
               NStencilFullBin3d,
               NS_FULL | NS_BIN | NS_3D | NS_ORTHO | NS_TRI);
 
-typedef NStencilBin<1, 0, 0> NStencilHalfBin2d;
+using NStencilHalfBin2d = NStencilBin<1, 0, 0>;
 NStencilStyle(half/bin/2d,
               NStencilHalfBin2d,
               NS_HALF | NS_BIN | NS_2D | NS_ORTHO);
 
-typedef NStencilBin<1, 0, 1> NStencilHalfBin2dTri;
+using NStencilHalfBin2dTri = NStencilBin<1, 0, 1>;
 NStencilStyle(half/bin/2d/tri,
               NStencilHalfBin2dTri,
               NS_HALF | NS_BIN | NS_2D | NS_TRI);
 
-typedef NStencilBin<1, 1, 0> NStencilHalfBin3d;
+using NStencilHalfBin3d = NStencilBin<1, 1, 0>;
 NStencilStyle(half/bin/3d,
               NStencilHalfBin3d,
               NS_HALF | NS_BIN | NS_3D | NS_ORTHO);
 
-typedef NStencilBin<1, 1, 1> NStencilHalfBin3dTri;
+using NStencilHalfBin3dTri = NStencilBin<1, 1, 1>;
 NStencilStyle(half/bin/3d/tri,
               NStencilHalfBin3dTri,
               NS_HALF | NS_BIN | NS_3D | NS_TRI);

--- a/src/nstencil_ghost_bin.h
+++ b/src/nstencil_ghost_bin.h
@@ -13,12 +13,12 @@
 
 #ifdef NSTENCIL_CLASS
 // clang-format off
-typedef NStencilGhostBin<0> NStencilFullGhostBin2d;
+using NStencilFullGhostBin2d = NStencilGhostBin<0>;
 NStencilStyle(full/ghost/bin/2d,
               NStencilFullGhostBin2d,
               NS_FULL | NS_GHOST | NS_BIN | NS_2D | NS_ORTHO | NS_TRI);
 
-typedef NStencilGhostBin<1> NStencilFullGhostBin3d;
+using NStencilFullGhostBin3d = NStencilGhostBin<1>;
 NStencilStyle(full/ghost/bin/3d,
               NStencilFullGhostBin3d,
               NS_FULL | NS_GHOST | NS_BIN | NS_3D | NS_ORTHO | NS_TRI);

--- a/src/nstencil_multi.h
+++ b/src/nstencil_multi.h
@@ -13,32 +13,32 @@
 
 #ifdef NSTENCIL_CLASS
 // clang-format off
-typedef NStencilMulti<0, 0, 0> NStencilFullMulti2d;
+using NStencilFullMulti2d = NStencilMulti<0, 0, 0>;
 NStencilStyle(full/multi/2d,
               NStencilFullMulti2d,
               NS_FULL | NS_MULTI | NS_2D | NS_ORTHO | NS_TRI);
 
-typedef NStencilMulti<0, 1, 0> NStencilFullMulti3d;
+using NStencilFullMulti3d = NStencilMulti<0, 1, 0>;
 NStencilStyle(full/multi/3d,
               NStencilFullMulti3d,
               NS_FULL | NS_MULTI | NS_3D | NS_ORTHO | NS_TRI);
 
-typedef NStencilMulti<1, 0, 0> NStencilHalfMulti2d;
+using NStencilHalfMulti2d = NStencilMulti<1, 0, 0>;
 NStencilStyle(half/multi/2d,
               NStencilHalfMulti2d,
               NS_HALF | NS_MULTI | NS_2D | NS_ORTHO);
 
-typedef NStencilMulti<1, 0, 1> NStencilHalfMulti2dTri;
+using NStencilHalfMulti2dTri = NStencilMulti<1, 0, 1>;
 NStencilStyle(half/multi/2d/tri,
               NStencilHalfMulti2dTri,
               NS_HALF | NS_MULTI | NS_2D | NS_TRI);
 
-typedef NStencilMulti<1, 1, 0> NStencilHalfMulti3d;
+using NStencilHalfMulti3d = NStencilMulti<1, 1, 0>;
 NStencilStyle(half/multi/3d,
               NStencilHalfMulti3d,
               NS_HALF | NS_MULTI | NS_3D | NS_ORTHO);
 
-typedef NStencilMulti<1, 1, 1> NStencilHalfMulti3dTri;
+using NStencilHalfMulti3dTri = NStencilMulti<1, 1, 1>;
 NStencilStyle(half/multi/3d/tri,
               NStencilHalfMulti3dTri,
               NS_HALF | NS_MULTI | NS_3D | NS_TRI);

--- a/src/nstencil_multi_old.h
+++ b/src/nstencil_multi_old.h
@@ -13,32 +13,32 @@
 
 #ifdef NSTENCIL_CLASS
 // clang-format off
-typedef NStencilMultiOld<0, 0, 0> NStencilFullMultiOld2d;
+using NStencilFullMultiOld2d = NStencilMultiOld<0, 0, 0>;
 NStencilStyle(full/multi/old/2d,
               NStencilFullMultiOld2d,
               NS_FULL | NS_MULTI_OLD | NS_2D | NS_ORTHO | NS_TRI);
 
-typedef NStencilMultiOld<0, 1, 0> NStencilFullMultiOld3d;
+using NStencilFullMultiOld3d = NStencilMultiOld<0, 1, 0>;
 NStencilStyle(full/multi/old/3d,
               NStencilFullMultiOld3d,
               NS_FULL | NS_MULTI_OLD | NS_3D | NS_ORTHO | NS_TRI);
 
-typedef NStencilMultiOld<1, 0, 0> NStencilHalfMultiOld2d;
+using NStencilHalfMultiOld2d = NStencilMultiOld<1, 0, 0>;
 NStencilStyle(half/multi/old/2d,
               NStencilHalfMultiOld2d,
               NS_HALF | NS_MULTI_OLD | NS_2D | NS_ORTHO);
 
-typedef NStencilMultiOld<1, 0, 1> NStencilHalfMultiOld2dTri;
+using NStencilHalfMultiOld2dTri = NStencilMultiOld<1, 0, 1>;
 NStencilStyle(half/multi/old/2d/tri,
               NStencilHalfMultiOld2dTri,
               NS_HALF | NS_MULTI_OLD | NS_2D | NS_TRI);
 
-typedef NStencilMultiOld<1, 1, 0> NStencilHalfMultiOld3d;
+using NStencilHalfMultiOld3d = NStencilMultiOld<1, 1, 0>;
 NStencilStyle(half/multi/old/3d,
               NStencilHalfMultiOld3d,
               NS_HALF | NS_MULTI_OLD | NS_3D | NS_ORTHO);
 
-typedef NStencilMultiOld<1, 1, 1> NStencilHalfMultiOld3dTri;
+using NStencilHalfMultiOld3dTri = NStencilMultiOld<1, 1, 1>;
 NStencilStyle(half/multi/old/3d/tri,
               NStencilHalfMultiOld3dTri,
               NS_HALF | NS_MULTI_OLD | NS_3D | NS_TRI);

--- a/src/pair.h
+++ b/src/pair.h
@@ -267,11 +267,12 @@ class Pair : protected Pointers {
 
  public:
   // custom data type for accessing Coulomb tables
-
+  // NOLINTBEGIN
   typedef union {
     int i;
     float f;
   } union_int_float_t;
+  // NOLINTEND
 
   // Accessor for the INTEL package to determine virial calc for hybrid
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2161,7 +2161,7 @@ enum {
   RX_NOT_WHITESPACE /*, BRANCH */
 };
 
-// BEGIN_NOLINT
+// NOLINTBEGIN
 typedef struct regex_t {
   unsigned char type; /* CHAR, STAR, etc.                      */
   union {
@@ -2176,7 +2176,7 @@ typedef struct regex_context_t {
   regex_t re_compiled[MAX_REGEXP_OBJECTS];
   unsigned char ccl_buf[MAX_CHAR_CLASS_LEN];
 } regex_context_t;
-// END_NOLINT
+// NOLINTEND
 
 int re_match(const char *text, const char *pattern)
 {


### PR DESCRIPTION
**Summary**

This pull request contains automated changes performed with clang-tidy for selected files to make LAMMPS follow a more modern C++ programming style and remove C-style programming leftovers.


**Related Issue(s)**

This is a followup to PR #4649 

**Author(s)**

clang-tidy

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

Just ran clang-tidy with only a single checker enabled on selected files and then committed them after review. Most of KOKKOS and INTEL were skipped because of the high risk of clang-tidy making a mess of that heavily templated or preprocessor heavy source files.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the CMake based build system
