### PR TITLE
Collected small changes and fixes

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -615,15 +615,6 @@ if(WITH_SWIG)
 endif()
 
 ########################################################################
-# Basic system tests (standard libraries, headers, functions, types)   #
-########################################################################
-if (NOT ((CMAKE_CXX_COMPILER_ID STREQUAL "Intel") OR (CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")))
-  check_include_file_cxx(cmath FOUND_CMATH)
-  if(NOT FOUND_CMATH)
-    message(FATAL_ERROR "Could not find the required 'cmath' header")
-  endif(NOT FOUND_CMATH)
-endif()
-
 # make the standard math library overrideable and autodetected (for systems that don't have it)
 find_library(STANDARD_MATH_LIB m DOC "Standard Math library")
 mark_as_advanced(STANDARD_MATH_LIB)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -137,7 +137,7 @@ endif()
 # silence nvcc warnings when using nvcc_wrapper
 get_filename_component(LAMMPS_CXX_COMPILER_NAME "${CMAKE_CXX_COMPILER}" NAME CACHE)
 if((PKG_KOKKOS) AND (Kokkos_ENABLE_CUDA) AND (LAMMPS_CXX_COMPILER_NAME STREQUAL "nvcc_wrapper"))
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xcudafe --diag_suppress=unrecognized_pragma,--diag_suppress=128")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xcudafe --diag_suppress=unrecognized_pragma,--diag_suppress=128,--diag_suppress=186")
 endif()
 
 # we *require* C++11 without extensions but prefer C++17.

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -134,10 +134,9 @@ if((CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC") OR (CMAKE_CXX_COMPILER_ID STREQUAL "
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Minform=severe")
 endif()
 
-# silence nvcc warnings
-if((PKG_KOKKOS) AND (Kokkos_ENABLE_CUDA) AND NOT
-    ((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") OR (CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
-    OR (CMAKE_CXX_COMPILER_ID STREQUAL "XLClang") OR (CMAKE_CXX_COMPILER_ID STREQUAL "CrayClang")))
+# silence nvcc warnings when using nvcc_wrapper
+get_filename_component(LAMMPS_CXX_COMPILER_NAME "${CMAKE_CXX_COMPILER}" NAME CACHE)
+if((PKG_KOKKOS) AND (Kokkos_ENABLE_CUDA) AND (LAMMPS_CXX_COMPILER_NAME STREQUAL "nvcc_wrapper"))
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xcudafe --diag_suppress=unrecognized_pragma,--diag_suppress=128")
 endif()
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -137,7 +137,7 @@ endif()
 # silence nvcc warnings when using nvcc_wrapper
 get_filename_component(LAMMPS_CXX_COMPILER_NAME "${CMAKE_CXX_COMPILER}" NAME CACHE)
 if((PKG_KOKKOS) AND (Kokkos_ENABLE_CUDA) AND (LAMMPS_CXX_COMPILER_NAME STREQUAL "nvcc_wrapper"))
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xcudafe --diag_suppress=unrecognized_pragma,--diag_suppress=128,--diag_suppress=186")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xcudafe --diag_suppress=unrecognized_pragma,--diag_suppress=128,--diag_suppress=186,-Wno-deprecated-gpu-targets")
 endif()
 
 # we *require* C++11 without extensions but prefer C++17.

--- a/cmake/presets/kokkos-cuda-nowrapper.cmake
+++ b/cmake/presets/kokkos-cuda-nowrapper.cmake
@@ -1,10 +1,8 @@
-# preset that enables KOKKOS and selects CUDA compilation using the nvcc_wrapper
+# preset that enables KOKKOS and selects CUDA compilation without nvcc_wrapper
 # enabled as well. The GPU architecture *must* match your hardware (If not manually set, Kokkos will try to autodetect it).
 set(PKG_KOKKOS ON CACHE BOOL "" FORCE)
 set(Kokkos_ENABLE_SERIAL ON CACHE BOOL "" FORCE)
 set(Kokkos_ENABLE_CUDA   ON CACHE BOOL "" FORCE)
-get_filename_component(NVCC_WRAPPER_CMD ${CMAKE_CURRENT_SOURCE_DIR}/../lib/kokkos/bin/nvcc_wrapper ABSOLUTE)
-set(CMAKE_CXX_COMPILER ${NVCC_WRAPPER_CMD} CACHE FILEPATH "" FORCE)
 
 # If KSPACE is also enabled, use CUFFT for FFTs
 set(FFT_KOKKOS "CUFFT" CACHE STRING "" FORCE)

--- a/cmake/presets/kokkos-openmp.cmake
+++ b/cmake/presets/kokkos-openmp.cmake
@@ -2,7 +2,6 @@
 set(PKG_KOKKOS ON CACHE BOOL "" FORCE)
 set(Kokkos_ENABLE_SERIAL ON  CACHE BOOL "" FORCE)
 set(Kokkos_ENABLE_OPENMP ON  CACHE BOOL "" FORCE)
-set(Kokkos_ENABLE_CUDA   OFF CACHE BOOL "" FORCE)
 set(BUILD_OMP ON CACHE BOOL "" FORCE)
 
 # hide deprecation warnings temporarily for stable release

--- a/cmake/presets/kokkos-serial.cmake
+++ b/cmake/presets/kokkos-serial.cmake
@@ -1,8 +1,6 @@
 # preset that enables KOKKOS and selects serial compilation only
 set(PKG_KOKKOS ON CACHE BOOL "" FORCE)
 set(Kokkos_ENABLE_SERIAL ON  CACHE BOOL "" FORCE)
-set(Kokkos_ENABLE_OPENMP OFF CACHE BOOL "" FORCE)
-set(Kokkos_ENABLE_CUDA   OFF CACHE BOOL "" FORCE)
 
 # hide deprecation warnings temporarily for stable release
 set(Kokkos_ENABLE_DEPRECATION_WARNINGS OFF CACHE BOOL "" FORCE)

--- a/doc/src/Build_extras.rst
+++ b/doc/src/Build_extras.rst
@@ -522,7 +522,7 @@ to have an executable that will run on this and newer architectures.
    the new hardware.  This is, however, only supported for GPUs of the
    **same** major hardware version and different minor hardware versions,
    e.g. 5.0 and 5.2 but not 5.2 and 6.0.  LAMMPS will abort with an
-   error message indicating a mismatch, if that happens.
+   error message indicating a mismatch, if the major version differs.
 
 The settings discussed below have been tested with LAMMPS and are
 confirmed to work.  Kokkos is an active project with ongoing improvements
@@ -794,23 +794,29 @@ This list was last updated for version 4.6.2 of the Kokkos library.
 
       This will enable FFTs on the GPU using the oneMKL library.
 
-      To simplify compilation, six preset files are included in the
+      To simplify compilation, seven preset files are included in the
       ``cmake/presets`` folder, ``kokkos-serial.cmake``,
       ``kokkos-openmp.cmake``, ``kokkos-cuda.cmake``,
-      ``kokkos-hip.cmake``, ``kokkos-sycl-nvidia.cmake``, and
-      ``kokkos-sycl-intel.cmake``.  They will enable the KOKKOS
-      package and enable some hardware choices.  For GPU support those
-      preset files must be customized to match the hardware used. So
-      to compile with CUDA device parallelization with some common
-      packages enabled, you can do the following:
+      ``kokkos-cuda-nowrapper.cmake``, ``kokkos-hip.cmake``,
+      ``kokkos-sycl-nvidia.cmake``, and ``kokkos-sycl-intel.cmake``.
+      They will enable the KOKKOS package and enable some hardware
+      choices.  For GPU support those preset files may need to be
+      customized to match the hardware used.  For some platforms,
+      e.g. CUDA, the Kokkos library will try to auto-detect a suitable
+      configuration.  So to compile with CUDA device parallelization
+      with some common packages enabled, you can do the following:
 
       .. code-block:: bash
 
          mkdir build-kokkos-cuda
          cd build-kokkos-cuda
          cmake -C ../cmake/presets/basic.cmake \
-               -C ../cmake/presets/kokkos-cuda.cmake ../cmake
+               -C ../cmake/presets/kokkos-cuda-nowrapper.cmake ../cmake
          cmake --build .
+
+      The ``kokkos-openmp.cmake`` preset can be combined with any of the
+      others, but it is not possible to combine multiple GPU
+      acceleration settings (CUDA, HIP, SYCL) into a single executable.
 
    .. tab:: Basic traditional make settings:
 

--- a/src/KOKKOS/pair_eam_alloy_kokkos.cpp
+++ b/src/KOKKOS/pair_eam_alloy_kokkos.cpp
@@ -34,7 +34,7 @@
 #include <cmath>
 using namespace LAMMPS_NS;
 
-#define MAX_CACHE_ROWS 500
+static constexpr int MAX_CACHE_ROWS = 500;
 
 // Cannot use virtual inheritance on the GPU, so must duplicate code
 

--- a/src/KOKKOS/pair_eam_alloy_kokkos.cpp
+++ b/src/KOKKOS/pair_eam_alloy_kokkos.cpp
@@ -34,8 +34,9 @@
 #include <cmath>
 using namespace LAMMPS_NS;
 
+#ifdef KOKKOS_ENABLE_HIP
 static constexpr int MAX_CACHE_ROWS = 500;
-
+#endif
 // Cannot use virtual inheritance on the GPU, so must duplicate code
 
 /* ---------------------------------------------------------------------- */
@@ -835,7 +836,7 @@ void PairEAMAlloyKokkos<DeviceType>::operator()(TagPairEAMAlloyKernelC<NEIGHFLAG
 }
 
 /* ---------------------------------------------------------------------- */
-
+#ifdef KOKKOS_ENABLE_HIP
 ////Specialisation for Neighborlist types Half, HalfThread, Full
 template<class DeviceType>
 template<int EFLAG>
@@ -920,7 +921,7 @@ void PairEAMAlloyKokkos<DeviceType>::operator()(TagPairEAMAlloyKernelAB<EFLAG>,
     }
   }
 }
-
+#endif
 template<class DeviceType>
 template<int EFLAG>
 KOKKOS_INLINE_FUNCTION
@@ -931,7 +932,7 @@ void PairEAMAlloyKokkos<DeviceType>::operator()(TagPairEAMAlloyKernelAB<EFLAG>,
 }
 
 /* ---------------------------------------------------------------------- */
-
+#ifdef KOKKOS_ENABLE_HIP
 ////Specialisation for Neighborlist types Half, HalfThread, Full
 template<class DeviceType>
 template<int NEIGHFLAG, int NEWTON_PAIR, int EVFLAG>
@@ -1052,7 +1053,7 @@ void PairEAMAlloyKokkos<DeviceType>::operator()(TagPairEAMAlloyKernelC<NEIGHFLAG
     a_f(i,2) += fztmp;
   }
 }
-
+#endif
 template<class DeviceType>
 template<int NEIGHFLAG, int NEWTON_PAIR, int EVFLAG>
 KOKKOS_INLINE_FUNCTION

--- a/src/KOKKOS/pair_eam_fs_kokkos.cpp
+++ b/src/KOKKOS/pair_eam_fs_kokkos.cpp
@@ -34,8 +34,9 @@
 #include <cmath>
 using namespace LAMMPS_NS;
 
+#ifdef KOKKOS_ENABLE_HIP
 static constexpr int MAX_CACHE_ROWS = 500;
-
+#endif
 // Cannot use virtual inheritance on the GPU, so must duplicate code
 
 /* ---------------------------------------------------------------------- */
@@ -835,7 +836,7 @@ void PairEAMFSKokkos<DeviceType>::operator()(TagPairEAMFSKernelC<NEIGHFLAG,NEWTO
 }
 
 /* ---------------------------------------------------------------------- */
-
+#ifdef KOKKOS_ENABLE_HIP
 ////Specialisation for Neighborlist types Half, HalfThread, Full
 template<class DeviceType>
 template<int EFLAG>
@@ -920,7 +921,7 @@ void PairEAMFSKokkos<DeviceType>::operator()(TagPairEAMFSKernelAB<EFLAG>,
     }
   }
 }
