### PR TITLE
Collected small changes and fixes

### DIFF
--- a/doc/src/Build_extras.rst
+++ b/doc/src/Build_extras.rst
@@ -1501,6 +1501,17 @@ details please see ``lib/hdnnp/README`` and the `n2p2 build documentation
       to path where *n2p2* is located. If *n2p2* is located directly in
       ``lib/hdnnp/n2p2`` it will be automatically found by CMake.
 
+      .. admonition:: Failure to build n2p2 due to git branch names
+         :class: note
+
+         Some script code inside the *n2p2* library build processes the
+         current branch name used by git and that will fail for LAMMPS
+         repository branch names containing the forward slash '/'
+         character, for example: ``user/update-n2p2``.  The workaround
+         is to change the (local) branch name, e.g. for the given
+         example with: ``git branch -m user/update-n2p2
+         user_update-n2p2``
+
    .. tab:: Traditional make
 
       .. versionchanged:: 10Sep2025

--- a/doc/src/Build_prerequisites.rst
+++ b/doc/src/Build_prerequisites.rst
@@ -7,16 +7,62 @@ which :doc:`features and settings <Build_settings>` and which
 Common to all is that you need a C++ and C compiler, where the C++
 compiler has to support at least the C++17 standard (note that some
 compilers require a command-line flag to activate C++17 support).
-Furthermore, if you are building with CMake, you need at least CMake
-version 3.20 and a compatible build tool (make or ninja-build); if you
-are building the the legacy GNU make based build system you need GNU
-make (other make variants are not going to work since the build system
-uses features unique to GNU make) and a Unix-like build environment with
-a Bourne shell, and shell tools like "sed", "grep", "touch", "test",
-"tr", "cp", "mv", "rm", "ln", "diff" and so on. Parts of LAMMPS
-interface with or use Python version 3.6 or later.
+
+CMake build system
+==================
+
+If you are building with CMake, you need at least CMake version 3.20 and
+a compatible build tool (e.g. GNU make or ninja-build on Linux).  The
+CMake scripting includes tests for required software and will
+auto-detect and auto-enable available tools and libraries for optional
+features (of course those can be disabled, if desired).  If required
+software is missing, CMake will try to download the compile the missing
+parts automatically, if possible or stop with an error.
+
+GNU build system
+================
+
+If you are building LAMMPS with the legacy GNU make based build system
+you need GNU make (other make variants are not going to work since the
+build system uses features unique to GNU make) and a Unix-like build
+environment with a Bourne shell, and shell tools like "sed", "grep",
+"touch", "test", "tr", "cp", "mv", "rm", "ln", "diff" and so on. Parts
+of LAMMPS interface with or use Python version 3.6 or later.
+
+Compiler and OS compatibility
+=============================
 
 The LAMMPS developers aim to keep LAMMPS very portable and usable -
 at least in parts - on most operating systems commonly used for
 running MD simulations.  Please see the :doc:`section on portablility
 <Intro_portability>` for more details.
+
+.. admonition:: Warning: LLVM based Intel Compilers
+   :class: warning
+
+   In recent years, Intel switched their compilers from a propriatary
+   code base to compilers based on LLVM (which is also the foundation of
+   the Clang compilers).  It has since stopped updating their legacy
+   compilers.  Some versions of those LLVM compilers creats incorrect
+   binary code that results in incorrect behavior of LAMMPS; this is
+   particularly common when using high optimization levels and
+   vectorization.  There have been several cases where people reported
+   bugs in LAMMPS which turned out to be caused by bugs in the Intel
+   LLVM compilers.
+
+   Unfortunately there is no simple way to detect whether a binary is
+   working correctly outside of running the unit and regression tests,
+   but those do not cover all of LAMMPS and and would be reliable only
+   for no or moderate optimization anyway.  For most of LAMMPS there is
+   not much of a benefit (if any) to use the Intel compilers over the
+   GCC or Clang compilers, except for the INTEL package (which *can* be
+   compiled with other compilers, but most vectorization directives are
+   inactive for those) or KOKKOS with SYCL.
+
+   Our recommendation is thus to compile with GCC or Clang unless you
+   are using features that *require* the Intel compilers.  In that case,
+   it is recommended to have a backup GCC/Clang compiled binary
+   available to validate correctness of the simulation.  If you have
+   access to multiple Intel compiler versions, please try the latest
+   version first and avoid "20##.0" versions which seem to have
+   problems most often.

--- a/doc/src/Build_prerequisites.rst
+++ b/doc/src/Build_prerequisites.rst
@@ -40,10 +40,10 @@ running MD simulations.  Please see the :doc:`section on portablility
 .. admonition:: Warning: LLVM based Intel Compilers
    :class: warning
 
