### PR TITLE
Colvars bugfixes targeting LAMMPS maintenance release

### DIFF
--- a/lib/colvars/colvarbias_meta.cpp
+++ b/lib/colvars/colvarbias_meta.cpp
@@ -564,7 +564,27 @@ int colvarbias_meta::update_bias()
       cvm::real hills_energy_sum_here = 0.0;
       if (use_grids) {
         std::vector<int> curr_bin = hills_energy->get_colvars_index();
-        hills_energy_sum_here = hills_energy->value(curr_bin);
+        const bool index_ok = hills_energy->index_ok(curr_bin);
+        if (index_ok) {
+          // TODO: Should I sum the energies from other replicas?
+          hills_energy_sum_here = hills_energy->value(curr_bin);
+        } else {
+          if (!keep_hills) {
+            // TODO: Should I sum the off-grid hills from other replicas?
+            calc_hills(hills_off_grid.begin(),
+                       hills_off_grid.end(),
+                       hills_energy_sum_here,
+                       &colvar_values);
+          } else {
+            // TODO: Is it better to compute the energy from all historic hills
+            //       when keepHills is on?
+            calc_hills(hills.begin(),
+                       hills.end(),
+                       hills_energy_sum_here,
+                       &colvar_values);
+          }
+          // cvm::log("WARNING: computing bias factor for off-grid hills. Hills energy: " + cvm::to_str(hills_energy_sum_here) + "\n");
+        }
       } else {
         calc_hills(new_hills_begin, hills.end(), hills_energy_sum_here, NULL);
       }