-
+#endif
 template<class DeviceType>
 template<int EFLAG>
 KOKKOS_INLINE_FUNCTION
@@ -933,6 +934,7 @@ void PairEAMFSKokkos<DeviceType>::operator()(TagPairEAMFSKernelAB<EFLAG>,
 /* ---------------------------------------------------------------------- */
 
 ////Specialisation for Neighborlist types Half, HalfThread, Full
+#ifdef KOKKOS_ENABLE_HIP
 template<class DeviceType>
 template<int NEIGHFLAG, int NEWTON_PAIR, int EVFLAG>
 KOKKOS_INLINE_FUNCTION
@@ -1052,7 +1054,7 @@ void PairEAMFSKokkos<DeviceType>::operator()(TagPairEAMFSKernelC<NEIGHFLAG,NEWTO
     a_f(i,2) += fztmp;
   }
 }
-
+#endif
 template<class DeviceType>
 template<int NEIGHFLAG, int NEWTON_PAIR, int EVFLAG>
 KOKKOS_INLINE_FUNCTION

--- a/src/KOKKOS/pair_eam_kokkos.cpp
+++ b/src/KOKKOS/pair_eam_kokkos.cpp
@@ -33,8 +33,9 @@
 #include <cmath>
 using namespace LAMMPS_NS;
 