-   In recent years, Intel switched their compilers from a propriatary
+   In recent years, Intel switched their compilers from a proprietary
    code base to compilers based on LLVM (which is also the foundation of
    the Clang compilers).  It has since stopped updating their legacy
-   compilers.  Some versions of those LLVM compilers creats incorrect
+   compilers.  Some versions of those LLVM compilers creates incorrect
    binary code that results in incorrect behavior of LAMMPS; this is
    particularly common when using high optimization levels and
    vectorization.  There have been several cases where people reported

--- a/doc/src/Developer_unittest.rst
+++ b/doc/src/Developer_unittest.rst
@@ -73,7 +73,7 @@ available:
      - Tests for standard FFT3d wrapper (KISS, FFTW3, MKL, NVPL)
    * - ``test_fft3d_kokkos.cpp``
      - FFT3DKokkos
-     - Tests for KOKKOS FFT3d wrapper (CPU and GPU backends)
+     - Tests for KOKKOS FFT3d wrapper (CPU and GPU back ends)
 
 
 To add tests either an existing source file needs to be modified or a
@@ -149,9 +149,9 @@ FFT Testing Infrastructure
 
 The FFT tests (``test_fft3d.cpp`` and ``test_fft3d_kokkos.cpp``)
 validate the LAMMPS FFT wrapper implementations for both standard (CPU)
-and KOKKOS (CPU/GPU) backends.  These tests require the KSPACE package
+and KOKKOS (CPU/GPU) back ends.  These tests require the KSPACE package
 and use specialized helper utilities to ensure FFT correctness across
-different library backends (KISS FFT, FFTW3, MKL, NVPL, cuFFT, hipFFT,
+different library back ends (KISS FFT, FFTW3, MKL, NVPL, cuFFT, hipFFT,
 etc.).
 
 **Building and Running FFT Tests:**
@@ -160,7 +160,7 @@ The FFT tests are automatically enabled when ``ENABLE_TESTING=ON`` and
 ``PKG_KSPACE=ON`` are set during CMake configuration. For KOKKOS FFT tests,
 ``PKG_KOKKOS=ON`` is also required.
 
-Run only FFT tests via CTest:
+Run only FFT tests using the ``ctest`` command of the CMake software:
 
 .. code-block:: bash
 
@@ -168,7 +168,7 @@ Run only FFT tests via CTest:
    ctest -R FFT3D -V       # Same as above but with verbose output
    ctest -L fft            # Run all tests labeled with 'fft'
 
-Tests automatically skip configurations requiring libraries or backends
+Tests automatically skip configurations requiring libraries or back ends
 not available in the current build (e.g., FFTW3, MPI, CUDA).
 
 **Helper Headers:**
@@ -184,15 +184,15 @@ etc.).
 
 The ``fft_test_helpers.h`` header provides three main namespaces:
 
-1. **FFTTestHelpers** - Utility functions:
+1. **FFTTestHelpers** - utility functions:
    ``FFTBuffer`` (RAII wrapper), ``idx3d()`` (index conversion),
    ``scaled_tolerance()`` (grid-size-dependent precision)
 
-2. **FFTTestData** - Test data generators:
+2. **FFTTestData** - test data generators:
    ``DeltaFunctionGenerator``, ``ConstantGenerator``, ``SineWaveGenerator``,
    ``GaussianGenerator``, ``RandomComplexGenerator``, ``MixedModesGenerator``
 
-3. **FFTValidation** - Validators:
+3. **FFTValidation** - validators:
    ``RoundTripValidator``, ``KnownAnswerValidator``, ``ParsevalValidator``,
    ``HermitianSymmetryValidator``, ``LinearityValidator``
 
@@ -218,7 +218,7 @@ The ``fft_test_helpers.h`` header provides three main namespaces:
 
 FFT tests use precision-aware tolerances that automatically adjust based
 on floating-point precision (``-D FFT_SINGLE=ON`` vs ``-D
-FFT_SINGLE=off``), grid size, and accelerator backend.  Base tolerances
+FFT_SINGLE=off``), grid size, and accelerator back end.  Base tolerances
 (``ROUNDTRIP_TOLERANCE``, ``PARSEVAL_TOLERANCE``, etc.)  are defined in
 ``fft_test_helpers.h``.  Use ``scaled_tolerance()`` to adjust for grid
 size effects.

--- a/doc/src/Developer_unittest.rst
+++ b/doc/src/Developer_unittest.rst
@@ -147,6 +147,8 @@ additional tests.
 FFT Testing Infrastructure
 """"""""""""""""""""""""""
 
