### PR TITLE
fix(molecule): bug fix for reading in molecule json files

### DIFF
--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -2301,6 +2301,9 @@ void Molecule::read(int flag)
       nspecial_read(flag, line);
     } else if (keyword == "Special Bonds") {
       specialflag = tag_require = 1;
+      if (!nspecialflag)
+        error->all(FLERR, fileiarg,
+                   "Special Bond Counts section must come before Special Bonds section");
       if (flag)
         special_read(line);
       else

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -1406,9 +1406,9 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
                        "Molecule template {}: invalid improper type in improper {}: {}", id, i + 1,
                        to_string(item));
           if (flag == 0) {
-            count[atom1 - 1]++;
+            count[atom2 - 1]++;
             if (newton_bond == 0) {
-              count[atom2 - 1]++;
+              count[atom1 - 1]++;
               count[atom3 - 1]++;
               count[atom4 - 1]++;
             }

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -1167,9 +1167,9 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
                        "Molecule template {}: invalid angle type in angle {}: {}", id, i + 1,
                        to_string(item));
           if (flag == 0) {
-            count[atom1 - 1]++;
+            count[atom2 - 1]++;
             if (newton_bond == 0) {
-              count[atom2 - 1]++;
+              count[atom1 - 1]++;
               count[atom3 - 1]++;
             }
           } else {
@@ -1248,7 +1248,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
                        i + 1, to_string(item));
 
           if (item[0].is_number_integer()) {    // numeric type
-            itype = int(item[0]) + aoffset;
+            itype = int(item[0]) + doffset;
           } else {
             const auto &typestr = std::string(item[0]);
             if (!atom->labelmapflag)
@@ -1281,9 +1281,9 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
                        "Molecule template {}: invalid dihedral type in dihedral {}: {}", id, i + 1,
                        to_string(item));
           if (flag == 0) {
-            count[atom1 - 1]++;
+            count[atom2 - 1]++;
             if (newton_bond == 0) {
-              count[atom2 - 1]++;
+              count[atom1 - 1]++;
               count[atom3 - 1]++;
               count[atom4 - 1]++;
             }


### PR DESCRIPTION
**Summary**

Fixes:
1. incorrect atom ordering when reading molecule JSON: swap ```atom1``` and ```atom2``` for both ```dihedrals``` and ```impropers``` when updating the ```count``` array so the internal representation matches LAMMPS conventions and the original molecule files.
2. parsing of the ```dihedrals``` section was using ```aoffset``` rather than the correct ```doffset``` to calculate ```itype```

**Related Issue(s)**

fixes #4726 

**Author(s)**

Aya Salama ([asalama0204@gmail.com](mailto:asalama0204@gmail.com), Stevens Institute of Technology)
Jacob Gissinger ([jgissing@stevens.edu](mailto:jgissing@stevens.edu), Stevens Institute of Technology)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