+#ifdef KOKKOS_ENABLE_HIP
 static constexpr int MAX_CACHE_ROWS = 500;
-
+#endif
 /* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
@@ -830,7 +831,7 @@ void PairEAMKokkos<DeviceType>::operator()(TagPairEAMKernelC<NEIGHFLAG,NEWTON_PA
 }
 
 /* ---------------------------------------------------------------------- */
-
+#ifdef KOKKOS_ENABLE_HIP
 ////Specialisation for Neighborlist types Half, HalfThread, Full
 template<class DeviceType>
 template<int EFLAG>
@@ -915,7 +916,7 @@ void PairEAMKokkos<DeviceType>::operator()(TagPairEAMKernelAB<EFLAG>,
     }
   }
 }
-
+#endif
 template<class DeviceType>
 template<int EFLAG>
 KOKKOS_INLINE_FUNCTION
@@ -926,7 +927,7 @@ void PairEAMKokkos<DeviceType>::operator()(TagPairEAMKernelAB<EFLAG>,
 }
 
 /* ---------------------------------------------------------------------- */
-
+#ifdef KOKKOS_ENABLE_HIP
 ////Specialisation for Neighborlist types Half, HalfThread, Full
 template<class DeviceType>
 template<int NEIGHFLAG, int NEWTON_PAIR, int EVFLAG>