+.. versionadded:: TBD
+
 The FFT tests (``test_fft3d.cpp`` and ``test_fft3d_kokkos.cpp``)
 validate the LAMMPS FFT wrapper implementations for both standard (CPU)
 and KOKKOS (CPU/GPU) back ends.  These tests require the KSPACE package
@@ -171,7 +173,7 @@ Run only FFT tests using the ``ctest`` command of the CMake software:
 Tests automatically skip configurations requiring libraries or back ends
 not available in the current build (e.g., FFTW3, MPI, CUDA).
 
-**Helper Headers:**
+**FFT Test Helper Header:**
 
 The testing infrastructure uses ``fft_test_helpers.h`` which contains
 test data generators, validators, and utilities.
@@ -179,8 +181,6 @@ test data generators, validators, and utilities.
 For runtime configuration detection, tests use the existing ``Info``
 class API (``Info::has_package()``, ``Info::has_accelerator_feature()``,
 etc.).
-
-**FFT Test Helpers:**
 
 The ``fft_test_helpers.h`` header provides three main namespaces:
 

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -4094,8 +4094,8 @@ valent
 Valeriu
 valgrind
 validator
+validators
 Valone
-valuev
 Valuev
 Vanden
 Vandenbrande

--- a/src/REPLICA/fix_pimd_langevin.cpp
+++ b/src/REPLICA/fix_pimd_langevin.cpp
@@ -878,6 +878,7 @@ void FixPIMDLangevin::qc_step()
     MPI_Bcast(&domain->boxhi[0], 3, MPI_DOUBLE, 0, universe->uworld);
     domain->set_global_box();
     domain->set_local_box();
+    if (kspace_flag) force->kspace->setup();
   }
 }
 

--- a/src/REPLICA/fix_pimd_langevin.cpp
+++ b/src/REPLICA/fix_pimd_langevin.cpp
@@ -476,9 +476,6 @@ void FixPIMDLangevin::init()
     error->universe_all(FLERR, fmt::format("Unknown integrator parameter for fix {}", style));
   }
 
-  if (force->kspace) kspace_flag = 1;
-  else kspace_flag = 0;
-
   comm_init();
 
   mass = new double[atom->ntypes + 1];
@@ -882,7 +879,7 @@ void FixPIMDLangevin::qc_step()
     MPI_Bcast(&domain->boxhi[0], 3, MPI_DOUBLE, 0, universe->uworld);
     domain->set_global_box();
     domain->set_local_box();
-    if (kspace_flag) force->kspace->setup();
+    if (force->kspace) force->kspace->setup();
   }
 }
 

--- a/src/REPLICA/fix_pimd_langevin.cpp
+++ b/src/REPLICA/fix_pimd_langevin.cpp
@@ -475,6 +475,9 @@ void FixPIMDLangevin::init()
     error->universe_all(FLERR, fmt::format("Unknown integrator parameter for fix {}", style));
   }
 
+  if (force->kspace) kspace_flag = 1;
+  else kspace_flag = 0;
+
   comm_init();
 
   mass = new double[atom->ntypes + 1];

--- a/src/REPLICA/fix_pimd_langevin.cpp
+++ b/src/REPLICA/fix_pimd_langevin.cpp
@@ -34,6 +34,7 @@
 #include "error.h"
 #include "force.h"
 #include "group.h"
+#include "kspace.h"
 #include "math_const.h"
 #include "math_special.h"
 #include "memory.h"

