### PR TITLE
Collected small changes and fixes

### DIFF
--- a/doc/src/Build_extras.rst
+++ b/doc/src/Build_extras.rst
@@ -243,7 +243,7 @@ necessary for ``hipcc`` and the linker to work correctly.
 When compiling for HIP ROCm, GPU sorting with ``-D
 HIP_USE_DEVICE_SORT=on`` requires installing the ``hipcub`` library
 (https://github.com/ROCmSoftwarePlatform/hipCUB).  The HIP CUDA-backend
-additionally requires cub (https://nvlabs.github.io/cub).  Setting
+additionally requires cub (https://nvidia.github.io/cccl/cub/).  Setting
 ``-DDOWNLOAD_CUB=yes`` will download and compile CUB.
 
 The GPU library has some multi-thread support using OpenMP.  If LAMMPS

--- a/doc/src/Errors_details.rst
+++ b/doc/src/Errors_details.rst
@@ -1068,3 +1068,22 @@ also increase the value for the "page" parameter to maintain the ratio
 between "one" and "page" to reduce waste of memory.  For some more
 details, please check out the documentation for the :doc:`neigh_modify
 command <neigh_modify>`.
+
+.. _err0037:
+
+Variable ...: Compute/Fix ... does not compute requested property
+-----------------------------------------------------------------
+
+Compute and fix styles can compute different kinds of properties: for
+example, global scalars, vectors, or arrays, or per-atom vectors or
+arrays.  In equal-style or similar variable, only scalar properties can
+be used, so to access a particular element in a vector one has to use
+square brackets with a suitable index to select it.  However, not all
+fixes and computes provide all types of properties.  So this error
+message will be shown if there is a mismatch, of if there are not
+enough or too many square brackets.  To differentiate between
+accessing an element of a global array or a per-atom array element of
+a specific atom, one has to use a reference with a lower case 'c'
+(e.g. 'c_name') for the former and upper case 'C' (e.g. 'C_name') for
+the latter. The same applies to fix styles.  The full details are
+in the documentation for the :doc:`variable command <variable>`.

--- a/doc/src/Howto_mdi.rst
+++ b/doc/src/Howto_mdi.rst
@@ -138,7 +138,7 @@ the ``examples/QUANTUM`` sub-directories for more details:
 
 There are also at least two quantum codes which have direct MDI
 support, `Quantum ESPRESSO (QE) <https://www.quantum-espresso.org/>`_
-and `INQ <https://qsg.llnl.gov/node/101.html>`_.  There are also
+and `INQ <https://gitlab.com/npneq/inq>`_.  There are also
 several QM codes which have indirect support through QCEngine or i-PI.
 The former means they require a wrapper program (QCEngine) with MDI
 support which writes/read files to pass data to the quantum code

--- a/doc/src/fix_external.rst
+++ b/doc/src/fix_external.rst
@@ -71,14 +71,8 @@ which is typically a 32-bit integer unless LAMMPS is compiled with
 <size>` section of the manual.  Finally, *fexternal* are the forces
 returned by the driver program.
 
-The fix has a set_callback() method which the external driver can call
-to pass a pointer to its foo() function.  See the
-couple/lammps_quest/lmpqst.cpp file in the LAMMPS distribution for an
-example of how this is done.  This sample application performs
-classical MD using quantum forces computed by a density functional
-code `Quest <quest_>`_.
-
-.. _quest: https://www.sandia.gov/quest/
+The best way to set up the callback function is to use the C-language
+library interface function :cpp:func:`lammps_set_fix_external_callback`.
 
 ----------
 

--- a/doc/src/fix_phonon.rst
+++ b/doc/src/fix_phonon.rst
@@ -134,7 +134,7 @@ for other systems, *nasr* = 10 is typically sufficient.
 The *map_file* contains the mapping information between the lattice
 indices and the atom IDs, which tells the code which atom sits at
 which lattice point; the lattice indices start from 0. An auxiliary
-code, `latgen <https://code.google.com/p/latgen>`_, can be employed to
+code, `latgen <https://code.google.com/archive/p/latgen>`_, can be employed to
 generate the compatible map file for various crystals.
 
 In case one simulates a non-periodic system, where the whole simulation

--- a/src/EXTRA-DUMP/dump_extxyz.h
+++ b/src/EXTRA-DUMP/dump_extxyz.h
@@ -36,9 +36,11 @@ class DumpExtXYZ : public DumpXYZ {
   int with_temp;
   int with_press;
   char *properties_string;
+  char *thermo_string;
 
   void update_properties();
   void init_style() override;
+  int count() override;
   void write_header(bigint) override;
   void pack(tagint *) override;
   int convert_string(int, double *) override;

--- a/src/KOKKOS/fix_spring_self_kokkos.cpp
+++ b/src/KOKKOS/fix_spring_self_kokkos.cpp
@@ -80,10 +80,11 @@ void FixSpringSelfKokkos<DeviceType>::init()
   FixSpringSelf::init();
 
   if (kstyle != CONSTANT)
-    error->all(FLERR, "Fix spring/self/kk does not support variable spring constants (yet)");
+    error->all(FLERR, Error::NOLASTLINE,
+               "Fix spring/self/kk does not support variable spring constants (yet)");
 
   if (utils::strmatch(update->integrate_style,"^respa"))
-    error->all(FLERR,"Cannot (yet) use respa with Kokkos");
+    error->all(FLERR, Error::NOLASTLINE, "Cannot (yet) use respa with Kokkos");
 }
 
 /* ---------------------------------------------------------------------- */
@@ -107,47 +108,45 @@ void FixSpringSelfKokkos<DeviceType>::post_force(int /*vflag*/)
   copymode = 1;
 
   {
-  // local variables for lambda capture
-  auto prd = Few<double,3>(domain->prd);
-  auto h = Few<double,6>(domain->h);
-  auto triclinic = domain->triclinic;
-  auto l_k = k;
-  auto l_xoriginal = d_xoriginal;
+    // local variables for lambda capture
+    auto prd = Few<double,3>(domain->prd);
+    auto h = Few<double,6>(domain->h);
+    auto triclinic = domain->triclinic;
+    auto l_k = k;
+    auto l_xoriginal = d_xoriginal;
 
-  auto l_x = x;
-  auto l_f = f;
-  auto l_mask = mask;
-  auto l_image = image;
-  auto l_groupbit = groupbit;
-  auto l_xflag = xflag;
-  auto l_yflag = yflag;
-  auto l_zflag = zflag;
+    auto l_x = x;
+    auto l_f = f;
+    auto l_mask = mask;
+    auto l_image = image;
+    auto l_groupbit = groupbit;
+    auto l_xflag = xflag;
+    auto l_yflag = yflag;
+    auto l_zflag = zflag;
 
-  Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType>(0,nlocal), LAMMPS_LAMBDA(const int& i, double& espring_kk) {
-    if (l_mask[i] & l_groupbit) {
-      Few<double,3> x_i;
-      x_i[0] = l_x(i,0);
-      x_i[1] = l_x(i,1);
-      x_i[2] = l_x(i,2);
-      auto unwrap = DomainKokkos::unmap(prd,h,triclinic,x_i,l_image(i));
-      auto dx = unwrap[0] - l_xoriginal(i, 0);
-      auto dy = unwrap[1] - l_xoriginal(i, 1);
-      auto dz = unwrap[2] - l_xoriginal(i, 2);
-      if (!l_xflag) dx = 0.0;
-      if (!l_yflag) dy = 0.0;
-      if (!l_zflag) dz = 0.0;
-      l_f(i,0) -= l_k*dx;
-      l_f(i,1) -= l_k*dy;
-      l_f(i,2) -= l_k*dz;
-      espring_kk += l_k * (dx*dx + dy*dy + dz*dz);
-    }
-  },espring_kk);
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType>(0,nlocal), LAMMPS_LAMBDA(const int& i, double& espring_kk) {
+        if (l_mask[i] & l_groupbit) {
+          Few<double,3> x_i;
+          x_i[0] = l_x(i,0);
+          x_i[1] = l_x(i,1);
+          x_i[2] = l_x(i,2);
+          auto unwrap = DomainKokkos::unmap(prd,h,triclinic,x_i,l_image(i));
+          auto dx = unwrap[0] - l_xoriginal(i, 0);
+          auto dy = unwrap[1] - l_xoriginal(i, 1);
+          auto dz = unwrap[2] - l_xoriginal(i, 2);
+          if (!l_xflag) dx = 0.0;
+          if (!l_yflag) dy = 0.0;
+          if (!l_zflag) dz = 0.0;
+          l_f(i,0) -= l_k*dx;
+          l_f(i,1) -= l_k*dy;
+          l_f(i,2) -= l_k*dz;
+          espring_kk += l_k * (dx*dx + dy*dy + dz*dz);
+        }
+      },espring_kk);
   }
 
   copymode = 0;
-
   atomKK->modified(execution_space, F_MASK);
-
   espring = 0.5*espring_kk;
 }
 