@@ -1047,7 +1048,7 @@ void PairEAMKokkos<DeviceType>::operator()(TagPairEAMKernelC<NEIGHFLAG,NEWTON_PA
     a_f(i,2) += fztmp;
   }
 }
-
+#endif
 template<class DeviceType>
 template<int NEIGHFLAG, int NEWTON_PAIR, int EVFLAG>
 KOKKOS_INLINE_FUNCTION

--- a/src/ML-POD/eapod.cpp
+++ b/src/ML-POD/eapod.cpp
@@ -172,7 +172,7 @@ void EAPOD::read_pod_file(const std::string &pod_file)
 
     if (words.size() == 0) continue;
 
-    auto keywd = words[0];
+    const auto &keywd = words[0];
 
     if (keywd == "species") {
       nelements = words.size()-1;

--- a/src/ML-RANN/rann_activation_linear.h
+++ b/src/ML-RANN/rann_activation_linear.h
@@ -43,9 +43,9 @@ namespace RANN {
       style = "linear";
     }
 
-    double activation_function(double A) { return A; }
-    double dactivation_function(double) { return 1.0; }
-    double ddactivation_function(double) { return 0.0; }
+    double activation_function(double A) override { return A; }
+    double dactivation_function(double) override { return 1.0; }
+    double ddactivation_function(double) override { return 0.0; }
   };
 
 }    // namespace RANN

--- a/src/ML-RANN/rann_activation_sig_i.h
+++ b/src/ML-RANN/rann_activation_sig_i.h
@@ -44,17 +44,17 @@ namespace RANN {
       style = "sigI";
     }
 
-    double activation_function(double in)
+    double activation_function(double in) override
     {
       if (in > 34) return in;
       return 0.1 * in + 0.9 * log(exp(in) + 1);
     }
-    double dactivation_function(double in)
+    double dactivation_function(double in) override
     {
       if (in > 34) return 1;
       return 0.1 + 0.9 / (exp(in) + 1) * exp(in);
     }
-    double ddactivation_function(double in)
+    double ddactivation_function(double in) override
     {
       if (in > 34) return 0;
       return 0.9 * exp(in) / (exp(in) + 1) / (exp(in) + 1);

--- a/src/REACTION/fix_bond_react.cpp
+++ b/src/REACTION/fix_bond_react.cpp
@@ -908,7 +908,7 @@ void FixBondReact::post_integrate()
   int nevery_check = 1;
   for (int i = 0; i < nreacts; i++) {
     if (var_flag[NEVERY][i])
-      nevery[i] = ceil(input->variable->compute_equal(var_id[NEVERY][i]));
+      nevery[i] = ceil(input->variable->compute_equal(var_id[NEVERY][i])); // NOLINT
     if (nevery[i] <= 0)
       error->all(FLERR,"Illegal fix bond/react command: "
                  "'Nevery' must be a positive integer");
@@ -987,7 +987,7 @@ void FixBondReact::post_integrate()
         int nrxns_delta = reaction_count_total[rxnID] - myrxn_count;
         int my_nrate;
         if (var_flag[NRATE][rxnID] == 1) {
-          my_nrate = input->variable->compute_equal(var_id[NRATE][rxnID]);
+          my_nrate = input->variable->compute_equal(var_id[NRATE][rxnID]); // NOLINT
         } else my_nrate = rate_limit[1][rxnID];
         if (nrxns_delta >= my_nrate) rate_limit_flag = 0;
       }
@@ -1502,7 +1502,7 @@ void FixBondReact::superimpose_algorithm()
         int nrxn_delta = reaction_count_total[i] + delta_rxn[i] - myrxn_count;
         int my_nrate;
         if (var_flag[NRATE][i] == 1) {
-          my_nrate = input->variable->compute_equal(var_id[NRATE][i]);
+          my_nrate = input->variable->compute_equal(var_id[NRATE][i]); // NOLINT
         } else my_nrate = rate_limit[1][i];
         int rate_limit_overstep = nrxn_delta - my_nrate;
         overstep = MAX(overstep,rate_limit_overstep);
@@ -2118,7 +2118,7 @@ int FixBondReact::check_constraints()
       memory->destroy(xmobile);
       if (rmsd > constraints[i][rxnID].par[0]) satisfied[i] = 0;
     } else if (constraints[i][rxnID].type == CUSTOM) {
-      satisfied[i] = custom_constraint(constraints[i][rxnID].str);
+      satisfied[i] = custom_constraint(constraints[i][rxnID].str); // NOLINT
     }
   }
 
