### PR TITLE
Fix bug in Kokkos neigh list with FP32 positions + newton on

### DIFF
--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -107,6 +107,10 @@ KokkosLMP::KokkosLMP(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
   int device = 0;
   nthreads = 1;
 
+  kk_fp32 = 0;
+  if (sizeof(KK_FLOAT) != sizeof(double))
+    kk_fp32 = 1;
+
   threads_per_atom = 1;
   threads_per_atom_set = 0;
   pair_team_size = 128;

--- a/src/KOKKOS/kokkos.h
+++ b/src/KOKKOS/kokkos.h
@@ -47,6 +47,7 @@ class KokkosLMP : protected Pointers {
   int sort_changed;
   int atom_map_changed;
   int nthreads,ngpus;
+  int kk_fp32;
   int auto_sync;
   int gpu_aware_flag;
   int neigh_thread;

--- a/src/accelerator_kokkos.h
+++ b/src/accelerator_kokkos.h
@@ -56,10 +56,7 @@ class KokkosLMP {
   int ngpus;
   int kk_fp32;
 
-  KokkosLMP(class LAMMPS *, int, char **) {
-    kokkos_exists = 0;
-    kk_fp32 = 0;
-  }
+  KokkosLMP(class LAMMPS *, int, char **) { kokkos_exists = 0; }
   ~KokkosLMP() = default;
   static void finalize() {}
   void accelerator(int, char **) {}

--- a/src/accelerator_kokkos.h
+++ b/src/accelerator_kokkos.h
@@ -54,8 +54,12 @@ class KokkosLMP {
   int kokkos_exists;
   int nthreads;
   int ngpus;
+  int kk_fp32;
 
-  KokkosLMP(class LAMMPS *, int, char **) { kokkos_exists = 0; }
+  KokkosLMP(class LAMMPS *, int, char **) {
+    kokkos_exists = 0;
+    kk_fp32 = 0;
+  }
   ~KokkosLMP() = default;
   static void finalize() {}
   void accelerator(int, char **) {}

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -2027,6 +2027,13 @@ int Neighbor::choose_stencil(NeighRequest *rq)
   if (rq->full) fullflag = 1;
   if (!newtflag) fullflag = 1;
 
+  int kk_fp32 = 0;
+  if (lmp->kokkos)
+    kk_fp32 = lmp->kokkos->kk_fp32;
+  if ((kk_fp32 && newtflag) && atom->tag_enable == 0)
+    error->all(FLERR, Error::NOLASTLINE,
+               "Cannot build Kokkos FP32 neighbor lists with newton on unless atoms have IDs");
+
   //printf("STENCIL RQ FLAGS: hff %d %d n %d g %d s %d newtflag %d fullflag %d\n",
   //       rq->half,rq->full,rq->newton,rq->ghost,rq->ssa,
   //       newtflag, fullflag);
@@ -2073,9 +2080,11 @@ int Neighbor::choose_stencil(NeighRequest *rq)
       if (!(mask & NS_3D)) continue;
     }
 
-    // domain triclinic flag is on or off and must match
+    // domain triclinic is on or off and must match
+    // if Kokkos FP32 and newton on, also use triclinic due to
+    //  roundoff issue
 
-    if (triclinic) {
+    if (triclinic || (kk_fp32 && newtflag)) {
       if (!(mask & NS_TRI)) continue;
     } else if (!triclinic) {
       if (!(mask & NS_ORTHO)) continue;
@@ -2114,6 +2123,13 @@ int Neighbor::choose_pair(NeighRequest *rq)
   else if (rq->newton == 1) newtflag = true;
   else if (rq->newton == 2) newtflag = false;
   else error->all(FLERR, Error::NOLASTLINE, "Illegal 'newton' flag in neighbor list request");
+
+  int kk_fp32 = 0;
+  if (lmp->kokkos)
+    kk_fp32 = lmp->kokkos->kk_fp32;
+  if ((kk_fp32 && newtflag) && atom->tag_enable == 0)
+    error->all(FLERR, Error::NOLASTLINE,
+               "Cannot build Kokkos FP32 neighbor lists with newton on unless atoms have IDs");
 
   int molecular = atom->molecular;
 
@@ -2212,9 +2228,11 @@ int Neighbor::choose_pair(NeighRequest *rq)
       if (!(mask & NP_MULTI)) continue;
     }
 
-    // domain triclinic flag is on or off and must match
+    // domain triclinic is on or off and must match
+    // if Kokkos FP32 and newton on, also use triclinic due to
+    //  roundoff issue
 
-    if (triclinic) {
+    if (triclinic || (kk_fp32 && newtflag)) {
       if (!(mask & NP_TRI)) continue;
     } else if (!triclinic) {
       if (!(mask & NP_ORTHO)) continue;

--- a/src/neighbor.cpp
+++ b/src/neighbor.cpp
@@ -2080,7 +2080,7 @@ int Neighbor::choose_stencil(NeighRequest *rq)
       if (!(mask & NS_3D)) continue;
     }
 
-    // domain triclinic is on or off and must match
+    // domain triclinic flag is on or off and must match
     // if Kokkos FP32 and newton on, also use triclinic due to
     //  roundoff issue
 
@@ -2228,7 +2228,7 @@ int Neighbor::choose_pair(NeighRequest *rq)
       if (!(mask & NP_MULTI)) continue;
     }
 
-    // domain triclinic is on or off and must match
+    // domain triclinic flag is on or off and must match
     // if Kokkos FP32 and newton on, also use triclinic due to
     //  roundoff issue
 


### PR DESCRIPTION
**Summary**

Fix bug in Kokkos half neigh list with atom positions in FP32 (true for either `single` or `mixed` precision) and `newton on` by falling back to triclinic neighborlist build (even when the box is orthogonal). The issue is that FP32 leads to a large amount of roundoff error in the coordinates that can put particles into an adjacent neighborlist bin leading to an incorrect number of neighbors and missed interactions. This is similar to the triclinic case where:

```
// for triclinic, bin stencil is full in all 3 dims
        // must use itag/jtag to eliminate half the I/J interactions
        // cannot use I/J exact coord comparision
        //   b/c transforming orthog -> lambda -> orthog for ghost atoms
        //   with an added PBC offset can shift all 3 coords by epsilon
```

```
  // For half stencils, only the upper plane is needed
  // for triclinic, need to use full stencil in all dims
  //   not a half stencil in y
  // b/c transforming orthog -> lambda -> orthog for ghost atoms
  //   with an added PBC offset can shift both coords by epsilon
  // thus for an I/J owned/ghost pair, the xy coords
  //   and bin assignments can be different on I proc vs J proc
```

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->

**Author(s)**

Stan Moore (SNL), reported by @weinbe2 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Backward Compatibility**

Yes