### PR TITLE
Provide access to constraint or restraint forces in fix shake

### DIFF
--- a/doc/src/fix_shake.rst
+++ b/doc/src/fix_shake.rst
@@ -33,7 +33,7 @@ Syntax
        *m* value = one or more mass values
 
 * zero or more keyword/value pairs may be appended
-* keyword = *mol* or *kbond*
+* keyword = *mol* or *kbond* or *store*
 
   .. parsed-literal::
 
@@ -41,6 +41,7 @@ Syntax
          template-ID = ID of molecule template specified in a separate :doc:`molecule <molecule>` command
        *kbond* value = force constant
          force constant = force constant used to apply a restraint force when used during minimization
+       *store* value = *yes* or *no*
 
 Examples
 """"""""
@@ -50,6 +51,7 @@ Examples
    fix 1 sub shake 0.0001 20 10 b 4 19 a 3 5 2
    fix 1 sub shake 0.0001 20 10 t 5 6 m 1.0 a 31
    fix 1 sub shake 0.0001 20 10 t 5 6 m 1.0 a 31 mol myMol
+   fix 1 sub shake 0.0001 20 10 t 5 6 m 1.0 a 31 store yes
    fix 1 sub rattle 0.0001 20 10 t 5 6 m 1.0 a 31
    fix 1 sub rattle 0.0001 20 10 t 5 6 m 1.0 a 31 mol myMol
 
@@ -198,6 +200,22 @@ will be fulfilled to the desired accuracy within a few MD steps
 following the minimization. The default value for *kbond* depends on the
 :doc:`units <units>` setting and is 1.0e9*k_B.
 
+.. versionadded:: TBD
+
+The *store* keyword controls whether the fix stores the constraint
+(or restraint) forces as a per-atom property.
+
+During an MD :doc:`run <run>`, the constraint forces are the forces on
+atoms due to the constraints after an constrained position update.
+Applying the SHAKE constraint *minimizes* those forces.  By using *store
+yes* the original constraint forces on all atoms can be accessed as a
+per-atom array of the fix.
+
+During a :doc:`minimization <minimize>`, restraint forces are added to
+the atoms to keep the constrained bonds and angles close to their
+initial values.  By using *store yes* those added forces can be accessed
+as a per-atom array of the fix.
+
 ----------
 
 .. include:: accel_styles.rst
@@ -292,7 +310,7 @@ Related commands
 Default
 """""""
 
-kbond = 1.0e9*k_B
+kbond = 1.0e9*k_B, store = no
 
 ----------
 

--- a/doc/src/fix_shake.rst
+++ b/doc/src/fix_shake.rst
@@ -206,7 +206,7 @@ The *store* keyword controls whether the fix stores the constraint
 (or restraint) forces as a per-atom property.
 
 During an MD :doc:`run <run>`, the constraint forces are the forces on
-atoms due to the constraints after an constrained position update.
+atoms due to the constraints after a constrained position update.
 Applying the SHAKE constraint *minimizes* those forces.  By using *store
 yes* the original constraint forces on all atoms can be accessed as a
 per-atom array of the fix.

--- a/doc/src/fix_shake.rst
+++ b/doc/src/fix_shake.rst
@@ -19,9 +19,9 @@ Syntax
 
 * ID, group-ID are documented in :doc:`fix <fix>` command
 * style = shake or rattle = style name of this fix command
-* tol = accuracy tolerance of SHAKE solution
-* iter = max # of iterations in each SHAKE solution
-* N = print SHAKE statistics every this many timesteps (0 = never)
+* tol = accuracy tolerance of SHAKE or RATTLE solution
+* iter = max # of iterations in each SHAKE or RATTLE solution
+* N = print SHAKE or RATTLE statistics every this many timesteps (0 = never)
 * one or more constraint/value pairs are appended
 * constraint = *b* or *a* or *t* or *m*
 
@@ -119,6 +119,8 @@ Setting the N argument will print statistics to the screen and log
 file about regarding the lengths of bonds and angles that are being
 constrained.  Small delta values mean SHAKE is doing a good job.
 
+-----
+
 In LAMMPS, only small clusters of atoms can be constrained.  This is
 so the constraint calculation for a cluster can be performed by a
 single processor, to enable good parallel performance.  A cluster is