@@ -2767,7 +2767,7 @@ void FixBondReact::dedup_mega_gloves(int dedup_mode)
   auto *temp_rxn = new double[max_natoms+cuff];
   for (int i = dedup_size-1; i > 0; --i) { //dedup_size
     // choose random entry to swap current one with
-    int k = floor(random[0]->uniform()*(i+1));
+    int k = floor(random[0]->uniform()*(i+1)); // NOLINT
 
     // swap entries
     for (int j = 0; j < max_natoms+cuff; j++)
@@ -2782,16 +2782,16 @@ void FixBondReact::dedup_mega_gloves(int dedup_mode)
 
   for (int i = 0; i < dedup_size; i++) {
     if (dedup_mask[i] == 0) {
-      int myrxnid1 = dedup_glove[0][i];
+      int myrxnid1 = dedup_glove[0][i]; // NOLINT
       onemol = atom->molecules[unreacted_mol[myrxnid1]];
       for (int j = 0; j < onemol->natoms; j++) {
-        int check1 = dedup_glove[j+cuff][i];
+        int check1 = dedup_glove[j+cuff][i]; // NOLINT
         for (int ii = i + 1; ii < dedup_size; ii++) {
           if (dedup_mask[ii] == 0) {
-            int myrxnid2 = dedup_glove[0][ii];
+            int myrxnid2 = dedup_glove[0][ii]; // NOLINT
             twomol = atom->molecules[unreacted_mol[myrxnid2]];
             for (int jj = 0; jj < twomol->natoms; jj++) {
-              int check2 = dedup_glove[jj+cuff][ii];
+              int check2 = dedup_glove[jj+cuff][ii]; // NOLINT
               if (check2 == check1) {
                 dedup_mask[ii] = 1;
                 break;

--- a/src/REAXFF/reaxff_inline.h
+++ b/src/REAXFF/reaxff_inline.h
@@ -56,7 +56,7 @@ struct cubic_spline_coef {
   }
 
   LAMMPS_INLINE
-  cubic_spline_coef &operator=(const cubic_spline_coef &rhs)
+  cubic_spline_coef &operator=(const cubic_spline_coef &rhs) // NOLINT
   {
     a = rhs.a;
     b = rhs.b;

--- a/src/math_eigen_impl.h
+++ b/src/math_eigen_impl.h
@@ -487,7 +487,7 @@ Jacobi<Scalar, Vector, Matrix, ConstMatrix>::
 
 template<typename Scalar,typename Vector,typename Matrix,typename ConstMatrix>
 Jacobi<Scalar, Vector, Matrix, ConstMatrix>::
-Jacobi(int n, Scalar **M, int *max_idx_row) {
+Jacobi(int n, Scalar **M, int *max_idx_row) : c(std::sqrt(2.0)), s(std::sqrt(2.0)) , t(1.0) {
   _Jacobi(n, M, max_idx_row);
 }
 


### PR DESCRIPTION
**Summary**

This pull request contains multiple small changes and fixes that don't warrant a pull request of their own.

**Related Issue(s)**

N/A

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

The following individual changes are included:
- a few more changes to address or suppress warnings from static code analysis
- revise logic to automatically suppress pointless warnings from `nvcc` when using `nvcc_wrapper`
- add more warnings to suppress when using `nvcc_wrapper`
- new cmake preset for Kokkos/CUDA to configure without using `nvcc_wrapper`
- ifdef Kokkos/HIP-only code path in pair styles `eam/kk`, `eam/alloy/kk`, and `eam/fs/kk`
- remove obsolete check for the presence of the `cmath` header file

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
