### PR TITLE
Restore fix_langevin omega keyword

### DIFF
--- a/src/fix_langevin.cpp
+++ b/src/fix_langevin.cpp
@@ -106,8 +106,7 @@ FixLangevin::FixLangevin(LAMMPS *lmp, int narg, char **arg) :
         ascale = utils::numeric(FLERR, arg[iarg + 1], false, lmp);
       iarg += 2;
     } else if (strcmp(arg[iarg], "omega") == 0) {
-      if (iarg + 2 > narg) utils::missing_cmd_args(FLERR, "fix langevin angmom", error);
-      error->all(FLERR, "Illegal fix langevin command");
+      if (iarg + 2 > narg) utils::missing_cmd_args(FLERR, "fix langevin omega", error);
       oflag = utils::logical(FLERR, arg[iarg + 1], false, lmp);
       iarg += 2;
     } else if (strcmp(arg[iarg], "scale") == 0) {


### PR DESCRIPTION
**Summary**

Removed faulty line from commit b3a6a7e triggering an error using the omega keyword with fix_langevin, probably a typo.

**Related Issue(s)**


**Author(s)**

@jeremyaqp  @ Sorbonne Université

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Backward Compatibility**

-

**Implementation Notes**
-

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**
-


