### PR TITLE
Remove various deprecation and removal warnings for the stable release

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -3,9 +3,6 @@
 # CMake build system
 # This file is part of LAMMPS
 cmake_minimum_required(VERSION 3.16)
-if(CMAKE_VERSION VERSION_LESS 3.20)
-  message(WARNING "LAMMPS is planning to require at least CMake version 3.20 by Summer 2025. Please upgrade!")
-endif()
 ########################################
 # initialize version variables with project command
 if(POLICY CMP0048)
@@ -155,9 +152,6 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 if(CMAKE_CXX_STANDARD LESS 11)
   message(FATAL_ERROR "C++ standard must be set to at least 11")
-endif()
-if(CMAKE_CXX_STANDARD LESS 17)
-  message(WARNING "Selecting C++17 standard is preferred over C++${CMAKE_CXX_STANDARD}")
 endif()
 if(PKG_KOKKOS AND (CMAKE_CXX_STANDARD LESS 17))
   set(CMAKE_CXX_STANDARD 17)
@@ -359,17 +353,6 @@ set(SUFFIX_PACKAGES CORESHELL GPU KOKKOS OPT INTEL OPENMP)
 
 foreach(PKG ${STANDARD_PACKAGES} ${SUFFIX_PACKAGES})
   option(PKG_${PKG} "Build ${PKG} Package" OFF)
-endforeach()
-
-set(DEPRECATED_PACKAGES AWPMD ATC POEMS)
-foreach(PKG ${DEPRECATED_PACKAGES})
-  if(PKG_${PKG})
-    message(WARNING
-          "The ${PKG} package will be removed from LAMMPS in Summer 2025 due to lack of "
-          "maintenance and use of code constructs that conflict with modern C++ compilers "
-          "and standards.  Please contact developers@lammps.org if you have any concerns "
-          "about this step.")
-  endif()
 endforeach()
 
 ######################################################