--- a/lib/colvars/colvarcomp_coordnums.cpp
+++ b/lib/colvars/colvarcomp_coordnums.cpp
@@ -54,7 +54,14 @@ cvm::real colvar::coordnum::switching_function(cvm::real const &r0,
   cvm::real const xn = cvm::integer_power(l2, en2);
   cvm::real const xd = cvm::integer_power(l2, ed2);
   //The subtraction and division stretches the function back to the range of [0,1] from [pairlist_tol,1]
-  cvm::real const func = (((1.0-xn)/(1.0-xd)) - pairlist_tol) / (1.0-pairlist_tol);
+  cvm::real const func_no_pairlist = (1.0-xn)/(1.0-xd);
+  cvm::real func, inv_one_pairlist_tol;
+  if (flags & ef_use_pairlist) {
+    inv_one_pairlist_tol = 1 / (1.0-pairlist_tol);
+    func = (func_no_pairlist - pairlist_tol) * inv_one_pairlist_tol;
+  } else {
+    func = func_no_pairlist;
+  }
 
   if (flags & ef_rebuild_pairlist) {
     //Particles just outside of the cutoff also are considered if they come near.
@@ -74,7 +81,12 @@ cvm::real colvar::coordnum::switching_function(cvm::real const &r0,
     //                                        func*ed2*(xd/l2))*(-1.0);
     //Recognizing that func = (1.0-xn)/(1.0-xd), we can group together the "func" and get a version of dFdl2 that is 0
     //when func=0, which lets us skip this gradient calculation when func=0.
-    cvm::real const dFdl2 = func * ((ed2*xd/((1.0-xd)*l2)) - (en2*xn/((1.0-xn)*l2)));
+    cvm::real dFdl2;
+    if (flags & ef_use_pairlist) {
+      dFdl2 = func_no_pairlist * inv_one_pairlist_tol * ((ed2*xd/((1.0-xd)*l2)) - (en2*xn/((1.0-xn)*l2)));
+    } else {
+      dFdl2 = func * ((ed2*xd/((1.0-xd)*l2)) - (en2*xn/((1.0-xn)*l2)));
+    }
     cvm::rvector const dl2dx((2.0/((flags & ef_anisotropic) ? r0sq_vec.x :
                                    r0*r0)) * diff.x,
                              (2.0/((flags & ef_anisotropic) ? r0sq_vec.y :
@@ -167,12 +179,14 @@ int colvar::coordnum::init(std::string const &conf)
                         COLVARS_INPUT_ERROR);
       // return and do not allocate the pairlists below
     }
+    size_t n;
     if (b_group2_center_only) {
-      pairlist = new bool[group1->size()];
+      n = group1->size();
+    } else {
+      n = group1->size() * group2->size();
     }
-    else {
-      pairlist = new bool[group1->size() * group2->size()];
-    }
+    pairlist = new bool[n];
+    for (size_t i = 0; i < n; i++) pairlist[i] = true;
   }
 
   init_scalar_boundaries(0.0, b_group2_center_only ?
@@ -424,7 +438,9 @@ int colvar::selfcoordnum::init(std::string const &conf)
       error_code |= cvm::error("Error: non-positive pairlistfrequency provided.\n",
                                COLVARS_INPUT_ERROR);
     }
-    pairlist = new bool[(group1->size()-1) * (group1->size()-1)];
+    size_t n = (group1->size()-1) * (group1->size()-1);
+    pairlist = new bool[n];
+    for (size_t i = 0; i < n; i++) pairlist[i] = true;
   }
 
   init_scalar_boundaries(0.0, static_cast<cvm::real>((group1->size()-1) *

--- a/lib/colvars/colvarcomp_distances.cpp
+++ b/lib/colvars/colvarcomp_distances.cpp
@@ -192,25 +192,23 @@ int colvar::distance_z::init(std::string const &conf)
 
 void colvar::distance_z::calc_value()
 {
+  cvm::rvector const M = main->center_of_mass();
+  cvm::rvector const R1 = ref1->center_of_mass();
   if (fixed_axis) {
     if (!is_enabled(f_cvc_pbc_minimum_image)) {
-      dist_v = main->center_of_mass() - ref1->center_of_mass();
+      dist_v = M - R1;
     } else {
-      dist_v = cvm::position_distance(ref1->center_of_mass(),
-                                      main->center_of_mass());
+      dist_v = cvm::position_distance(R1, M);
     }
   } else {
-
+    cvm::rvector const R2 = ref2->center_of_mass();
+    cvm::rvector const C = 0.5 * (R1 + R2);
     if (!is_enabled(f_cvc_pbc_minimum_image)) {
-      dist_v = main->center_of_mass() -
-               (0.5 * (ref1->center_of_mass() + ref2->center_of_mass()));
-      axis = ref2->center_of_mass() - ref1->center_of_mass();
+      dist_v = M - C;
+      axis = R2 - R1;
     } else {
-      dist_v = cvm::position_distance(0.5 * (ref1->center_of_mass() +
-                                             ref2->center_of_mass()),
-                                      main->center_of_mass());
-      axis = cvm::position_distance(ref1->center_of_mass(),
-                                    ref2->center_of_mass());
+      dist_v = cvm::position_distance(C, M);
+      axis = cvm::position_distance(R1, R2);
     }
     axis_norm = axis.norm();
     axis = axis.unit();
@@ -227,21 +225,14 @@ void colvar::distance_z::calc_gradients()
   if (fixed_axis) {
     ref1->set_weighted_gradient(-1.0 * axis);
   } else {
-    if (!is_enabled(f_cvc_pbc_minimum_image)) {
-      ref1->set_weighted_gradient( 1.0 / axis_norm *
-                                   (main->center_of_mass() - ref2->center_of_mass() -
-                                   x.real_value * axis ));
-      ref2->set_weighted_gradient( 1.0 / axis_norm *
-                                   (ref1->center_of_mass() - main->center_of_mass() +
-                                   x.real_value * axis ));
-    } else {
-      ref1->set_weighted_gradient( 1.0 / axis_norm * (
-        cvm::position_distance(ref2->center_of_mass(),
-                               main->center_of_mass()) - x.real_value * axis ));
-      ref2->set_weighted_gradient( 1.0 / axis_norm * (
-        cvm::position_distance(main->center_of_mass(),
-                               ref1->center_of_mass()) + x.real_value * axis ));
-    }
+    // Perpendicular term: (M - C) - Â(Â·(M - C)) = (M - C) - Â x
+    cvm::rvector const perp_term = dist_v - axis * x.real_value;
+    // ∂x/∂R₁ = -common_term/‖A‖ - (1/2)Â
+    cvm::rvector const grad_R1 = -perp_term / axis_norm - 0.5 * axis;
+    // ∂x/∂R₂ = common_term/‖A‖ - (1/2)Â
+    cvm::rvector const grad_R2 = perp_term / axis_norm - 0.5 * axis;
+    ref1->set_weighted_gradient(grad_R1);
+    ref2->set_weighted_gradient(grad_R2);
   }
 }
 
@@ -1132,8 +1123,6 @@ int colvar::eigenvector::init(std::string const &conf)
     atoms->enable(f_ag_rotate);
     atoms->ref_pos = ref_pos;
     atoms->center_ref_pos();
-    atoms->disable(f_ag_fit_gradients); // cancel out if group is fitted on itself
-                                        // and cvc is translationally invariant
   }
   atoms->setup_rotation_derivative();
 

--- a/lib/colvars/colvarcomp_rotations.cpp
+++ b/lib/colvars/colvarcomp_rotations.cpp
@@ -135,15 +135,16 @@ void colvar::orientation::apply_force(colvarvalue const &force)
   cvm::quaternion const &FQ = force.quaternion_value;
 
   if (!atoms->noforce) {
+    const cvm::real sign = (rot.q).inner(ref_quat) >= 0.0 ? 1.0 : -1.0;
     rot_deriv_impl->prepare_derivative(rotation_derivative_dldq::use_dq);
     cvm::vector1d<cvm::rvector> dq0_2;
     auto ag_force = atoms->get_group_force_object();
     for (size_t ia = 0; ia < atoms->size(); ia++) {
       rot_deriv_impl->calc_derivative_wrt_group2<false, true, false>(ia, nullptr, &dq0_2);
-      const auto f_ia = FQ[0] * dq0_2[0] +
+      const auto f_ia = sign * (FQ[0] * dq0_2[0] +
                         FQ[1] * dq0_2[1] +
                         FQ[2] * dq0_2[2] +
-                        FQ[3] * dq0_2[3];
+                        FQ[3] * dq0_2[3]);
       ag_force.add_atom_force(ia, f_ia);
     }
   }
@@ -200,8 +201,9 @@ void colvar::orientation_angle::calc_value()
 
 void colvar::orientation_angle::calc_gradients()
 {
+  const cvm::real sign = (rot.q).q0 >= 0.0 ? 1.0 : -1.0;
   cvm::real const dxdq0 =
-    ( ((rot.q).q0 * (rot.q).q0 < 1.0) ?
+    sign * ( ((rot.q).q0 * (rot.q).q0 < 1.0) ?
       ((180.0 / PI) * (-2.0) / cvm::sqrt(1.0 - ((rot.q).q0 * (rot.q).q0))) :
       0.0 );
 

--- a/lib/colvars/colvarmodule.h
+++ b/lib/colvars/colvarmodule.h
@@ -89,7 +89,7 @@ private:
   int version_int = 0;
 
   /// Patch version number (non-zero in patch releases of other packages)
-  int patch_version_int = 0;
+  int patch_version_int = 1;
 
 public:
 

--- a/lib/colvars/colvartypes.h
+++ b/lib/colvars/colvartypes.h
@@ -957,11 +957,6 @@ public:
 
   cvm::real q0, q1, q2, q3;
 
-  /// Constructor from a 3-d vector
-  inline quaternion(cvm::real x, cvm::real y, cvm::real z)
-    : q0(0.0), q1(x), q2(y), q3(z)
-  {}
-
   /// Constructor component by component
   inline quaternion(cvm::real const qv[4])
     : q0(qv[0]), q1(qv[1]), q2(qv[2]), q3(qv[3])
@@ -979,47 +974,15 @@ public:
     : q0(v[0]), q1(v[1]), q2(v[2]), q3(v[3])
   {}
 
-  /// "Constructor" after Euler angles (in radians)
-  ///
-  /// http://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
-  inline void set_from_euler_angles(cvm::real phi_in,
-                                    cvm::real theta_in,
-                                    cvm::real psi_in)
-  {
-    q0 = ( (cvm::cos(phi_in/2.0)) * (cvm::cos(theta_in/2.0)) * (cvm::cos(psi_in/2.0)) +
-           (cvm::sin(phi_in/2.0)) * (cvm::sin(theta_in/2.0)) * (cvm::sin(psi_in/2.0)) );
-
-    q1 = ( (cvm::sin(phi_in/2.0)) * (cvm::cos(theta_in/2.0)) * (cvm::cos(psi_in/2.0)) -
-           (cvm::cos(phi_in/2.0)) * (cvm::sin(theta_in/2.0)) * (cvm::sin(psi_in/2.0)) );
-
-    q2 = ( (cvm::cos(phi_in/2.0)) * (cvm::sin(theta_in/2.0)) * (cvm::cos(psi_in/2.0)) +
-           (cvm::sin(phi_in/2.0)) * (cvm::cos(theta_in/2.0)) * (cvm::sin(psi_in/2.0)) );
-
-    q3 = ( (cvm::cos(phi_in/2.0)) * (cvm::cos(theta_in/2.0)) * (cvm::sin(psi_in/2.0)) -
-           (cvm::sin(phi_in/2.0)) * (cvm::sin(theta_in/2.0)) * (cvm::cos(psi_in/2.0)) );
-  }
-
   /// \brief Default constructor
   inline quaternion()
   {
     reset();
   }
 
-  /// \brief Set all components to a scalar
-  inline void set(cvm::real value)
-  {
-    q0 = q1 = q2 = q3 = value;
-  }
-
-  /// \brief Set all components to zero (null quaternion)
-  inline void reset()
-  {
-    set(0.0);
-  }
-
   /// \brief Set the q0 component to 1 and the others to 0 (quaternion
   /// representing no rotation)
-  inline void reset_rotation()
+  inline void reset()
   {
     q0 = 1.0;
     q1 = q2 = q3 = 0.0;


### PR DESCRIPTION
**Summary**

Colvars library bugfixes

**Related Issue(s)**

PRs in Colvars repo linked below (they link issues there as well)

**Author(s)**

@giacomofiorin, @HanatoK, @jhenin

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Bugfixes

**Implementation Notes**

Only the library code is updated

The following is a list of bugfix pull requests in Colvars affecting LAMMPS merged since 2025-04-30:

- 838 More functional tests https://github.com/Colvars/colvars/pull/838 (@jhenin, @giacomofiorin)

- 829 fix: try fixing the orientation sign https://github.com/Colvars/colvars/pull/829 (@HanatoK)
 fix: fix the gradients of the eigenvector CVC https://github.com/Colvars/colvars/pull/828 (@HanatoK, @jhenin)

- 824 fix: fix a potential issue of "fit gradients" for non-scalar components with only centering but not rotating https://github.com/Colvars/colvars/pull/824 (@HanatoK, @jhenin)

- 808 fix: fix the calculation of bias factor with off-grid hills https://github.com/Colvars/colvars/pull/808 (@HanatoK)

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