--- a/src/REPLICA/fix_pimd_langevin.h
+++ b/src/REPLICA/fix_pimd_langevin.h
@@ -67,7 +67,6 @@ class FixPIMDLangevin : public Fix {
   int integrator;          // obabo or baoab
   int ensemble;            // nve or nvt or nph or npt
   int mapflag;             // should be 1 if number of beads > 1
-  int kspace_flag;         // 1 if KSpace invoked, 0 if not
   int removecomflag;
   double masstotal;
 

--- a/src/REPLICA/fix_pimd_langevin.h
+++ b/src/REPLICA/fix_pimd_langevin.h
@@ -67,6 +67,7 @@ class FixPIMDLangevin : public Fix {
   int integrator;          // obabo or baoab
   int ensemble;            // nve or nvt or nph or npt
   int mapflag;             // should be 1 if number of beads > 1
+  int kspace_flag;         // 1 if KSpace invoked, 0 if not
   int removecomflag;
   double masstotal;
 

--- a/src/RIGID/fix_rigid.cpp
+++ b/src/RIGID/fix_rigid.cpp
@@ -811,7 +811,6 @@ void FixRigid::setup(int vflag)
   int i, ibody, n;
   const int nlocal = atom->nlocal;
 
-  if (langflag) apply_langevin_thermostat();
   compute_forces_and_torques();
 
   // enforce 2d body forces and torques

--- a/src/RIGID/fix_rigid.cpp
+++ b/src/RIGID/fix_rigid.cpp
@@ -582,7 +582,7 @@ FixRigid::FixRigid(LAMMPS *lmp, int narg, char **arg) :
     random = new RanMars(lmp, seed + comm->me);
     memory->create(langextra, nbody, 6, "rigid:langextra");
     for (i = 0; i < nbody; i++) {
-      for (j = 0; i < 6; j++) langextra[i][j] = 0.0;
+      for (j = 0; j < 6; j++) langextra[i][j] = 0.0;
     }
   }
 

--- a/src/RIGID/fix_rigid_small.cpp
+++ b/src/RIGID/fix_rigid_small.cpp
@@ -627,7 +627,6 @@ void FixRigidSmall::setup(int vflag)
   if (maxextent > cutghost)
     error->all(FLERR,"Rigid body extent {} > ghost atom cutoff - use comm_modify cutoff", maxextent);
 
-  if (langflag) apply_langevin_thermostat();
   compute_forces_and_torques();
 
   // enforce 2d body forces and torques

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -511,8 +511,10 @@ void Image::draw_sphere(const double *x, const double *surfaceColor, double diam
 
 void Image::draw_cube(const double *x, const double *surfaceColor, double diameter)
 {
-  double xlocal[3],surface[3],normal[3];
-  double t,tdir[3];
+  double xlocal[3],surface[3];
+  double normal[3] = {0.0, 0.0, 1.0};
+  double t = 1.0;
+  double tdir[3] = {0.5, 0.5, 0.0};
   double depth;
 
   xlocal[0] = x[0] - xctr;

--- a/src/label_map.cpp
+++ b/src/label_map.cpp
@@ -37,7 +37,8 @@ static const char cite_type_label_framework[] =
     " pages =   {3282--3297}\n"
     "}\n\n";
 
-static const std::string empty = "";
+static const std::string empty;
+
 /* ---------------------------------------------------------------------- */
 
 LabelMap::LabelMap(LAMMPS *_lmp, int _natomtypes, int _nbondtypes, int _nangletypes,

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -4499,7 +4499,7 @@ void Molecule::print(FILE *fp)
   }
 
   if (bodyflag) {
-    auto avec = dynamic_cast<AtomVecBody *>(atom->style_match("body"));
+    auto *avec = dynamic_cast<AtomVecBody *>(atom->style_match("body"));
     if (avec) {
       fputs("\nBody Integers\n\n", fp);
       if ((strcmp(avec->bptr->style, "nparticle") == 0) ||

--- a/src/read_dump.cpp
+++ b/src/read_dump.cpp
@@ -974,6 +974,19 @@ void ReadDump::process_atoms()
       }
     }
 
+    // check if atom type is valid
+
+    if ((itype < 1) || (itype > atom->ntypes)) {
+      tagint newtag = i + 1;
+      if ((atom->tag_enable) && (atom->map_tag_max > 0)) {
+        newtag += atom->map_tag_max;
+      } else {
+        newtag += atom->natoms;
+      }
+      error->all(FLERR, Error::NOLASTLINE, "Atom type {} for new atom-ID {} is out of range",
+                 itype, newtag);
+    }
+
     // create the atom on proc that owns it
     // reset v,image ptrs in case they are reallocated
 

--- a/unittest/force-styles/test_fix_timestep.cpp
+++ b/unittest/force-styles/test_fix_timestep.cpp
@@ -23,8 +23,10 @@
 
 #include "atom.h"
 #include "fix.h"
+#include "force.h"
 #include "info.h"
 #include "input.h"
+#include "kspace.h"
 #include "modify.h"
 #include "update.h"
 #include "variable.h"

--- a/unittest/force-styles/test_pair_style.cpp
+++ b/unittest/force-styles/test_pair_style.cpp
@@ -27,6 +27,7 @@
 #include "force.h"
 #include "info.h"
 #include "input.h"
+#include "kspace.h"
 #include "modify.h"
 #include "pair.h"
 


### PR DESCRIPTION
**Summary**

This pull request combines multiple small changes and bug fixes that do not warrant pull requests on their own.

**Related Issue(s)**

Fixes #4741 
Includes and thus closes #4743 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Backward Compatibility**

N/A

**Implementation Notes**

The following individual changes are included:
- bugfix for read_dump to not allow creating atoms with out-of-range atom type
- correct some minor issues in the recently merged fix rigid and rigid/small refactor
- small refactoring changes suggested by clang-tidy
- add missing includes in a couple tester programs
- document with more detail build prerequisites and add note about problems with some IntelLLVM compilers
- update kspace grid when using fix pimd/langevin with variable cell imported from PR #4743 

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