--- a/doc/utils/sphinx-config/conf.py.in
+++ b/doc/utils/sphinx-config/conf.py.in
@@ -371,17 +371,6 @@ latex_elements = {
 {%
   \hypersetup{pageanchor=false}% avoid duplicate destination warnings
   \begin{titlepage}%
-    \sffamily\Large
-    The LAMMPS developers are thinking about dropping the PDF format version of
-    the LAMMPS manual.  This would allow us to focus on the HTML version, use
-    HTML-only features, and skip checking if the documentation source files,
-    especially the embedded mathematical expressions, are compatible with \LaTeX{} output.
-
-    Please let us know how you feel about this change by sending an email to
-    \texttt{developers@lammps.org} stating whether you agree or disagree with
-    removing support for the PDF format version of the  manual and optionally
-    provide arguments for your preference.
-    \clearpage
     \sffamily\bfseries
     \begingroup % for PDF information dictionary
       \def\endgraf{ }\def\and{\& }%

--- a/src/ATC/Install.sh
+++ b/src/ATC/Install.sh
@@ -9,19 +9,6 @@ mode=$1
 LC_ALL=C
 export LC_ALL
 
-cat <<EOF
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-
- The ATC package will be removed from LAMMPS in Summer 2025 due to lack of
- maintenance and use of code constructs that conflict with modern C++ compilers
- and standards.  Please contact developers@lammps.org if you have any concerns
- about this step.
-
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-EOF
-
 action () {
   if (test $mode = 0) then
     rm -f ../$1

--- a/src/AWPMD/Install.sh
+++ b/src/AWPMD/Install.sh
@@ -9,19 +9,6 @@ mode=$1
 LC_ALL=C
 export LC_ALL
 
-cat <<EOF
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-
- The AWPMD package will be removed from LAMMPS in Summer 2025 due to lack of
- maintenance and use of code constructs that conflict with modern C++ compilers
- and standards.  Please contact developers@lammps.org if you have any concerns
- about this step.
-
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-EOF
-
 action () {
   if (test $mode = 0) then
     rm -f ../$1

--- a/src/COLVARS/Install.sh
+++ b/src/COLVARS/Install.sh
@@ -9,19 +9,6 @@ mode=$1
 LC_ALL=C
 export LC_ALL
 
-cat <<EOF
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-
-  Support for building the COLVARS package with the legacy build system using GNU
-  make will be removed in Summer 2025.  Please switch to using CMake to build
-  LAMMPS as soon as possible and report any problems to developers@lammps.org
-  or post a bug report issue at https://github.com/lammps/lammps/issues
-
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-EOF
-
 action () {
   if (test $mode = 0) then
     rm -f ../$1

--- a/src/COMPRESS/Install.sh
+++ b/src/COMPRESS/Install.sh
@@ -7,19 +7,6 @@ mode=$1
 LC_ALL=C
 export LC_ALL
 
-cat <<EOF
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-
- Support for building the COMPRESS package with the legacy build system using
- GNU make will be removed in Summer 2025.  Please switch to using CMake to build
- LAMMPS as soon as possible and report any problems to developers@lammps.org
- or post a bug report issue at https://github.com/lammps/lammps/issues
-
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-EOF
-
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/ELECTRODE/Install.sh
+++ b/src/ELECTRODE/Install.sh
@@ -11,19 +11,6 @@ mode=$1
 LC_ALL=C
 export LC_ALL
 
-cat <<EOF
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-
-  Support for building the ELECTRODE package with the legacy build system using
-  GNU make will be removed in Summer 2025.  Please switch to using CMake to build
-  LAMMPS as soon as possible and report any problems to developers@lammps.org
-  or post a bug report issue at https://github.com/lammps/lammps/issues
-
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-EOF
-
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/GPU/Install.sh
+++ b/src/GPU/Install.sh
@@ -7,19 +7,6 @@ mode=$1
 LC_ALL=C
 export LC_ALL
 
-cat <<EOF
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-
-  Support for building the GPU package with the legacy build system using GNU
-  make will be removed in Summer 2025.  Please switch to using CMake to build
-  LAMMPS as soon as possible and report any problems to developers@lammps.org
-  or post a bug report issue at https://github.com/lammps/lammps/issues
-
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-EOF
-
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/KOKKOS/Install.sh
+++ b/src/KOKKOS/Install.sh
@@ -7,19 +7,6 @@ mode=$1
 LC_ALL=C
 export LC_ALL
 
-cat <<EOF
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-
-  Support for building the KOKKOS package with the legacy build system using GNU
-  make will be removed in Summer 2025.  Please switch to using CMake to build
-  LAMMPS as soon as possible and report any problems to developers@lammps.org
-  or post a bug report issue at https://github.com/lammps/lammps/issues
-
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-EOF
-
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/LEPTON/Install.sh
+++ b/src/LEPTON/Install.sh
@@ -9,19 +9,6 @@ mode=$1
 LC_ALL=C
 export LC_ALL
 
-cat <<EOF
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-
-  Support for building the LEPTON package with the legacy build system using GNU
-  make will be removed in Summer 2025.  Please switch to using CMake to build
-  LAMMPS as soon as possible and report any problems to developers@lammps.org
-  or post a bug report issue at https://github.com/lammps/lammps/issues
-
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-EOF
-
 action () {
   if (test $mode = 0) then
     rm -f ../$1

--- a/src/ML-POD/Install.sh
+++ b/src/ML-POD/Install.sh
@@ -7,19 +7,6 @@ mode=$1
 LC_ALL=C
 export LC_ALL
 
-cat <<EOF
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-
- Support for building the ML-POD package with the legacy build system using GNU
- make will be removed in Summer 2025.  Please switch to using CMake to build
- LAMMPS as soon as possible and report any problems to developers@lammps.org
- or post a bug report issue at https://github.com/lammps/lammps/issues
-
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-EOF
-
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/PLUMED/Install.sh
+++ b/src/PLUMED/Install.sh
@@ -7,19 +7,6 @@ mode=$1
 LC_ALL=C
 export LC_ALL
 
-cat <<EOF
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-
-  Support for building the PLUMED package with the legacy build system using GNU
-  make will be removed in Summer 2025.  Please switch to using CMake to build
-  LAMMPS as soon as possible and report any problems to developers@lammps.org
-  or post a bug report issue at https://github.com/lammps/lammps/issues
-
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-EOF
-
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/POEMS/Install.sh
+++ b/src/POEMS/Install.sh
@@ -9,19 +9,6 @@ mode=$1
 LC_ALL=C
 export LC_ALL
 
-cat <<EOF
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-
- The POEMS package will be removed from LAMMPS in Summer 2025 due to lack of
- maintenance and use of code constructs that conflict with modern C++ compilers
- and standards.  Please contact developers@lammps.org if you have any concerns
- about this step.
-
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-EOF
-
 action () {
   if (test $mode = 0) then
     rm -f ../$1

--- a/src/VTK/Install.sh
+++ b/src/VTK/Install.sh
@@ -7,19 +7,6 @@ mode=$1
 LC_ALL=C
 export LC_ALL
 
-cat <<EOF
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-
-  Support for building the VTK package with the legacy build system using GNU
-  make will be removed in Summer 2025.  Please switch to using CMake to build
-  LAMMPS as soon as possible and report any problems to developers@lammps.org
-  or post a bug report issue at https://github.com/lammps/lammps/issues
-
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING-WARNING
-EOF
-
 # arg1 = file, arg2 = file it depends on
 
 action () {

--- a/src/lmptype.h
+++ b/src/lmptype.h
@@ -34,13 +34,6 @@
 #error LAMMPS requires a C++11 (or later) compliant compiler. Enable C++11 compatibility or upgrade the compiler.
 #endif
 
-// C++17 check
-#ifndef LAMMPS_CXX11
-#if __cplusplus < 201703L
-#error LAMMPS is planning to transition to requiring C++17. To disable this error please use a C++17 compliant compiler, enable C++17 support, or define -DLAMMPS_CXX11 in your makefile or when running cmake
-#endif
-#endif
-
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
 #endif


### PR DESCRIPTION
**Summary**

Since the stable release is "frozen" we don't need the warnings that were intended for developers.

**Related Issue(s)**

N/A

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