@@ -150,25 +152,27 @@ Thus, LAMMPS will print a warning and type label handling is disabled
 and numeric types must be used.
 
 For all constraints, a particular bond is only constrained if *both*
-atoms in the bond are in the group specified with the SHAKE fix.
+atoms in the bond are in the group specified with the SHAKE or RATTLE
+fix.
 
 The degrees-of-freedom removed by SHAKE bonds and angles are accounted
-for in temperature and pressure computations.  Similarly, the SHAKE
-contribution to the pressure of the system (virial) is also accounted
-for.
+for in temperature and pressure computations.  Similarly, the SHAKE or
+RATTLE contribution to the pressure of the system (virial) is also
+accounted for.
 
 .. note::
 
-   This command works by using the current forces on atoms to calculate
-   an additional constraint force which when added will leave the atoms
-   in positions that satisfy the SHAKE constraints (e.g. bond length)
-   after the next time integration step.  If you define fixes
-   (e.g. :doc:`fix efield <fix_efield>`) that add additional force to
-   the atoms after *fix shake* operates, then this fix will not take them
-   into account and the time integration will typically not satisfy the
-   SHAKE constraints.  The solution for this is to make sure that fix
-   shake is defined in your input script after any other fixes which add
-   or change forces (to atoms that *fix shake* operates on).
+   The *fix shake* command works by using the current forces on atoms to
+   calculate an additional constraint force which when added will leave
+   the atoms in positions that satisfy the SHAKE constraints (e.g. bond
+   length) after the next time integration step.  If you define fixes
+   (e.g. :doc:`fix efield <fix_efield>`) that add additional forces to
+   the atoms **after** *fix shake* operates, then those forces will not
+   be taken into account, and the time integration will typically not
+   fully satisfy the SHAKE constraints.  The solution for this is to make
+   sure that *fix shake* is defined in your input script **after** any
+   other fixes which add or change forces (to atoms that *fix shake*
+   operates on).
 
 ----------
 

--- a/src/KOKKOS/fix_shake_kokkos.cpp
+++ b/src/KOKKOS/fix_shake_kokkos.cpp
@@ -44,6 +44,9 @@ FixShakeKokkos<DeviceType>::FixShakeKokkos(LAMMPS *lmp, int narg, char **arg) :
   atomKK = (AtomKokkos *)atom;
   execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
 
+  if (store_flag)
+    error->all(FLERR, "Option 'store yes' is not (yet) supported by fix {}/kk", style);
+
   datamask_read = EMPTY_MASK;
   datamask_modify = EMPTY_MASK;
 

--- a/src/RIGID/fix_rattle.cpp
+++ b/src/RIGID/fix_rattle.cpp
@@ -64,8 +64,6 @@ FixRattle::FixRattle(LAMMPS *lmp, int narg, char **arg) :
   vp = nullptr;
   FixRattle::grow_arrays(atom->nmax);
 
-  if (store_flag) error->all(FLERR, "Option 'store yes' is not yet compatible with fix rattle");
-
   // default communication mode
   // necessary for compatibility with SHAKE
   // see pack_forward and unpack_forward
@@ -139,8 +137,7 @@ void FixRattle::init() {
   }
 
   if (flag && comm->me == 0)