--- a/src/KSPACE/fft3d.cpp
+++ b/src/KSPACE/fft3d.cpp
@@ -264,12 +264,12 @@ struct fft_plan_3d *fft_3d_create_plan(
   MPI_Comm_rank(comm,&me);
   MPI_Comm_size(comm,&nprocs);
 
+#if defined(FFT_MKL_THREADS) || defined(FFT_FFTW_THREADS)
 #if defined(_OPENMP)
   // query OpenMP info.
   // should have been initialized systemwide in Comm class constructor
   int nthreads = omp_get_max_threads();
 #else
-#if defined(FFT_MKL_THREADS) || defined(FFT_FFTW_THREADS)
   int nthreads = 1;
 #endif
 #endif

--- a/src/KSPACE/fft3d.cpp
+++ b/src/KSPACE/fft3d.cpp
@@ -251,7 +251,7 @@ struct fft_plan_3d *fft_3d_create_plan(
        int scaled, int permute, int *nbuf, int usecollective)
 {
   struct fft_plan_3d *plan;
-  int me,nprocs,nthreads;
+  int me,nprocs;
   int flag,remapflag;
   int first_ilo,first_ihi,first_jlo,first_jhi,first_klo,first_khi;
   int second_ilo,second_ihi,second_jlo,second_jhi,second_klo,second_khi;
@@ -267,9 +267,11 @@ struct fft_plan_3d *fft_3d_create_plan(
 #if defined(_OPENMP)
   // query OpenMP info.
   // should have been initialized systemwide in Comm class constructor
-  nthreads = omp_get_max_threads();
+  int nthreads = omp_get_max_threads();
 #else
-  nthreads = 1;
+#if defined(FFT_MKL_THREADS) || defined(FFT_FFTW_THREADS)
+  int nthreads = 1;
+#endif
 #endif
 
   // compute division of procs in 2 dimensions not on-processor

--- a/src/KSPACE/kissfft.h
+++ b/src/KSPACE/kissfft.h
@@ -158,7 +158,7 @@ static void kiss_fft(kiss_fft_cfg, const FFT_DATA *, FFT_DATA *);
     (x)->im = KISS_FFT_SIN(phase); \
   } while (0)
 
-static void kf_bfly2(FFT_DATA *Fout, const size_t fstride, const kiss_fft_cfg st, int m)
+static void kf_bfly2(FFT_DATA *Fout, const size_t fstride, kiss_fft_cfg st, int m)
 {
   FFT_DATA *Fout2;
   FFT_DATA *tw1 = st->twiddles;
@@ -178,7 +178,7 @@ static void kf_bfly2(FFT_DATA *Fout, const size_t fstride, const kiss_fft_cfg st
   } while (--m);
 }
 
-static void kf_bfly4(FFT_DATA *Fout, const size_t fstride, const kiss_fft_cfg st, const size_t m)
+static void kf_bfly4(FFT_DATA *Fout, const size_t fstride, kiss_fft_cfg st, const size_t m)
 {
   FFT_DATA *tw1, *tw2, *tw3;
   FFT_DATA scratch[6];
@@ -223,7 +223,7 @@ static void kf_bfly4(FFT_DATA *Fout, const size_t fstride, const kiss_fft_cfg st
   } while (--k);
 }
 
-static void kf_bfly3(FFT_DATA *Fout, const size_t fstride, const kiss_fft_cfg st, size_t m)
+static void kf_bfly3(FFT_DATA *Fout, const size_t fstride, kiss_fft_cfg st, size_t m)
 {
   size_t k = m;
   const size_t m2 = 2 * m;
@@ -264,7 +264,7 @@ static void kf_bfly3(FFT_DATA *Fout, const size_t fstride, const kiss_fft_cfg st
   } while (--k);
 }
 
-static void kf_bfly5(FFT_DATA *Fout, const size_t fstride, const kiss_fft_cfg st, int m)
+static void kf_bfly5(FFT_DATA *Fout, const size_t fstride, kiss_fft_cfg st, int m)
 {
   FFT_DATA *Fout0, *Fout1, *Fout2, *Fout3, *Fout4;
   int u;
@@ -329,7 +329,7 @@ static void kf_bfly5(FFT_DATA *Fout, const size_t fstride, const kiss_fft_cfg st
 }
 
 /* perform the butterfly for one stage of a mixed radix FFT */
-static void kf_bfly_generic(FFT_DATA *Fout, const size_t fstride, const kiss_fft_cfg st, int m,
+static void kf_bfly_generic(FFT_DATA *Fout, const size_t fstride, kiss_fft_cfg st, int m,
                             int p)
 {
   int u, k, q1, q;
@@ -363,7 +363,7 @@ static void kf_bfly_generic(FFT_DATA *Fout, const size_t fstride, const kiss_fft
 }
 
 static void kf_work(FFT_DATA *Fout, const FFT_DATA *f, const size_t fstride, int in_stride,
-                    int *factors, const kiss_fft_cfg st)
+                    int *factors, kiss_fft_cfg st)
 {
   FFT_DATA *Fout_beg = Fout;
   const int p = *factors++; /* the radix  */

--- a/src/KSPACE/kissfft.h
+++ b/src/KSPACE/kissfft.h
@@ -337,7 +337,7 @@ static void kf_bfly_generic(FFT_DATA *Fout, const size_t fstride, const kiss_fft
   FFT_DATA t;
   int Norig = st->nfft;
 
-  FFT_DATA *scratch = (FFT_DATA *) KISS_FFT_TMP_ALLOC(sizeof(FFT_DATA) * p);
+  auto *scratch = (FFT_DATA *) KISS_FFT_TMP_ALLOC(sizeof(FFT_DATA) * p);
   for (u = 0; u < m; ++u) {
     k = u;
     for (q1 = 0; q1 < p; ++q1) {
@@ -482,7 +482,7 @@ static void kiss_fft_stride(kiss_fft_cfg st, const FFT_DATA *fin, FFT_DATA *fout
   if (fin == fout) {
     // NOTE: this is not really an in-place FFT algorithm.
     // It just performs an out-of-place FFT into a temp buffer
-    FFT_DATA *tmpbuf = (FFT_DATA *) KISS_FFT_TMP_ALLOC(sizeof(FFT_DATA) * st->nfft);
+    auto *tmpbuf = (FFT_DATA *) KISS_FFT_TMP_ALLOC(sizeof(FFT_DATA) * st->nfft);
     kf_work(tmpbuf, fin, 1, in_stride, st->factors, st);
     memcpy(fout, tmpbuf, sizeof(FFT_DATA) * st->nfft);
     KISS_FFT_TMP_FREE(tmpbuf);

--- a/src/fix_spring_self.cpp
+++ b/src/fix_spring_self.cpp
@@ -55,7 +55,7 @@ FixSpringSelf::FixSpringSelf(LAMMPS *lmp, int narg, char **arg) :
   } else {
     k = utils::numeric(FLERR,arg[3],false,lmp);
     kstyle = CONSTANT;
-    if (k <= 0.0) error->all(FLERR,"Illegal force constant for fix spring/self command");
+    if (k <= 0.0) error->all(FLERR, 3, "Illegal force constant for fix spring/self command");
   }
 
   xflag = yflag = zflag = 1;
@@ -138,13 +138,16 @@ void FixSpringSelf::init()
 
   if (kstr) {
     kvar = input->variable->find(kstr);
-    if (kvar < 0) error->all(FLERR, "Variable {} for fix spring/self does not exist", kstr);
-    if (input->variable->equalstyle(kvar))
+    if (kvar < 0)
+      error->all(FLERR, Error::NOLASTLINE, "Variable {} for fix spring/self does not exist", kstr);
+    if (input->variable->equalstyle(kvar)) {
       kstyle = EQUAL;
-    else if (input->variable->atomstyle(kvar))
+    } else if (input->variable->atomstyle(kvar)) {
       kstyle = ATOM;
-    else
-      error->all(FLERR, "Variable {} for fix spring/self is invalid style", kstr);
+    } else {
+      error->all(FLERR, Error::NOLASTLINE, "Variable {} for fix spring/self is invalid style",
+                 kstr);
+    }
   }
 
 
@@ -207,7 +210,8 @@ void FixSpringSelf::post_force(int /*vflag*/)
     if (kstyle == EQUAL) {
       k = input->variable->compute_equal(kvar);
       if (k < 0.0)
-        error->all(FLERR,"Evaluation of {} gave bad value {} for fix spring/self", kstr, k);
+        error->all(FLERR, Error::NOLASTLINE,
+                   "Evaluation of {} gave bad value {} for fix spring/self", kstr, k);
     }
     for (int i = 0; i < nlocal; i++)
       if (mask[i] & groupbit) {

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -509,7 +509,7 @@ bigint Thermo::lost_check()
     warnbefore = 1;
     if (comm->me == 0)
       utils::logmesg(
-          lmp, "WARNING: Too many warnings: {} vs {}. All future warnings willbe suppressed\n",
+          lmp, "WARNING: Too many warnings: {} vs {}. All future warnings will be suppressed\n",
           ntotal[1], maxwarn);
   }
   error->set_allwarn(MIN(MAXSMALLINT, ntotal[1]));

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1592,6 +1592,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           }
         }
 
+        auto mismatch_msg = fmt::format("Compute '{}' in variable formula does not compute the "
+                                    "requested property. {}", compute->id, utils::errorurl(37));
+
         // equal-style or immediate variable is being evaluated
 
         if ((ivar < 0) || (style[ivar] == EQUAL)) {
@@ -1601,7 +1604,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           if (lowercase && nbracket == 0) {
 
             if (!compute->scalar_flag)
-              print_var_error(FLERR,"Mismatched compute in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (!compute->is_initialized())
               print_var_error(FLERR,"Variable formula compute cannot be invoked before "
                               "initialization by a run",ivar);
@@ -1618,7 +1621,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           } else if (lowercase && nbracket == 1) {
 
             if (!compute->vector_flag)
-              print_var_error(FLERR,"Mismatched compute in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (!compute->is_initialized())
               print_var_error(FLERR,"Variable formula compute cannot be invoked before "
                               "initialization by a run",ivar);
@@ -1642,7 +1645,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           } else if (lowercase && nbracket == 2) {
 
             if (!compute->array_flag)
-              print_var_error(FLERR,"Mismatched compute in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (index2 > compute->size_array_cols)
               print_var_error(FLERR,"Variable formula compute array is accessed out-of-range"
                               + utils::errorurl(20), ivar, 0);
@@ -1669,9 +1672,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           } else if (!lowercase && nbracket == 1) {
 
             if (!compute->peratom_flag)
-              print_var_error(FLERR,"Mismatched compute in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (compute->size_peratom_cols)
-              print_var_error(FLERR,"Mismatched compute in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (!compute->is_initialized())
               print_var_error(FLERR,"Variable formula compute cannot be invoked before "
                               "initialization by a run",ivar);
@@ -1688,9 +1691,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           } else if (!lowercase && nbracket == 2) {
 
             if (!compute->peratom_flag)
-              print_var_error(FLERR,"Mismatched compute in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (!compute->size_peratom_cols)
-              print_var_error(FLERR,"Mismatched compute in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (index2 > compute->size_peratom_cols)
               print_var_error(FLERR,"Variable formula compute array is accessed out-of-range"
                               + utils::errorurl(20), ivar,0);
@@ -1712,7 +1715,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
 
           // no other possibilities for equal-style variable, so error
 
-          } else print_var_error(FLERR,"Mismatched compute in variable formula",ivar);
+          } else print_var_error(FLERR, mismatch_msg, ivar);
 
         // vector-style variable is being evaluated
 
@@ -1723,7 +1726,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           if (lowercase && nbracket == 0) {
 
             if (!compute->vector_flag)
-              print_var_error(FLERR,"Mismatched compute in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (!compute->is_initialized())
               print_var_error(FLERR,"Variable formula compute cannot be invoked before "
                               "initialization by a run",ivar);
@@ -1750,7 +1753,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           } else if (lowercase && nbracket == 1) {
 
             if (!compute->array_flag)
-              print_var_error(FLERR,"Mismatched compute in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (!compute->is_initialized())
               print_var_error(FLERR,"Variable formula compute cannot be invoked before "
                               "initialization by a run",ivar);
@@ -1777,7 +1780,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
 
           // no other possibilities for vector-style variable, so error
 
-          } else print_var_error(FLERR,"Mismatched compute in variable formula",ivar);
+          } else print_var_error(FLERR, mismatch_msg, ivar);
 
         // atom-style variable is being evaluated
 
@@ -1788,9 +1791,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           if (lowercase && nbracket == 0) {
 
             if (!compute->peratom_flag)
-              print_var_error(FLERR,"Mismatched compute in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (compute->size_peratom_cols)
-              print_var_error(FLERR,"Mismatched compute in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (!compute->is_initialized())
               print_var_error(FLERR,"Variable formula compute cannot be invoked before "
                               "initialization by a run",ivar);
@@ -1810,9 +1813,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           } else if (lowercase && nbracket == 1) {
 
             if (!compute->peratom_flag)
-              print_var_error(FLERR,"Mismatched compute in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (!compute->size_peratom_cols)
-              print_var_error(FLERR,"Mismatched compute in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (index1 > compute->size_peratom_cols)
               print_var_error(FLERR,"Variable formula compute array is accessed out-of-range"
                               + utils::errorurl(20), ivar,0);
@@ -1834,7 +1837,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
 
           // no other possibilities for atom-style variable, so error
 
-          } else print_var_error(FLERR,"Mismatched compute in variable formula",ivar);
+          } else print_var_error(FLERR, mismatch_msg, ivar);
         }
 
       // ----------------
@@ -1877,6 +1880,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           }
         }
 
+        auto mismatch_msg = fmt::format("Fix '{}' in variable formula does not compute the "
+                                    "requested property. {}", fix->id, utils::errorurl(37));
+
         // equal-style or immediate variable is being evaluated
 
         if ((ivar < 0) || (style[ivar] == EQUAL)) {
@@ -1886,7 +1892,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           if (lowercase && nbracket == 0) {
 
             if (!fix->scalar_flag)
-              print_var_error(FLERR,"Mismatched fix in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (update->whichflag > 0 && update->ntimestep % fix->global_freq)
               print_var_error(FLERR,"Fix in variable not computed at a compatible time"
                               + utils::errorurl(7), ivar);
@@ -1899,7 +1905,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           } else if (lowercase && nbracket == 1) {
 
             if (!fix->vector_flag)
-              print_var_error(FLERR,"Mismatched fix in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (index1 > fix->size_vector && fix->size_vector_variable == 0)
               print_var_error(FLERR,"Variable formula fix vector is accessed out-of-range"
                               + utils::errorurl(20), ivar,0);
@@ -1919,7 +1925,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           } else if (lowercase && nbracket == 2) {
 
             if (!fix->array_flag)
-              print_var_error(FLERR,"Mismatched fix in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (index1 > fix->size_array_rows && fix->size_array_rows_variable == 0)
               print_var_error(FLERR,"Variable formula fix array is accessed out-of-range"
                               + utils::errorurl(20), ivar,0);
@@ -1942,9 +1948,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           } else if (!lowercase && nbracket == 1) {
 
             if (!fix->peratom_flag)
-              print_var_error(FLERR,"Mismatched fix in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (fix->size_peratom_cols)
-              print_var_error(FLERR,"Mismatched fix in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (update->whichflag > 0 &&
                 update->ntimestep % fix->peratom_freq)
               print_var_error(FLERR,"Fix in variable not computed at a compatible time"
@@ -1958,9 +1964,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           } else if (!lowercase && nbracket == 2) {
 
             if (!fix->peratom_flag)
-              print_var_error(FLERR,"Mismatched fix in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (!fix->size_peratom_cols)
-              print_var_error(FLERR,"Mismatched fix in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (index2 > fix->size_peratom_cols)
               print_var_error(FLERR,"Variable formula fix array is accessed out-of-range"
                               + utils::errorurl(20), ivar,0);
@@ -1978,7 +1984,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
 
           // no other possibilities for equal-style variable, so error
 
-          } else print_var_error(FLERR,"Mismatched fix in variable formula",ivar);
+          } else print_var_error(FLERR, mismatch_msg, ivar);
 
         // vector-style variable is being evaluated
 
@@ -1989,7 +1995,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           if (lowercase && nbracket == 0) {
 
             if (!fix->vector_flag)
-              print_var_error(FLERR,"Mismatched fix in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (fix->size_vector == 0)
               print_var_error(FLERR,"Variable formula fix vector is zero length",ivar);
             if (update->whichflag > 0 && update->ntimestep % fix->global_freq)
@@ -2015,7 +2021,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           } else if (lowercase && nbracket == 1) {
 
             if (!fix->array_flag)
-              print_var_error(FLERR,"Mismatched fix in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (fix->size_array_rows == 0)
               print_var_error(FLERR,"Variable formula fix array is zero length",ivar);
             if (index1 > fix->size_array_cols)
@@ -2041,7 +2047,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
 
           // no other possibilities for vector-style variable, so error
 
-          } else print_var_error(FLERR,"Mismatched fix in variable formula",ivar);
+          } else print_var_error(FLERR, mismatch_msg, ivar);
 
         // atom-style variable is being evaluated
 
@@ -2052,9 +2058,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           if (lowercase && nbracket == 0) {
 
             if (!fix->peratom_flag)
-              print_var_error(FLERR,"Mismatched fix in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (fix->size_peratom_cols)
-              print_var_error(FLERR,"Mismatched fix in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (update->whichflag > 0 && update->ntimestep % fix->peratom_freq)
               print_var_error(FLERR,"Fix in variable not computed at compatible time"
                               + utils::errorurl(7), ivar);
@@ -2070,9 +2076,9 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
           } else if (lowercase && nbracket == 1) {
 
             if (!fix->peratom_flag)
-              print_var_error(FLERR,"Mismatched fix in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (!fix->size_peratom_cols)
-              print_var_error(FLERR,"Mismatched fix in variable formula",ivar);
+              print_var_error(FLERR, mismatch_msg, ivar);
             if (index1 > fix->size_peratom_cols)
               print_var_error(FLERR,"Variable formula fix array is accessed out-of-range"
                               + utils::errorurl(20), ivar,0);
@@ -2090,7 +2096,7 @@ double Variable::evaluate(char *str, Tree **tree, int ivar)
 
           // no other possibilities for atom-style variable, so error
 
-          } else print_var_error(FLERR,"Mismatched fix in variable formula",ivar);
+          } else print_var_error(FLERR, mismatch_msg, ivar);
         }
 
       // ----------------
@@ -4593,6 +4599,8 @@ int Variable::special_function(const std::string &word, char *contents, Tree **t
         mesg += "' in variable formula";
         print_var_error(FLERR,mesg,ivar);
       }
+      auto mismatch_msg = fmt::format("Compute '{}' in variable formula does not compute the "
+                                  "requested property. {}", compute->id, utils::errorurl(37));
       if (index == 0 && compute->vector_flag) {
         if (!compute->is_initialized())
           print_var_error(FLERR,"Variable formula compute cannot be invoked before "
@@ -4616,7 +4624,7 @@ int Variable::special_function(const std::string &word, char *contents, Tree **t
         }
         nvec = compute->size_array_rows;
         nstride = compute->size_array_cols;
-      } else print_var_error(FLERR,"Mismatched compute in variable formula",ivar);
+      } else print_var_error(FLERR, mismatch_msg, ivar);
 
     // argument is fix
 
@@ -4635,6 +4643,8 @@ int Variable::special_function(const std::string &word, char *contents, Tree **t
         mesg += "' in variable formula";
         print_var_error(FLERR,mesg,ivar);
       }
+      auto mismatch_msg = fmt::format("Fix '{}' in variable formula does not compute the "
+                                    "requested property. {}", fix->id, utils::errorurl(37));
       if (index == 0 && fix->vector_flag) {
         if (update->whichflag > 0 && update->ntimestep % fix->global_freq) {
           std::string mesg = "Fix with ID '";
@@ -4654,7 +4664,7 @@ int Variable::special_function(const std::string &word, char *contents, Tree **t
                           + utils::errorurl(7), ivar);
         nvec = fix->size_array_rows;
         nstride = fix->size_array_cols;
-      } else print_var_error(FLERR,"Mismatched fix in variable formula",ivar);
+      } else print_var_error(FLERR, mismatch_msg, ivar);
 
     // argument is vector-style variable
 

--- a/unittest/commands/test_variables.cpp
+++ b/unittest/commands/test_variables.cpp
@@ -303,7 +303,7 @@ TEST_F(VariableTest, AtomicSystem)
                  variable->compute_equal("v_self"););
     TEST_FAILURE(".*ERROR: Variable sum2: Inconsistent lengths in vector-style variable.*",
                  variable->compute_equal("max(v_sum2)"););
-    TEST_FAILURE(".*ERROR: Mismatched fix in variable formula.*",
+    TEST_FAILURE(".*ERROR: Fix 'press' in variable formula does not compute.*",
                  variable->compute_equal("f_press"););
     TEST_FAILURE(".*ERROR .*Variable formula compute vector is accessed out-of-range.*",
                  variable->compute_equal("c_press[10]"););


### PR DESCRIPTION
**Summary**

This pull request combines multiple small changes and fixes that do not warrant a pull request of their own.

**Related Issue(s)**

Fixes #4721 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

N/A

**Implementation Notes**

The following individual changes are included:
- fix bug in dump style extxyz that would prevent it from working with multiple MPI processes
- remove a misplaced const in kissfft.h functions
- use auto to avoid redundant type information
- improve error messages in `fix spring/self` and its KOKKOS version; update indentation
- improve error messages for mismatched compute or fix style property references
- update some outdated URLs in the documentation
- remove reference to no longer existing code example in fix external docs and replace with alternate recommendation

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
