### PR TITLE
Aurora Makefile & cmake updates

### DIFF
--- a/cmake/presets/kokkos-sycl-intel.cmake
+++ b/cmake/presets/kokkos-sycl-intel.cmake
@@ -1,5 +1,7 @@
 # preset that enables KOKKOS and selects SYCL compilation with OpenMP
 # enabled as well. Also sets some performance related compiler flags.
+#set(BUILD_OMP ON CACHE BOOL "" FORCE)
+
 set(PKG_KOKKOS ON CACHE BOOL "" FORCE)
 set(Kokkos_ENABLE_SERIAL ON CACHE BOOL "" FORCE)
 set(Kokkos_ENABLE_OPENMP ON CACHE BOOL "" FORCE)
@@ -8,6 +10,7 @@ set(Kokkos_ENABLE_SYCL   ON CACHE BOOL "" FORCE)
 
 set(FFT "MKL" CACHE STRING "" FORCE)
 set(FFT_KOKKOS "MKL_GPU" CACHE STRING "" FORCE)
+set(FFT_SINGLE ON CACHE BOOL "" FORCE)
 
 unset(USE_INTERNAL_LINALG)
 unset(USE_INTERNAL_LINALG CACHE)
@@ -18,13 +21,10 @@ set(Kokkos_ENABLE_DEPRECATION_WARNINGS OFF CACHE BOOL "" FORCE)
 
 set(CMAKE_CXX_COMPILER icpx CACHE STRING "" FORCE)
 set(CMAKE_C_COMPILER icx CACHE STRING "" FORCE)
-set(CMAKE_Fortran_COMPILER "" CACHE STRING "" FORCE)
+set(CMAKE_Fortran_COMPILER ifx CACHE STRING "" FORCE)
 set(MPI_CXX_COMPILER "mpicxx" CACHE STRING "" FORCE)
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "" FORCE)
 
-# set(_intel_sycl_flags " -w -fsycl -flink-huge-device-code -fsycl-targets=spir64_gen "
-set(_intel_sycl_flags " -w -fsycl -fsycl-device-code-split=per_kernel -fsycl-targets=spir64_gen ")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_intel_sycl_flags}" CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w -O3 -fsycl-device-code-split=per_kernel " CACHE STRING "" FORCE)
 
-#set(CMAKE_EXE_LINKER_FLAGS "-fsycl -flink-huge-device-code -fsycl-targets=spir64_gen " CACHE STRING "" FORCE)
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsycl -flink-huge-device-code " CACHE STRING "" FORCE)
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -O3 -fsycl -flink-huge-device-code " CACHE STRING "" FORCE)

--- a/lib/kokkos/Makefile.kokkos
+++ b/lib/kokkos/Makefile.kokkos
@@ -1396,7 +1396,7 @@ endif
 ifeq ($(KOKKOS_INTERNAL_USE_ARCH_INTEL_PVC), 1)
   tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_INTEL_GPU")
   tmp := $(call kokkos_append_header,"$H""define KOKKOS_ARCH_INTEL_PVC")
-  KOKKOS_INTERNAL_INTEL_ARCH_FLAG := -f${KOKKOS_INTERNAL_LC_BACKEND}-targets=spir64_gen -X${KOKKOS_INTERNAL_LC_BACKEND}-target-backend "-device 12.60.7"
+  KOKKOS_INTERNAL_INTEL_ARCH_FLAG := -f${KOKKOS_INTERNAL_LC_BACKEND}-targets=spir64_gen -X${KOKKOS_INTERNAL_LC_BACKEND}-target-backend "-device pvc"
 endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_SYCL), 1)

--- a/src/KOKKOS/pair_snap_kokkos.h
+++ b/src/KOKKOS/pair_snap_kokkos.h
@@ -121,7 +121,7 @@ class PairSNAPKokkos : public PairSNAP {
   static constexpr int team_size_compute_fused_deidrj_all = 1;
 
   static constexpr int padding_factor = host_flag ? 1 : 2; // extra padding factor
-  static constexpr int ui_batch = 1;
+  static constexpr int ui_batch = host_flag ? 1 : 2;
   static constexpr int yi_batch = host_flag ? 1 : 2;
   static constexpr bool use_deidrj_all = false; // whether or not to use the directionally fused deidrj
 #else

--- a/src/KOKKOS/sna_kokkos_impl.h
+++ b/src/KOKKOS/sna_kokkos_impl.h
@@ -558,7 +558,9 @@ void SNAKokkos<DeviceType, real_type, vector_length>::compute_ui_large(const typ
 
   // we need to "choose" when to bend
   #ifdef LMP_KK_DEVICE_COMPILE
+  #ifndef KOKKOS_ENABLE_SYCL
   #pragma unroll
+  #endif
   #endif
   for (int j_bend = 0; j_bend <= twojmax; j_bend++) {
     // Initialize u00 to 1.0 for all legal neighbors
@@ -939,7 +941,9 @@ auto SNAKokkos<DeviceType, real_type, vector_length>::evaluate_zi(const int& j1,
   int jju2 = idxu_block[j2] + (j2+1)*mb2max;
   int icgb = mb1min*(j2+1) + mb2max;
   #ifdef LMP_KK_DEVICE_COMPILE
+  #ifndef KOKKOS_ENABLE_SYCL
   #pragma unroll
+  #endif
   #endif
   for (int ib = 0; ib < nb; ib++) {
 
@@ -948,7 +952,9 @@ auto SNAKokkos<DeviceType, real_type, vector_length>::evaluate_zi(const int& j1,
     int icga = ma1min*(j2+1) + ma2max;
 
     #ifdef LMP_KK_DEVICE_COMPILE
+    #ifndef KOKKOS_ENABLE_SYCL
     #pragma unroll
+    #endif
     #endif
     for (int ia = 0; ia < na; ia++) {
       const real_type cgcoeff_a = cgblock[icga];

--- a/src/MAKE/MACHINES/Makefile.aurora_kokkos
+++ b/src/MAKE/MACHINES/Makefile.aurora_kokkos
@@ -7,13 +7,19 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		mpicxx
-CCFLAGS =	-g -O3 -DNDEBUG -w
+CCFLAGS =	-O3 -DNDEBUG -w
 CCFLAGS +=      -fsycl-device-code-split=per_kernel
+
+# The following include directory has patched file resolving issue in oneapi/2025.2.0
+# /opt/aurora/25.190.0/oneapi/compiler/2025.2/bin/compiler/../../include/sycl/detail/cg_types.hpp:178:3: error: exception specification of overriding function is more lax than base version
+#  178 |   ~HostKernel() = default;
+CCFLAGS +=      -I/home/knight/public/lammps/sycl_mod
+
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpicxx
-LINKFLAGS =	-g -O3
+LINKFLAGS =	-O3
 LINKFLAGS +=    -flink-huge-device-code -fsycl-max-parallel-link-jobs=64
 LIB = 
 SIZE =		size


### PR DESCRIPTION
**Summary**

Updates for Makefile and cmake build recipes for Aurora @ ALCF based on oneapi/2025.2.0. Expect these will continue to provide appropriate starting points for building on other Intel GPU based systems.

**Author(s)**

Christopher Knight (ANL) <cjknight2009@gmail.com>
Brian Holland
Renzo Bustmante

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

Including the patched sycl header in Makefile.aurora_kokkos should be commented out if using an earlier oneapi release. 

**Implementation Notes**

Several LAMMPS examples checked for consistent results and expected timings. 

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

N/A


