### PR TITLE
adding energy calculation

### DIFF
--- a/src/SPIN/atom_vec_spin.cpp
+++ b/src/SPIN/atom_vec_spin.cpp
@@ -113,8 +113,7 @@ void AtomVecSpin::read_data_general_to_restricted(int nlocal_previous, int nloca
 {
   AtomVec::read_data_general_to_restricted(nlocal_previous, nlocal);
 
-  for (int i = nlocal_previous; i < nlocal; i++)
-    domain->general_to_restricted_vector(sp[i]);
+  for (int i = nlocal_previous; i < nlocal; i++) domain->general_to_restricted_vector(sp[i]);
 }
 
 /* ----------------------------------------------------------------------
@@ -128,9 +127,9 @@ void AtomVecSpin::write_data_restricted_to_general()
   AtomVec::write_data_restricted_to_general();
 
   int nlocal = atom->nlocal;
-  memory->create(sp_hold,nlocal,3,"atomvec:sp_hold");
+  memory->create(sp_hold, nlocal, 3, "atomvec:sp_hold");
   for (int i = 0; i < nlocal; i++) {
-    memcpy(&sp_hold[i][0],&sp[i][0],3*sizeof(double));
+    memcpy(&sp_hold[i][0], &sp[i][0], 3 * sizeof(double));
     domain->restricted_to_general_vector(sp[i]);
   }
 }
@@ -149,8 +148,7 @@ void AtomVecSpin::write_data_restore_restricted()
   if (!sp_hold) return;
 
   int nlocal = atom->nlocal;
-  for (int i = 0; i < nlocal; i++)
-    memcpy(&sp[i][0],&sp_hold[i][0],3*sizeof(double));
+  for (int i = 0; i < nlocal; i++) memcpy(&sp[i][0], &sp_hold[i][0], 3 * sizeof(double));
   memory->destroy(sp_hold);
   sp_hold = nullptr;
 }

--- a/src/SPIN/fix_langevin_spin.cpp
+++ b/src/SPIN/fix_langevin_spin.cpp
@@ -193,12 +193,11 @@ void FixLangevinSpin::compute_single_langevin(int i, double spi[3], double fmi[3
 
 double FixLangevinSpin::compute_vector(int n)
 {
-  double energy_allS;
-  MPI_Allreduce(&energyS,&energy_allS,1,MPI_DOUBLE,MPI_SUM,world);
-  double energy_allD;
-  MPI_Allreduce(&energyD,&energy_allD,1,MPI_DOUBLE,MPI_SUM,world);
-  energy_vec[0] = energy_allS / output->thermo_every;
-  energy_vec[1] = energy_allD / output->thermo_every;
+  double energy_one[2] = {energyS, energyD}, energy_all[2];
+  MPI_Allreduce(energy_one, energy_all, 2, MPI_DOUBLE, MPI_SUM, world);
+  energy_vec[0] = energy_all[0] / output->thermo_every;
+  energy_vec[1] = energy_all[1] / output->thermo_every;
+
   if (n==0) energyS = 0;
   if (n==1) energyD = 0;
   if (n == 0) return energy_vec[0];

--- a/src/SPIN/fix_langevin_spin.cpp
+++ b/src/SPIN/fix_langevin_spin.cpp
@@ -33,6 +33,8 @@
 #include "random_mars.h"
 #include "respa.h"
 #include "update.h"
+#include "memory.h"
+#include "output.h"
 
 #include <cmath>
 #include <cstring>
@@ -51,6 +53,11 @@ FixLangevinSpin::FixLangevinSpin(LAMMPS *lmp, int narg, char **arg) :
   temp = utils::numeric(FLERR,arg[3],false,lmp);
   alpha_t = utils::numeric(FLERR,arg[4],false,lmp);
   seed = utils::inumeric(FLERR,arg[5],false,lmp);
+
+  nevery = 1;
+  vector_flag = 1;
+  size_vector = 2;
+  extvector = 0;
 
   if (alpha_t < 0.0) {
     error->all(FLERR,"Illegal langevin/spin command");
@@ -72,6 +79,7 @@ FixLangevinSpin::FixLangevinSpin(LAMMPS *lmp, int narg, char **arg) :
 
   // random = new RanPark(lmp,seed + comm->me);
   random = new RanMars(lmp,seed + comm->me);
+  allocate();
 }
 
 /* ---------------------------------------------------------------------- */
@@ -79,6 +87,7 @@ FixLangevinSpin::FixLangevinSpin(LAMMPS *lmp, int narg, char **arg) :
 FixLangevinSpin::~FixLangevinSpin()
 {
   delete random;
+  memory->destroy(energy_vec);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -132,21 +141,28 @@ void FixLangevinSpin::add_tdamping(double spi[3], double fmi[3])
   double cpx = fmi[1]*spi[2] - fmi[2]*spi[1];
   double cpy = fmi[2]*spi[0] - fmi[0]*spi[2];
   double cpz = fmi[0]*spi[1] - fmi[1]*spi[0];
-
+  double hbar = force->hplanck/MY_2PI;
   // adding the transverse damping
 
   fmi[0] -= alpha_t*cpx;
   fmi[1] -= alpha_t*cpy;
   fmi[2] -= alpha_t*cpz;
+  
+  energyD -= hbar*(alpha_t*cpx*cpx + alpha_t*cpy*cpy + alpha_t*cpz*cpz);
 }
 
 /* ---------------------------------------------------------------------- */
 
-void FixLangevinSpin::add_temperature(double fmi[3])
+void FixLangevinSpin::add_temperature(double spi[3], double fmi[3])
 {
   double rx = sigma*random->gaussian();
   double ry = sigma*random->gaussian();
   double rz = sigma*random->gaussian();
+
+  double hbar = force->hplanck/MY_2PI;
+  double kb = force->boltz;             // eV/K
+
+  energyS += 2*alpha_t*kb*temp*(spi[0]*fmi[0] + spi[1]*fmi[1] + spi[2]*fmi[2]);
 
   // adding the random field
 
@@ -159,6 +175,7 @@ void FixLangevinSpin::add_temperature(double fmi[3])
   fmi[0] *= gil_factor;
   fmi[1] *= gil_factor;
   fmi[2] *= gil_factor;
+  
 }
 
 /* ---------------------------------------------------------------------- */
@@ -168,6 +185,29 @@ void FixLangevinSpin::compute_single_langevin(int i, double spi[3], double fmi[3
   int *mask = atom->mask;
   if (mask[i] & groupbit) {
     if (tdamp_flag) add_tdamping(spi,fmi);
-    if (temp_flag) add_temperature(fmi);
+    if (temp_flag) add_temperature(spi,fmi);
   }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double FixLangevinSpin::compute_vector(int n)
+{
+  double energy_allS;
+  MPI_Allreduce(&energyS,&energy_allS,1,MPI_DOUBLE,MPI_SUM,world);
+  double energy_allD;
+  MPI_Allreduce(&energyD,&energy_allD,1,MPI_DOUBLE,MPI_SUM,world);
+  energy_vec[0] = energy_allS / output->thermo_every;
+  energy_vec[1] = energy_allD / output->thermo_every;
+  if (n==0) energyS = 0;
+  if (n==1) energyD = 0;
+  if (n == 0) return energy_vec[0];
+  if (n == 1) return energy_vec[1];
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixLangevinSpin::allocate()
+{
+  memory->create(energy_vec,size_vector,"fix/langevin/spin:vector");
 }

--- a/src/SPIN/fix_langevin_spin.cpp
+++ b/src/SPIN/fix_langevin_spin.cpp
@@ -46,7 +46,7 @@ using namespace MathConst;
 /* ---------------------------------------------------------------------- */
 
 FixLangevinSpin::FixLangevinSpin(LAMMPS *lmp, int narg, char **arg) :
-  Fix(lmp, narg, arg), random(nullptr)
+  Fix(lmp, narg, arg), random(nullptr), energy_vec{0.0, 0.0}
 {
   if (narg != 6) error->all(FLERR,"Illegal langevin/spin command");
 
@@ -58,6 +58,7 @@ FixLangevinSpin::FixLangevinSpin(LAMMPS *lmp, int narg, char **arg) :
   vector_flag = 1;
   size_vector = 2;
   extvector = 0;
+
 
   if (alpha_t < 0.0) {
     error->all(FLERR,"Illegal langevin/spin command");
@@ -79,7 +80,6 @@ FixLangevinSpin::FixLangevinSpin(LAMMPS *lmp, int narg, char **arg) :
 
   // random = new RanPark(lmp,seed + comm->me);
   random = new RanMars(lmp,seed + comm->me);
-  allocate();
 }
 
 /* ---------------------------------------------------------------------- */
@@ -87,7 +87,6 @@ FixLangevinSpin::FixLangevinSpin(LAMMPS *lmp, int narg, char **arg) :
 FixLangevinSpin::~FixLangevinSpin()
 {
   delete random;
-  memory->destroy(energy_vec);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -148,7 +147,7 @@ void FixLangevinSpin::add_tdamping(double spi[3], double fmi[3])
   fmi[1] -= alpha_t*cpy;
   fmi[2] -= alpha_t*cpz;
 
-  energyD -= hbar*(alpha_t*cpx*cpx + alpha_t*cpy*cpy + alpha_t*cpz*cpz);
+  energy_vec[0] -= hbar*(alpha_t*cpx*cpx + alpha_t*cpy*cpy + alpha_t*cpz*cpz);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -162,7 +161,7 @@ void FixLangevinSpin::add_temperature(double spi[3], double fmi[3])
   double hbar = force->hplanck/MY_2PI;
   double kb = force->boltz;             // eV/K
 
-  energyS += 2*alpha_t*kb*temp*(spi[0]*fmi[0] + spi[1]*fmi[1] + spi[2]*fmi[2]);
+  energy_vec[1] += 2*alpha_t*kb*temp*(spi[0]*fmi[0] + spi[1]*fmi[1] + spi[2]*fmi[2]);
 
   // adding the random field
 
@@ -193,20 +192,12 @@ void FixLangevinSpin::compute_single_langevin(int i, double spi[3], double fmi[3
 
 double FixLangevinSpin::compute_vector(int n)
 {
-  double energy_one[2] = {energyS, energyD}, energy_all[2];
-  MPI_Allreduce(energy_one, energy_all, 2, MPI_DOUBLE, MPI_SUM, world);
-  energy_vec[0] = energy_all[0] / output->thermo_every;
-  energy_vec[1] = energy_all[1] / output->thermo_every;
+  double energy_all[2];
+  MPI_Allreduce(energy_vec, energy_all, 2, MPI_DOUBLE, MPI_SUM, world);
+  energy_all[0] /= output->thermo_every;
+  energy_all[1] /= output->thermo_every;
 
-  if (n==0) energyS = 0;
-  if (n==1) energyD = 0;
-  if (n == 0) return energy_vec[0];
-  if (n == 1) return energy_vec[1];
-}
-
-/* ---------------------------------------------------------------------- */
-
-void FixLangevinSpin::allocate()
-{
-  memory->create(energy_vec,size_vector,"fix/langevin/spin:vector");
+  if (n > 2) return 0.0;
+  energy_vec[n] = 0;
+  return energy_all[n];
 }

--- a/src/SPIN/fix_langevin_spin.cpp
+++ b/src/SPIN/fix_langevin_spin.cpp
@@ -147,7 +147,7 @@ void FixLangevinSpin::add_tdamping(double spi[3], double fmi[3])
   fmi[0] -= alpha_t*cpx;
   fmi[1] -= alpha_t*cpy;
   fmi[2] -= alpha_t*cpz;
-  
+
   energyD -= hbar*(alpha_t*cpx*cpx + alpha_t*cpy*cpy + alpha_t*cpz*cpz);
 }
 
@@ -175,7 +175,7 @@ void FixLangevinSpin::add_temperature(double spi[3], double fmi[3])
   fmi[0] *= gil_factor;
   fmi[1] *= gil_factor;
   fmi[2] *= gil_factor;
-  
+
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/SPIN/fix_langevin_spin.h
+++ b/src/SPIN/fix_langevin_spin.h
@@ -34,15 +34,20 @@ class FixLangevinSpin : public Fix {
   void init() override;
   void setup(int) override;
   void add_tdamping(double *, double *);    // add transverse damping
-  void add_temperature(double[3]);
+  void add_temperature(double *, double *);
   void compute_single_langevin(int, double *, double *);
+  void allocate();
+  double compute_vector(int);
 
  protected:
   double alpha_t;       // transverse mag. damping
   double dts;           // magnetic timestep
   double temp;          // spin bath temperature
-  double D, sigma;      // bath intensity var.
+  double D,sigma;      // bath intensity var.
   double gil_factor;    // gilbert's prefactor
+  double *energy_vec;
+  double energyS;
+  double energyD;
 
   int nlevels_respa;
   class RanMars *random;

--- a/src/SPIN/fix_langevin_spin.h
+++ b/src/SPIN/fix_langevin_spin.h
@@ -36,18 +36,15 @@ class FixLangevinSpin : public Fix {
   void add_tdamping(double *, double *);    // add transverse damping
   void add_temperature(double *, double *);
   void compute_single_langevin(int, double *, double *);
-  void allocate();
   double compute_vector(int);
 
  protected:
   double alpha_t;       // transverse mag. damping
   double dts;           // magnetic timestep
   double temp;          // spin bath temperature
-  double D,sigma;      // bath intensity var.
+  double D, sigma;      // bath intensity var.
   double gil_factor;    // gilbert's prefactor
-  double *energy_vec;
-  double energyS;
-  double energyD;
+  double energy_vec[2]; // D and sigma
 
   int nlevels_respa;
   class RanMars *random;


### PR DESCRIPTION
**Summary**

Adding energy tracking to fix_langevin_spin - to replicate similar behavior by fix_langevin

**Related Issue(s)**

N/A

**Author(s)**

Svetoslav Nikolov
Julien Tranchida

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Backward Compatibility**

Should be backward compatible

**Implementation Notes**

Correctness verified by carrying out magnon thermal conductivity calculations for iron. See https://doi.org/10.1007/s10853-021-06865-3

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**