### PR TITLE
add the MN15 D3(BJ) parameter to `pair d3`

### DIFF
--- a/doc/src/pair_dispersion_d3.rst
+++ b/doc/src/pair_dispersion_d3.rst
@@ -85,7 +85,7 @@ and depend on the selected damping function.
 | | bj             | | o-lyp, pbesol, bpbe, opbe, ssb, revssb, otpss, b3pw91, bh-lyp, revpbe0,      |
 | |                | | tpssh, mpw1b95, pwb6k, b1b95, bmk, cam-b3lyp, lc-wpbe, b2gp-plyp, ptpss,     |
 | |                | | pwpb95, hf/mixed, hf/sv, hf/minis, b3lyp/6-31gd, hcth120, pw1pw, pwgga,      |
-| |                | | hsesol, hf3c, hf3cv, pbeh3c, pbeh-3c                                         |
+| |                | | hsesol, hf3c, hf3cv, pbeh3c, pbeh-3c, mn15                                   |
 +------------------+--------------------------------------------------------------------------------+
 | bjm              |  b2-plyp, b3-lyp, b97-d, b-lyp, b-p, pbe, pbe0, lc-wpbe                        |
 +------------------+--------------------------------------------------------------------------------+

--- a/src/EXTRA-PAIR/pair_dispersion_d3.cpp
+++ b/src/EXTRA-PAIR/pair_dispersion_d3.cpp
@@ -1060,7 +1060,8 @@ void PairDispersionD3::set_funcpar(std::string &functional_name)
           {"lc-wpbe", 37},  {"b2gp-plyp", 38},   {"ptpss", 39},    {"pwpb95", 40},
           {"hf/mixed", 41}, {"hf/sv", 42},       {"hf/minis", 43}, {"b3-lyp/6-31gd", 44},
           {"hcth120", 45},  {"pw1pw", 46},       {"pwgga", 47},    {"hsesol", 48},
-          {"hf3c", 49},     {"hf3cv", 50},       {"pbeh3c", 51},   {"pbeh-3c", 52}};
+          {"hf3c", 49},     {"hf3cv", 50},       {"pbeh3c", 51},   {"pbeh-3c", 52},
+          {"mn15", 53}};
 
       int functionalCode = functionalMap[functional_name];
       switch (functionalCode) {
@@ -1338,6 +1339,11 @@ void PairDispersionD3::set_funcpar(std::string &functional_name)
           a1 = 0.4860;
           s8 = 0.0000;
           a2 = 4.5000;
+          break;
+        case 53:
+          a1 = 2.0971;
+          s8 = 0.7862;
+          a2 = 7.5923;
           break;
         default:
           error->all(FLERR, Error::NOLASTLINE,


### PR DESCRIPTION
**Summary**

<!--Briefly describe the new feature(s), enhancement(s), or bugfix(es) included in this pull request.-->
Add the MN15 D3(BJ) parameter to `pair d3`. Machine learning potential models trained against the MN15 functional have been used by LAMMPS in several publications (including mine) as follows, but the D3 correction has never been combined (while the dispersion is important). So it will be valuable to add the MN15 parameter.

- https://doi.org/10.1038/s41467-020-19497-z
- https://doi.org/10.1021/acs.energyfuels.0c03211
- https://doi.org/10.1016/j.cej.2024.151492
- https://doi.org/10.1039/D3CP05425J
- https://doi.org/10.1016/j.combustflame.2025.114039
- https://doi.org/10.1021/acs.jpca.3c07859

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->

**Author(s)**

<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request. If this pull request adds new files to the distribution, please also provide a suitable "long-lived" e-mail address (ideally something that can outlive your institution's e-mail, in case you change jobs) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this contributed code.-->
Jinzhe Zeng (University of Science and Technology of China) jinzhe.zeng@ustc.edu.cn

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->
N/A

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->
The parameter is copied from https://github.com/dftd3/simple-dftd3/blob/442fbec1b0cf249359358ed247d90731d4da4b37/assets/parameters.toml#L422-L423.

What are the criteria for including parameters of functionals in LAMMPS? I am not sure why only a set of functionals are included.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