-    error->warning(FLERR,
-                   "Fix rattle should come after all other integration fixes ");
+    error->warning(FLERR, "Fix rattle should come after all other integration fixes ");
 }
 
 /* ----------------------------------------------------------------------

--- a/src/RIGID/fix_rattle.cpp
+++ b/src/RIGID/fix_rattle.cpp
@@ -64,6 +64,8 @@ FixRattle::FixRattle(LAMMPS *lmp, int narg, char **arg) :
   vp = nullptr;
   FixRattle::grow_arrays(atom->nmax);
 
+  if (store_flag) error->all(FLERR, "Option 'store yes' is not yet compatible with fix rattle");
+
   // default communication mode
   // necessary for compatibility with SHAKE
   // see pack_forward and unpack_forward
@@ -83,18 +85,20 @@ FixRattle::~FixRattle()
 
 #if RATTLE_DEBUG
 
-    // communicate maximum distance error
+  // communicate maximum distance error
 
-    double global_derr_max, global_verr_max;
-    int npid;
+  double global_derr_max, global_verr_max;
+  int npid;
 
-    MPI_Reduce(&derr_max, &global_derr_max, 1 , MPI_DOUBLE, MPI_MAX, 0, world);
-    MPI_Reduce(&verr_max, &global_verr_max, 1 , MPI_DOUBLE, MPI_MAX, 0, world);
+  MPI_Reduce(&derr_max, &global_derr_max, 1 , MPI_DOUBLE, MPI_MAX, 0, world);
+  MPI_Reduce(&verr_max, &global_verr_max, 1 , MPI_DOUBLE, MPI_MAX, 0, world);
 
-    if (comm->me == 0 && screen) {
-      fprintf(screen, "RATTLE: Maximum overall relative position error ( (r_ij-d_ij)/d_ij ): %.10g\n", global_derr_max);
-      fprintf(screen, "RATTLE: Maximum overall absolute velocity error (r_ij * v_ij): %.10g\n", global_verr_max);
-    }
+  if (comm->me == 0) {
+    utils::logmesg(lmp, "RATTLE: Maximum overall relative position error ( (r_ij-d_ij)/d_ij ): "
+                   "{:.10}\n", global_derr_max);
+    utils::logmesg(lmp, "RATTLE: Maximum overall absolute velocity error (r_ij * v_ij): {:.10}\n",
+                   global_verr_max);
+  }
 #endif
 }
 

--- a/src/RIGID/fix_rattle.cpp
+++ b/src/RIGID/fix_rattle.cpp
@@ -262,13 +262,13 @@ void FixRattle::vrattle3angle(int m)
   // matrix coeffs and rhs for lamda equations
 
   if (rmass) {
-    imass[0] = 1.0/rmass[i0];
-    imass[1] = 1.0/rmass[i1];
-    imass[2] = 1.0/rmass[i2];
+    imass[0] = 1.0 / rmass[i0];
+    imass[1] = 1.0 / rmass[i1];
+    imass[2] = 1.0 / rmass[i2];
   } else {
-    imass[0] = 1.0/mass[type[i0]];
-    imass[1] = 1.0/mass[type[i1]];
-    imass[2] = 1.0/mass[type[i2]];
+    imass[0] = 1.0 / mass[type[i0]];
+    imass[1] = 1.0 / mass[type[i1]];
+    imass[2] = 1.0 / mass[type[i2]];
   }
 
   // setup matrix
@@ -333,11 +333,11 @@ void FixRattle::vrattle2(int m)
   // matrix coeffs and rhs for lamda equations
 
   if (rmass) {
-    imass[0] = 1.0/rmass[i0];
-    imass[1] = 1.0/rmass[i1];
+    imass[0] = 1.0 / rmass[i0];
+    imass[1] = 1.0 / rmass[i1];
   } else {
-    imass[0] = 1.0/mass[type[i0]];
-    imass[1] = 1.0/mass[type[i1]];
+    imass[0] = 1.0 / mass[type[i0]];
+    imass[1] = 1.0 / mass[type[i1]];
   }
 
   // Lagrange multiplier: exact solution
@@ -385,13 +385,13 @@ void FixRattle::vrattle3(int m)
   MathExtra::sub3(vp[i2],vp[i0],vp02);
 
   if (rmass) {
-    imass[0] = 1.0/rmass[i0];
-    imass[1] = 1.0/rmass[i1];
-    imass[2] = 1.0/rmass[i2];
+    imass[0] = 1.0 / rmass[i0];
+    imass[1] = 1.0 / rmass[i1];
+    imass[2] = 1.0 / rmass[i2];
   } else {
-    imass[0] = 1.0/mass[type[i0]];
-    imass[1] = 1.0/mass[type[i1]];
-    imass[2] = 1.0/mass[type[i2]];
+    imass[0] = 1.0 / mass[type[i0]];
+    imass[1] = 1.0 / mass[type[i1]];
+    imass[2] = 1.0 / mass[type[i2]];
   }
 
   // setup matrix
@@ -460,15 +460,15 @@ void FixRattle::vrattle4(int m)
   // matrix coeffs and rhs for lamda equations
 
   if (rmass) {
-    imass[0] = 1.0/rmass[i0];
-    imass[1] = 1.0/rmass[i1];
-    imass[2] = 1.0/rmass[i2];
-    imass[3] = 1.0/rmass[i3];
+    imass[0] = 1.0 / rmass[i0];
+    imass[1] = 1.0 / rmass[i1];
+    imass[2] = 1.0 / rmass[i2];
+    imass[3] = 1.0 / rmass[i3];
   } else {
-    imass[0] = 1.0/mass[type[i0]];
-    imass[1] = 1.0/mass[type[i1]];
-    imass[2] = 1.0/mass[type[i2]];
-    imass[3] = 1.0/mass[type[i3]];
+    imass[0] = 1.0 / mass[type[i0]];
+    imass[1] = 1.0 / mass[type[i1]];
+    imass[2] = 1.0 / mass[type[i2]];
+    imass[3] = 1.0 / mass[type[i3]];
   }
 
   // setup matrix
@@ -604,7 +604,7 @@ void FixRattle::update_v_half_nocons()
   }
   else {
     for (int i = 0; i < nlocal; i++) {
-      dtfvinvm = dtfv/mass[type[i]];
+      dtfvinvm = dtfv / mass[type[i]];
       if (shake_flag[i]) {
         for (int k=0; k<3; k++)
           vp[i][k] = v[i][k] + dtfvinvm * f[i][k];

--- a/src/RIGID/fix_shake.cpp
+++ b/src/RIGID/fix_shake.cpp
@@ -48,12 +48,12 @@ static constexpr double MASSDELTA = 0.1;
 
 FixShake::FixShake(LAMMPS *lmp, int narg, char **arg) :
     Fix(lmp, narg, arg), bond_flag(nullptr), angle_flag(nullptr), type_flag(nullptr),
-    mass_list(nullptr), bond_distance(nullptr), angle_distance(nullptr), loop_respa(nullptr),
-    step_respa(nullptr), x(nullptr), v(nullptr), f(nullptr), ftmp(nullptr), vtmp(nullptr),
-    mass(nullptr), rmass(nullptr), type(nullptr), shake_flag(nullptr), shake_atom(nullptr),
-    shake_type(nullptr), xshake(nullptr), nshake(nullptr), list(nullptr), closest_list(nullptr),
-    b_count(nullptr), b_count_all(nullptr), b_ave(nullptr), b_max(nullptr), b_min(nullptr),
-    b_ave_all(nullptr), b_max_all(nullptr), b_min_all(nullptr), a_count(nullptr),
+    mass_list(nullptr), bond_distance(nullptr), angle_distance(nullptr), fstore(nullptr),
+    loop_respa(nullptr), step_respa(nullptr), x(nullptr), v(nullptr), f(nullptr), ftmp(nullptr),
+    vtmp(nullptr), mass(nullptr), rmass(nullptr), type(nullptr), shake_flag(nullptr),
+    shake_atom(nullptr), shake_type(nullptr), xshake(nullptr), nshake(nullptr), list(nullptr),
+    closest_list(nullptr), b_count(nullptr), b_count_all(nullptr), b_ave(nullptr), b_max(nullptr),
+    b_min(nullptr), b_ave_all(nullptr), b_max_all(nullptr), b_min_all(nullptr), a_count(nullptr),
     a_count_all(nullptr), a_ave(nullptr), a_max(nullptr), a_min(nullptr), a_ave_all(nullptr),
     a_max_all(nullptr), a_min_all(nullptr), atommols(nullptr), onemols(nullptr)
 {
@@ -79,16 +79,13 @@ FixShake::FixShake(LAMMPS *lmp, int narg, char **arg) :
   if (molecular == Atom::ATOMIC)
     error->all(FLERR, "Cannot use fix {} with non-molecular system", style);
 
+  // do not store constraint forces by default
+
+  store_flag = peratom_flag = 0;
+  maxstore = -1;
+
   // perform initial allocation of atom-based arrays
   // register with Atom class
-
-  shake_flag = nullptr;
-  shake_atom = nullptr;
-  shake_type = nullptr;
-  xshake = nullptr;
-
-  ftmp = nullptr;
-  vtmp = nullptr;
 
   FixShake::grow_arrays(atom->nmax);
   atom->add_callback(Atom::GROW);
@@ -150,7 +147,8 @@ FixShake::FixShake(LAMMPS *lmp, int narg, char **arg) :
 
     // break if known optional keyword
 
-    } else if ((strcmp(arg[next], "mol") == 0) || (strcmp(arg[next], "kbond") == 0)) {
+    } else if ((strcmp(arg[next], "mol") == 0) || (strcmp(arg[next], "kbond") == 0) ||
+               (strcmp(arg[next], "store") == 0)) {
       break;
 
     // get numeric types for b, a, t, or m keywords.
@@ -211,6 +209,19 @@ FixShake::FixShake(LAMMPS *lmp, int narg, char **arg) :
       if (iarg+2 > narg) utils::missing_cmd_args(FLERR,mystyle+" kbond",error);
       kbond = utils::numeric(FLERR, arg[iarg+1], false, lmp);
       if (kbond < 0) error->all(FLERR,"Illegal {} kbond value {}. Must be >= 0.0", mystyle, kbond);
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"store") == 0) {
+      if (iarg+2 > narg) utils::missing_cmd_args(FLERR,mystyle+" store",error);
+      store_flag = utils::logical(FLERR, arg[iarg+1], false, lmp);
+      if (store_flag) {
+        peratom_flag = 1;
+        size_peratom_cols = 3;
+        peratom_freq = 1;
+      } else {
+        peratom_flag = 0;
+        size_peratom_cols = 0;
+        peratom_freq = 0;
+      }
       iarg += 2;
     } else error->all(FLERR,"Unknown {} command option: {}", mystyle, arg[iarg]);
   }
@@ -315,6 +326,7 @@ FixShake::~FixShake()
   memory->destroy(ftmp);
   memory->destroy(vtmp);
 
+  memory->destroy(fstore);
 
   delete[] bond_flag;
   delete[] angle_flag;
@@ -777,9 +789,22 @@ void FixShake::min_post_force(int vflag)
     a_min[i] = BIG;
   }
 
+  // allocate storage for restraint forces if requested
+
+  if (store_flag) {
+    if (maxstore < atom->nmax) {
+      maxstore = MAX(atom->nmax, 1);
+      memory->destroy(fstore);
+      memory->create(fstore, maxstore, 3, "shake/fstore");
+      for (int i = 0; i < maxstore; ++i) fstore[i][0] = fstore[i][1] = fstore[i][2] = 0.0;
+    }
+    array_atom = fstore;
+  }
+
   // loop over local shake clusters to add restraint forces
 
   for (int i = 0; i < nlocal; i++) {
+    if (store_flag) fstore[i][0] = fstore[i][1] = fstore[i][2] = 0.0;
     if (shake_flag[i]) {
       if (shake_flag[i] == 2) {
         atom1 = atom->map(shake_atom[i][0]);
@@ -1455,8 +1480,9 @@ void FixShake::partner_info(int *npartner, tagint **partner_tag,
           partner_massflag[i][j] = masscheck(massone);
         }
         n = bondtype_findset(i,tag[i],partner_tag[i][j],0);
-        if (n) partner_bondtype[i][j] = n;
-        else {
+        if (n) {
+          partner_bondtype[i][j] = n;
+        } else {
           n = bondtype_findset(m,tag[i],partner_tag[i][j],0);
           if (n) partner_bondtype[i][j] = n;
         }
@@ -2809,6 +2835,11 @@ double FixShake::bond_force(int i1, int i2, double length)
     f[i1][0] += delx * fbond;
     f[i1][1] += dely * fbond;
     f[i1][2] += delz * fbond;
+    if (store_flag) {
+      fstore[i1][0] += delx * fbond;
+      fstore[i1][1] += dely * fbond;
+      fstore[i1][2] += delz * fbond;
+    }
     atomlist[count++] = i1;
     ebond += 0.5*eb;
   }
@@ -2816,6 +2847,11 @@ double FixShake::bond_force(int i1, int i2, double length)
     f[i2][0] -= delx * fbond;
     f[i2][1] -= dely * fbond;
     f[i2][2] -= delz * fbond;
+    if (store_flag) {
+      fstore[i2][0] -= delx * fbond;
+      fstore[i2][1] -= dely * fbond;
+      fstore[i2][2] -= delz * fbond;
+    }
     atomlist[count++] = i2;
     ebond += 0.5*eb;
   }
@@ -3445,11 +3481,23 @@ void FixShake::correct_velocities() {}
 
 void FixShake::correct_coordinates(int vflag) {
 
+  // allocate storage for constraint forces if requested
+
+  if (store_flag) {
+    if (maxstore < atom->nmax) {
+      maxstore = MAX(atom->nmax,1);
+      memory->destroy(fstore);
+      memory->create(fstore, maxstore, 3, "shake/fstore");
+      for (int i = 0; i < maxstore; ++i) fstore[i][0] = fstore[i][1] = fstore[i][2] = 0.0;
+    }
+    array_atom = fstore;
+  }
+
   // save current forces and velocities so that you
   // initialize them to zero such that FixShake::unconstrained_coordinate_update has no effect
 
-  for (int j=0; j<nlocal; j++) {
-    for (int k=0; k<3; k++) {
+  for (int j = 0; j < nlocal; ++j) {
+    for (int k = 0; k < 3; ++k) {
 
       // store current value of forces and velocities
 
@@ -3458,8 +3506,8 @@ void FixShake::correct_coordinates(int vflag) {
 
       // set f and v to zero for SHAKE
 
-      v[j][k] = 0;
-      f[j][k] = 0;
+      v[j][k] = 0.0;
+      f[j][k] = 0.0;
     }
   }
 
@@ -3480,8 +3528,7 @@ void FixShake::correct_coordinates(int vflag) {
       x[i][1] = x[i][1] + dtfmsq*f[i][1];
       x[i][2] = x[i][2] + dtfmsq*f[i][2];
     }
-  }
-  else {
+  } else {
     for (int i = 0; i < nlocal; i++) {
       dtfmsq = dtfsq / mass[type[i]];
       x[i][0] = x[i][0] + dtfmsq*f[i][0];
@@ -3490,10 +3537,20 @@ void FixShake::correct_coordinates(int vflag) {
     }
   }
 
+  // store constraint forces if requested
+
+  if (store_flag) {
+    for (int j = 0; j < nlocal; ++j) {
+      for (int k = 0; k < 3; ++k) {
+        fstore[j][k] = f[j][k];
+      }
+    }
+  }
+
   // copy forces and velocities back
 
-  for (int j=0; j<nlocal; j++) {
-    for (int k=0; k<3; k++) {
+  for (int j = 0; j < nlocal; ++j) {
+    for (int k = 0; k < 3; ++k) {
       f[j][k] = ftmp[j][k];
       v[j][k] = vtmp[j][k];
     }

--- a/src/RIGID/fix_shake.cpp
+++ b/src/RIGID/fix_shake.cpp
@@ -2070,11 +2070,11 @@ void FixShake::shake(int ilist)
   // a,b,c = coeffs in quadratic equation for lamda
 
   if (rmass) {
-    invmass0 = 1.0/rmass[i0];
-    invmass1 = 1.0/rmass[i1];
+    invmass0 = 1.0 / rmass[i0];
+    invmass1 = 1.0 / rmass[i1];
   } else {
-    invmass0 = 1.0/mass[type[i0]];
-    invmass1 = 1.0/mass[type[i1]];
+    invmass0 = 1.0 / mass[type[i0]];
+    invmass1 = 1.0 / mass[type[i1]];
   }
 
   double a = (invmass0+invmass1)*(invmass0+invmass1) * r01sq;
@@ -2187,13 +2187,13 @@ void FixShake::shake3(int ilist)
   // matrix coeffs and rhs for lamda equations
 
   if (rmass) {
-    invmass0 = 1.0/rmass[i0];
-    invmass1 = 1.0/rmass[i1];
-    invmass2 = 1.0/rmass[i2];
+    invmass0 = 1.0 / rmass[i0];
+    invmass1 = 1.0 / rmass[i1];
+    invmass2 = 1.0 / rmass[i2];
   } else {
-    invmass0 = 1.0/mass[type[i0]];
-    invmass1 = 1.0/mass[type[i1]];
-    invmass2 = 1.0/mass[type[i2]];
+    invmass0 = 1.0 / mass[type[i0]];
+    invmass1 = 1.0 / mass[type[i1]];
+    invmass2 = 1.0 / mass[type[i2]];
   }
 
   double a11 = 2.0 * (invmass0+invmass1) *
@@ -2375,15 +2375,15 @@ void FixShake::shake4(int ilist)
   // matrix coeffs and rhs for lamda equations
 
   if (rmass) {
-    invmass0 = 1.0/rmass[i0];
-    invmass1 = 1.0/rmass[i1];
-    invmass2 = 1.0/rmass[i2];
-    invmass3 = 1.0/rmass[i3];
+    invmass0 = 1.0 / rmass[i0];
+    invmass1 = 1.0 / rmass[i1];
+    invmass2 = 1.0 / rmass[i2];
+    invmass3 = 1.0 / rmass[i3];
   } else {
-    invmass0 = 1.0/mass[type[i0]];
-    invmass1 = 1.0/mass[type[i1]];
-    invmass2 = 1.0/mass[type[i2]];
-    invmass3 = 1.0/mass[type[i3]];
+    invmass0 = 1.0 / mass[type[i0]];
+    invmass1 = 1.0 / mass[type[i1]];
+    invmass2 = 1.0 / mass[type[i2]];
+    invmass3 = 1.0 / mass[type[i3]];
   }
 
   double a11 = 2.0 * (invmass0+invmass1) *
@@ -2626,13 +2626,13 @@ void FixShake::shake3angle(int ilist)
   // matrix coeffs and rhs for lamda equations
 
   if (rmass) {
-    invmass0 = 1.0/rmass[i0];
-    invmass1 = 1.0/rmass[i1];
-    invmass2 = 1.0/rmass[i2];
+    invmass0 = 1.0 / rmass[i0];
+    invmass1 = 1.0 / rmass[i1];
+    invmass2 = 1.0 / rmass[i2];
   } else {
-    invmass0 = 1.0/mass[type[i0]];
-    invmass1 = 1.0/mass[type[i1]];
-    invmass2 = 1.0/mass[type[i2]];
+    invmass0 = 1.0 / mass[type[i0]];
+    invmass1 = 1.0 / mass[type[i1]];
+    invmass2 = 1.0 / mass[type[i2]];
   }
 
   double a11 = 2.0 * (invmass0+invmass1) *
@@ -3523,7 +3523,7 @@ void FixShake::correct_coordinates(int vflag) {
   double dtfmsq;
   if (rmass) {
     for (int i = 0; i < nlocal; i++) {
-      dtfmsq = dtfsq/ rmass[i];
+      dtfmsq = dtfsq / rmass[i];
       x[i][0] = x[i][0] + dtfmsq*f[i][0];
       x[i][1] = x[i][1] + dtfmsq*f[i][1];
       x[i][2] = x[i][2] + dtfmsq*f[i][2];

--- a/src/RIGID/fix_shake.h
+++ b/src/RIGID/fix_shake.h
@@ -84,6 +84,10 @@ class FixShake : public Fix {
   double kbond;                              // force constant for restraint
   double ebond;                              // energy of bond restraints
 
+  int store_flag;               // store per-atom constraint/restraint forces if true
+  int maxstore;                 // current size of fstore array
+  double **fstore;              // constraint/restraint force
+
   class FixRespa *fix_respa;    // rRESPA fix needed by SHAKE
   int nlevels_respa;            // copies of needed rRESPA variables
   int *loop_respa;


### PR DESCRIPTION
**Summary**

This pull request adds a feature to fix shake to optionally store constraint forces as per-atom data.

**Related Issue(s)**

Implements and thus closes #4679 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Backward Compatibility**

Yes

**Implementation Notes**

Fix shake temporarily zeroes forces and velocities to perform an unconstrained position update and then computes the forces on atoms due to the constraints. This change makes a copy of the forces before the original forces and velocities are restored.

Support for KOKKOS and fix rattle are pending.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
