### PR TITLE
Improve support for dynamic and variable regions

### DIFF
--- a/doc/src/dump_image.rst
+++ b/doc/src/dump_image.rst
@@ -530,20 +530,20 @@ change this via the dump_modify command.
 
 .. versionadded:: 10Sep2025
 
-The *region* keyword can be used to create a graphical representation
-of a :doc:`region <region>`.  This can be helpful in debugging the
-location and extent of regions, especially when those have parameters
-controlled by variables.  Three styles of representing a region are
-available: *filled*, *frame*, and *points*. With style *filled* the
-surface of the region is drawn.  For region styles that support open
-faces, surfaces are not drawn for such open faces. Draw style *frame*
-represents the region with a mesh of "wires" the diameter of which can
-be set. Unlike with *filled*, you can look inside the region with this
-draw style. The third draw style *points* generates a random point
-cloud inside the simulation box and draws only those points that are
-within the region.  Draw styles *filled* and *frame* support only
-"primitive" region style (no unions or intersections), but the *points*
-draw style supports all region styles.
+The *region* keyword can be used to create a graphical representation of
+a :doc:`region <region>`.  This can be helpful in debugging the location
+and extent of regions, especially when those have parameters controlled
+by variables.  Three styles of representing a region are available:
+*filled*, *frame*, and *points*.  With style *filled* the surface of the
+region is drawn.  For region styles that support open faces, surfaces
+are not drawn for such open faces.  Draw style *frame* represents the
+region with a mesh of "wires".  The diameter of these "wires" can be
+set.  Unlike with the *filled* style, you can see what is *inside* the
+region with this draw style.  The third draw style *points* generates a
+random point cloud inside the simulation box and draws only those points
+that are within the region.  Draw styles *filled* and *frame* support
+only "primitive" region style (no unions or intersections), but the
+*points* draw style supports all region styles.
 
 ----------
 

--- a/doc/src/region.rst
+++ b/doc/src/region.rst
@@ -232,16 +232,16 @@ a time dependent position of the sphere or cylinder region.
 
    Whenever a region property, such as a coordinate or an upper/lower
    bound, is defined via an equal-style variable, the variable should
-   not cause any of the region boundaries to move
-   too far within a single timestep. Otherwise, bad dynamics will occur.
-   "Too far" means a small fraction of the approximate distance of
-   closest approach between two particles, which for the case of Lennard-Jones
-   particles is the distance of the energy minimum while for granular
-   particles it is their diameter. An example is a rapidly varying direction
-   vector in region plane since a small change in the normal to plane will
-   shift the region surface far away from the region point by a large displacement.
-   Similarly, bad dynamics can also occur for fast changing variables employed
-   in the move/rotate options.
+   not cause any of the region boundaries to move too far within a
+   single timestep. Otherwise, bad dynamics will occur.  "Too far" means
+   a small fraction of the approximate distance of closest approach
+   between two particles, which for the case of Lennard-Jones particles
+   is the distance of the energy minimum while for granular particles it
+   is their diameter. An example is a rapidly varying direction vector
+   in region plane since a small change in the normal to plane will
+   shift the region surface far away from the region point by a large
+   displacement.  Similarly, bad dynamics can also occur for fast
+   changing variables employed in the move/rotate options.
 
 See the :doc:`Howto tricilinc <Howto_triclinic>` page for a
 geometric description of triclinic boxes, as defined by LAMMPS, and
@@ -311,17 +311,18 @@ define the lattice spacings which are used as follows:
 
 If the *move* or *rotate* keywords are used, the region is "dynamic",
 meaning its location or orientation changes with time.  These keywords
-cannot be used with a *union* or *intersect* style region.  Instead,
-the keywords should be used to make the individual sub-regions of the
-*union* or *intersect* region dynamic.  Normally, each sub-region
-should be "dynamic" in the same manner (e.g. rotate around the same
-point), though this is not a requirement.
+cannot be used with a *union* or *intersect* style region.  Instead, the
+keywords should be used to make the individual sub-regions of the
+*union* or *intersect* region dynamic.  Normally, each sub-region should
+be "dynamic" in the same manner (e.g. rotate around the same point),
+though this is not a requirement.
 
-The *move* keyword allows one or more :doc:`equal-style variables <variable>` to be used to specify the x,y,z displacement
-of the region, typically as a function of time.  A variable is
-specified as v_name, where name is the variable name.  Any of the
-three variables can be specified as NULL, in which case no
-displacement is calculated in that dimension.
+The *move* keyword allows one or more :doc:`equal-style variables
+<variable>` to be used to specify the x,y,z displacement of the region,
+typically as a function of time.  A variable is specified as v_name,
+where name is the variable name.  Any of the three variables can be
+specified as NULL, in which case no displacement is calculated in that
+dimension.
 
 Note that equal-style variables can specify formulas with various
 mathematical functions, and include :doc:`thermo_style <thermo_style>`
@@ -329,7 +330,8 @@ command keywords for the simulation box parameters and timestep and
 elapsed time.  Thus it is easy to specify a region displacement that
 change as a function of time or spans consecutive runs in a continuous
 fashion.  For the latter, see the *start* and *stop* keywords of the
-:doc:`run <run>` command and the *elaplong* keyword of :doc:`thermo_style custom <thermo_style>` for details.
+:doc:`run <run>` command and the *elaplong* keyword of
+:doc:`thermo_style custom <thermo_style>` for details.
 
 For example, these commands would displace a region from its initial
 position, in the positive x direction, effectively at a constant
@@ -362,7 +364,8 @@ wrap around the axis in the direction of rotation.
 
 The *move* and *rotate* keywords can be used together.  In this case,
 the displacement specified by the *move* keyword is applied to the *P*
-point of the *rotate* keyword.
+point of the *rotate* keyword which is equivalent to applying the
+rotation *first* and then the translation.
 
 ----------
 

--- a/src/dump_image.cpp
+++ b/src/dump_image.cpp
@@ -1829,6 +1829,7 @@ void DumpImage::create_image()
         // inconsistent style. should not happen.
         if (!myreg) continue;
 
+        // construct coordinates for lo/hi tip/center of cone
         double lo[3], hi[3];
         if (myreg->axis == 'x') {
           lo[0] = myreg->lo;
@@ -1852,6 +1853,9 @@ void DumpImage::create_image()
           hi[1] = myreg->c2;
           hi[2] = myreg->hi;
         }
+        // Apply forward_transform for cone lo/hi tip/center for dynamic regions
+        myreg->forward_transform(lo[0], lo[1], lo[2]);
+        myreg->forward_transform(hi[0], hi[1], hi[2]);
 
         double p1[3], p2[3], p3[3], p4[3];
         if (reg.style == FRAME) {
@@ -1990,6 +1994,7 @@ void DumpImage::create_image()
         // inconsistent style. should not happen.
         if (!myreg) continue;
 
+        // construct coordinates for lo/hi center of cylinder
         double lo[3], hi[3];
         if (myreg->axis == 'x') {
           lo[0] = myreg->lo;
@@ -2013,6 +2018,9 @@ void DumpImage::create_image()
           hi[1] = myreg->c2;
           hi[2] = myreg->hi;
         }
+        // Apply forward_transform for cylinder lo/hi center for dynamic regions
+        myreg->forward_transform(lo[0], lo[1], lo[2]);
+        myreg->forward_transform(hi[0], hi[1], hi[2]);
 
         double p1[3], p2[3], p3[3], p4[3];
         if (reg.style == FRAME) {

--- a/src/dump_image.cpp
+++ b/src/dump_image.cpp
@@ -127,7 +127,7 @@ void scale_and_displace_triangle(triangle &tri, const double *radius, const vec3
 }
 
 void ellipsoid2wireframe(LAMMPS_NS::Image *img, int level, const double *color, double diameter,
-                         const double *center, const double *radius)
+                         const double *center, const double *radius, LAMMPS_NS::Region *reg)
 {
   vec3 offset = {center[0], center[1], center[2]};
 
@@ -148,6 +148,9 @@ void ellipsoid2wireframe(LAMMPS_NS::Image *img, int level, const double *color, 
   if (level <= 1) {
     for (auto &tri : trilist) {
       scale_and_displace_triangle(tri, radius, offset);
+      reg->forward_transform(tri[0][0], tri[0][1], tri[0][2]);
+      reg->forward_transform(tri[1][0], tri[1][1], tri[1][2]);
+      reg->forward_transform(tri[2][0], tri[2][1], tri[2][2]);
       img->draw_cylinder(tri[0].data(), tri[1].data(), color, diameter, 3);
       img->draw_cylinder(tri[0].data(), tri[2].data(), color, diameter, 3);
       img->draw_cylinder(tri[1].data(), tri[2].data(), color, diameter, 3);
@@ -160,6 +163,9 @@ void ellipsoid2wireframe(LAMMPS_NS::Image *img, int level, const double *color, 
     if (level == 2) {
       for (auto &tri : trilist) {
         scale_and_displace_triangle(tri, radius, offset);
+        reg->forward_transform(tri[0][0], tri[0][1], tri[0][2]);
+        reg->forward_transform(tri[1][0], tri[1][1], tri[1][2]);
+        reg->forward_transform(tri[2][0], tri[2][1], tri[2][2]);
         img->draw_cylinder(tri[0].data(), tri[1].data(), color, diameter, 3);
         img->draw_cylinder(tri[0].data(), tri[2].data(), color, diameter, 3);
         img->draw_cylinder(tri[1].data(), tri[2].data(), color, diameter, 3);
@@ -173,6 +179,9 @@ void ellipsoid2wireframe(LAMMPS_NS::Image *img, int level, const double *color, 
     if (level == 3) {
       for (auto &tri : trilist) {
         scale_and_displace_triangle(tri, radius, offset);
+        reg->forward_transform(tri[0][0], tri[0][1], tri[0][2]);
+        reg->forward_transform(tri[1][0], tri[1][1], tri[1][2]);
+        reg->forward_transform(tri[2][0], tri[2][1], tri[2][2]);
         img->draw_cylinder(tri[0].data(), tri[1].data(), color, diameter, 3);
         img->draw_cylinder(tri[0].data(), tri[2].data(), color, diameter, 3);
         img->draw_cylinder(tri[1].data(), tri[2].data(), color, diameter, 3);
@@ -185,6 +194,9 @@ void ellipsoid2wireframe(LAMMPS_NS::Image *img, int level, const double *color, 
 
     for (auto &tri : trilist) {
       scale_and_displace_triangle(tri, radius, offset);
+      reg->forward_transform(tri[0][0], tri[0][1], tri[0][2]);
+      reg->forward_transform(tri[1][0], tri[1][1], tri[1][2]);
+      reg->forward_transform(tri[2][0], tri[2][1], tri[2][2]);
       img->draw_cylinder(tri[0].data(), tri[1].data(), color, diameter, 3);
       img->draw_cylinder(tri[0].data(), tri[2].data(), color, diameter, 3);
       img->draw_cylinder(tri[1].data(), tri[2].data(), color, diameter, 3);
@@ -193,7 +205,7 @@ void ellipsoid2wireframe(LAMMPS_NS::Image *img, int level, const double *color, 
 }
 
 void ellipsoid2filled(LAMMPS_NS::Image *img, int level, const double *color,
-                      const double *center, const double *radius)
+                      const double *center, const double *radius, LAMMPS_NS::Region *reg)
 {
   vec3 offset = {center[0], center[1], center[2]};
 
@@ -213,6 +225,9 @@ void ellipsoid2filled(LAMMPS_NS::Image *img, int level, const double *color,
   if (level <= 1) {
     for (auto &tri : trilist) {
       scale_and_displace_triangle(tri, radius, offset);
+      reg->forward_transform(tri[0][0], tri[0][1], tri[0][2]);
+      reg->forward_transform(tri[1][0], tri[1][1], tri[1][2]);
+      reg->forward_transform(tri[2][0], tri[2][1], tri[2][2]);
       img->draw_triangle(tri[0].data(), tri[1].data(), tri[2].data(), color);
     }
   }
@@ -224,6 +239,9 @@ void ellipsoid2filled(LAMMPS_NS::Image *img, int level, const double *color,
     if (level == 2) {
       for (auto &tri : trilist) {
         scale_and_displace_triangle(tri, radius, offset);
+        reg->forward_transform(tri[0][0], tri[0][1], tri[0][2]);
+        reg->forward_transform(tri[1][0], tri[1][1], tri[1][2]);
+        reg->forward_transform(tri[2][0], tri[2][1], tri[2][2]);
         img->draw_triangle(tri[0].data(), tri[1].data(), tri[2].data(), color);
       }
     }
@@ -235,6 +253,9 @@ void ellipsoid2filled(LAMMPS_NS::Image *img, int level, const double *color,
     if (level == 3) {
       for (auto &tri : trilist) {
         scale_and_displace_triangle(tri, radius, offset);
+        reg->forward_transform(tri[0][0], tri[0][1], tri[0][2]);
+        reg->forward_transform(tri[1][0], tri[1][1], tri[1][2]);
+        reg->forward_transform(tri[2][0], tri[2][1], tri[2][2]);
         img->draw_triangle(tri[0].data(), tri[1].data(), tri[2].data(), color);
       }
     }
@@ -245,6 +266,9 @@ void ellipsoid2filled(LAMMPS_NS::Image *img, int level, const double *color,
 
     for (auto &tri : trilist) {
       scale_and_displace_triangle(tri, radius, offset);
+      reg->forward_transform(tri[0][0], tri[0][1], tri[0][2]);
+      reg->forward_transform(tri[1][0], tri[1][1], tri[1][2]);
+      reg->forward_transform(tri[2][0], tri[2][1], tri[2][2]);
       img->draw_triangle(tri[0].data(), tri[1].data(), tri[2].data(), color);
     }
   }
@@ -1704,24 +1728,11 @@ void DumpImage::create_image()
     if (!ptr) error->all(FLERR, "Dump image region {} does not exist", reg.id);
     reg.ptr = ptr;
 
-    if (reg.ptr->rotateflag) {
-      utils::logmesg(lmp, "Cannot (yet) handle rotating region {}. Skipping...\n", reg.ptr->id);
-      continue;
-    }
-
     // update internal variables
+
     reg.ptr->prematch();
 
-    // compute position offset for moving regions
-
-    double dx = 0.0;
-    double dy = 0.0;
-    double dz = 0.0;
-    if (reg.ptr->moveflag) {
-      dx = reg.ptr->dx;
-      dy = reg.ptr->dy;
-      dz = reg.ptr->dz;
-    }
+    // for POINTS style we have the same code for all region styles
 
     if (reg.style == POINTS) {
       int seed = (int)(platform::walltime()*1000000) % 1000000;
@@ -1748,29 +1759,30 @@ void DumpImage::create_image()
         pos[1] = rand.uniform() * ylen + yoff;
         pos[2] = rand.uniform() * zlen + zoff;
         if (reg.ptr->inside(pos[0], pos[1], pos[2])) {
-          pos[0] += dx;
-          pos[1] += dy;
-          pos[2] += dz;
+          reg.ptr->forward_transform(pos[0], pos[1], pos[2]);
           image->draw_sphere(pos, reg.color, reg.diameter);
         }
       }
-    } else {
 
+    } else {
       std::string regstyle = reg.ptr->style;
+
       if (regstyle == "block") {
         auto *myreg = dynamic_cast<RegBlock *>(reg.ptr);
         // inconsistent style. should not happen.
         if (!myreg) continue;
 
         double block[8][3];
-        block[0][0] = myreg->xlo + dx; block[0][1] = myreg->ylo + dy; block[0][2] = myreg->zlo + dz;
-        block[1][0] = myreg->xlo + dx; block[1][1] = myreg->ylo + dy; block[1][2] = myreg->zhi + dz;
-        block[2][0] = myreg->xlo + dx; block[2][1] = myreg->yhi + dy; block[2][2] = myreg->zhi + dz;
-        block[3][0] = myreg->xlo + dx; block[3][1] = myreg->yhi + dy; block[3][2] = myreg->zlo + dz;
-        block[4][0] = myreg->xhi + dx; block[4][1] = myreg->ylo + dy; block[4][2] = myreg->zlo + dz;
-        block[5][0] = myreg->xhi + dx; block[5][1] = myreg->ylo + dy; block[5][2] = myreg->zhi + dz;
-        block[6][0] = myreg->xhi + dx; block[6][1] = myreg->yhi + dy; block[6][2] = myreg->zhi + dz;
-        block[7][0] = myreg->xhi + dx; block[7][1] = myreg->yhi + dy; block[7][2] = myreg->zlo + dz;
+        block[0][0] = myreg->xlo; block[0][1] = myreg->ylo; block[0][2] = myreg->zlo;
+        block[1][0] = myreg->xlo; block[1][1] = myreg->ylo; block[1][2] = myreg->zhi;
+        block[2][0] = myreg->xlo; block[2][1] = myreg->yhi; block[2][2] = myreg->zhi;
+        block[3][0] = myreg->xlo; block[3][1] = myreg->yhi; block[3][2] = myreg->zlo;
+        block[4][0] = myreg->xhi; block[4][1] = myreg->ylo; block[4][2] = myreg->zlo;
+        block[5][0] = myreg->xhi; block[5][1] = myreg->ylo; block[5][2] = myreg->zhi;
+        block[6][0] = myreg->xhi; block[6][1] = myreg->yhi; block[6][2] = myreg->zhi;
+        block[7][0] = myreg->xhi; block[7][1] = myreg->yhi; block[7][2] = myreg->zlo;
+        for (int i = 0; i < 8; ++i)
+          reg.ptr->forward_transform(block[i][0], block[i][1], block[i][2]);
 
         if (reg.style == FRAME) {
           image->draw_cylinder(block[0],block[1],reg.color,reg.diameter,3);
@@ -1811,6 +1823,7 @@ void DumpImage::create_image()
             image->draw_triangle(block[6], block[7], block[3], reg.color);
           }
         }
+
       } else if (regstyle == "cone") {
         auto *myreg = dynamic_cast<RegCone *>(reg.ptr);
         // inconsistent style. should not happen.
@@ -1818,72 +1831,84 @@ void DumpImage::create_image()
 
         double lo[3], hi[3];
         if (myreg->axis == 'x') {
-          lo[0] = myreg->lo + dx;
-          lo[1] = myreg->c1 + dy;
-          lo[2] = myreg->c2 + dz;
-          hi[0] = myreg->hi + dx;
-          hi[1] = myreg->c1 + dy;
-          hi[2] = myreg->c2 + dz;
+          lo[0] = myreg->lo;
+          lo[1] = myreg->c1;
+          lo[2] = myreg->c2;
+          hi[0] = myreg->hi;
+          hi[1] = myreg->c1;
+          hi[2] = myreg->c2;
         } else if (myreg->axis == 'y') {
-          lo[0] = myreg->c1 + dx;
-          lo[1] = myreg->lo + dy;
-          lo[2] = myreg->c2 + dz;
-          hi[0] = myreg->c1 + dx;
-          hi[1] = myreg->hi + dy;
-          hi[2] = myreg->c2 + dz;
+          lo[0] = myreg->c1;
+          lo[1] = myreg->lo;
+          lo[2] = myreg->c2;
+          hi[0] = myreg->c1;
+          hi[1] = myreg->hi;
+          hi[2] = myreg->c2;
         } else { // myreg->axis == 'z'
-          lo[0] = myreg->c1 + dx;
-          lo[1] = myreg->c2 + dy;
-          lo[2] = myreg->lo + dz;
-          hi[0] = myreg->c1 + dx;
-          hi[1] = myreg->c2 + dy;
-          hi[2] = myreg->hi + dz;
+          lo[0] = myreg->c1;
+          lo[1] = myreg->c2;
+          lo[2] = myreg->lo;
+          hi[0] = myreg->c1;
+          hi[1] = myreg->c2;
+          hi[2] = myreg->hi;
         }
 
         double p1[3], p2[3], p3[3], p4[3];
         if (reg.style == FRAME) {
           for (int i = 0; i < RESOLUTION; ++i) {
             if (myreg->axis == 'x') {
-              p1[0] = p2[0] = myreg->lo + dx;
-              p3[0] = p4[0] = myreg->hi + dx;
-              p1[1] = myreg->radiuslo * sin(RADINC * i) + myreg->c1 + dy;
-              p1[2] = myreg->radiuslo * cos(RADINC * i) + myreg->c2 + dz;
-              p2[1] = myreg->radiuslo * sin(RADINC * (i+1)) + myreg->c1 + dy;
-              p2[2] = myreg->radiuslo * cos(RADINC * (i+1)) + myreg->c2 + dz;
-              p3[1] = myreg->radiushi * sin(RADINC * i) + myreg->c1 + dy;
-              p3[2] = myreg->radiushi * cos(RADINC * i) + myreg->c2 + dz;
-              p4[1] = myreg->radiushi * sin(RADINC * (i+1)) + myreg->c1 + dy;
-              p4[2] = myreg->radiushi * cos(RADINC * (i+1)) + myreg->c2 + dz;
+              p1[0] = p2[0] = myreg->lo;
+              p3[0] = p4[0] = myreg->hi;
+              p1[1] = myreg->radiuslo * sin(RADINC * i) + myreg->c1;
+              p1[2] = myreg->radiuslo * cos(RADINC * i) + myreg->c2;
+              p2[1] = myreg->radiuslo * sin(RADINC * (i+1)) + myreg->c1;
+              p2[2] = myreg->radiuslo * cos(RADINC * (i+1)) + myreg->c2;
+              p3[1] = myreg->radiushi * sin(RADINC * i) + myreg->c1;
+              p3[2] = myreg->radiushi * cos(RADINC * i) + myreg->c2;
+              p4[1] = myreg->radiushi * sin(RADINC * (i+1)) + myreg->c1;
+              p4[2] = myreg->radiushi * cos(RADINC * (i+1)) + myreg->c2;
+              myreg->forward_transform(p1[0], p1[1], p1[2]);
+              myreg->forward_transform(p2[0], p2[1], p2[2]);
+              myreg->forward_transform(p3[0], p3[1], p3[2]);
+              myreg->forward_transform(p4[0], p4[1], p4[2]);
               image->draw_cylinder(p1, p2, reg.color, reg.diameter, 3);
               image->draw_cylinder(p3, p4, reg.color, reg.diameter, 3);
               image->draw_cylinder(p1, p3, reg.color, reg.diameter, 3);
               image->draw_cylinder(p2, p4, reg.color, reg.diameter, 3);
             } else if (myreg->axis == 'y') {
-              p1[1] = p2[1] = myreg->lo + dy;
-              p3[1] = p4[1] = myreg->hi + dy;
-              p1[0] = myreg->radiuslo * sin(RADINC * i) + myreg->c1 + dx;
-              p1[2] = myreg->radiuslo * cos(RADINC * i) + myreg->c2 + dz;
-              p2[0] = myreg->radiuslo * sin(RADINC * (i+1)) + myreg->c1 + dx;
-              p2[2] = myreg->radiuslo * cos(RADINC * (i+1)) + myreg->c2 + dz;
-              p3[0] = myreg->radiushi * sin(RADINC * i) + myreg->c1 + dx;
-              p3[2] = myreg->radiushi * cos(RADINC * i) + myreg->c2 + dz;
-              p4[0] = myreg->radiushi * sin(RADINC * (i+1)) + myreg->c1 + dx;
-              p4[2] = myreg->radiushi * cos(RADINC * (i+1)) + myreg->c2 + dz;
+              p1[1] = p2[1] = myreg->lo;
+              p3[1] = p4[1] = myreg->hi;
+              p1[0] = myreg->radiuslo * sin(RADINC * i) + myreg->c1;
+              p1[2] = myreg->radiuslo * cos(RADINC * i) + myreg->c2;
+              p2[0] = myreg->radiuslo * sin(RADINC * (i+1)) + myreg->c1;
+              p2[2] = myreg->radiuslo * cos(RADINC * (i+1)) + myreg->c2;
+              p3[0] = myreg->radiushi * sin(RADINC * i) + myreg->c1;
+              p3[2] = myreg->radiushi * cos(RADINC * i) + myreg->c2;
+              p4[0] = myreg->radiushi * sin(RADINC * (i+1)) + myreg->c1;
+              p4[2] = myreg->radiushi * cos(RADINC * (i+1)) + myreg->c2;
+              myreg->forward_transform(p1[0], p1[1], p1[2]);
+              myreg->forward_transform(p2[0], p2[1], p2[2]);
+              myreg->forward_transform(p3[0], p3[1], p3[2]);
+              myreg->forward_transform(p4[0], p4[1], p4[2]);
               image->draw_cylinder(p1, p2, reg.color, reg.diameter, 3);
               image->draw_cylinder(p3, p4, reg.color, reg.diameter, 3);
               image->draw_cylinder(p1, p3, reg.color, reg.diameter, 3);
               image->draw_cylinder(p2, p4, reg.color, reg.diameter, 3);
             } else {  // if (myreg->axis == 'z')
-              p1[2] = p2[2] = myreg->lo + dz;
-              p3[2] = p4[2] = myreg->hi + dz;
-              p1[0] = myreg->radiuslo * sin(RADINC * i) + myreg->c1 + dx;
-              p1[1] = myreg->radiuslo * cos(RADINC * i) + myreg->c2 + dy;
-              p2[0] = myreg->radiuslo * sin(RADINC * (i+1)) + myreg->c1 + dx;
-              p2[1] = myreg->radiuslo * cos(RADINC * (i+1)) + myreg->c2 + dy;
-              p3[0] = myreg->radiushi * sin(RADINC * i) + myreg->c1 + dx;
-              p3[1] = myreg->radiushi * cos(RADINC * i) + myreg->c2 + dy;
-              p4[0] = myreg->radiushi * sin(RADINC * (i+1)) + myreg->c1 + dx;
-              p4[1] = myreg->radiushi * cos(RADINC * (i+1)) + myreg->c2 + dy;
+              p1[2] = p2[2] = myreg->lo;
+              p3[2] = p4[2] = myreg->hi;
+              p1[0] = myreg->radiuslo * sin(RADINC * i) + myreg->c1;
+              p1[1] = myreg->radiuslo * cos(RADINC * i) + myreg->c2;
+              p2[0] = myreg->radiuslo * sin(RADINC * (i+1)) + myreg->c1;
+              p2[1] = myreg->radiuslo * cos(RADINC * (i+1)) + myreg->c2;
+              p3[0] = myreg->radiushi * sin(RADINC * i) + myreg->c1;
+              p3[1] = myreg->radiushi * cos(RADINC * i) + myreg->c2;
+              p4[0] = myreg->radiushi * sin(RADINC * (i+1)) + myreg->c1;
+              p4[1] = myreg->radiushi * cos(RADINC * (i+1)) + myreg->c2;
+              myreg->forward_transform(p1[0], p1[1], p1[2]);
+              myreg->forward_transform(p2[0], p2[1], p2[2]);
+              myreg->forward_transform(p3[0], p3[1], p3[2]);
+              myreg->forward_transform(p4[0], p4[1], p4[2]);
               image->draw_cylinder(p1, p2, reg.color, reg.diameter, 3);
               image->draw_cylinder(p3, p4, reg.color, reg.diameter, 3);
               image->draw_cylinder(p1, p3, reg.color, reg.diameter, 3);
@@ -1893,16 +1918,20 @@ void DumpImage::create_image()
         } else if (reg.style == FILLED) {
           for (int i = 0; i < RESOLUTION; ++i) {
             if (myreg->axis == 'x') {
-              p1[0] = p2[0] = myreg->lo + dx;
-              p3[0] = p4[0] = myreg->hi + dx;
-              p1[1] = myreg->radiuslo * sin(RADINC * i) + myreg->c1 + dy;
-              p1[2] = myreg->radiuslo * cos(RADINC * i) + myreg->c2 + dz;
-              p2[1] = myreg->radiuslo * sin(RADINC * (i+1)) + myreg->c1 + dy;
-              p2[2] = myreg->radiuslo * cos(RADINC * (i+1)) + myreg->c2 + dz;
-              p3[1] = myreg->radiushi * sin(RADINC * i) + myreg->c1 + dy;
-              p3[2] = myreg->radiushi * cos(RADINC * i) + myreg->c2 + dz;
-              p4[1] = myreg->radiushi * sin(RADINC * (i+1)) + myreg->c1 + dy;
-              p4[2] = myreg->radiushi * cos(RADINC * (i+1)) + myreg->c2 + dz;
+              p1[0] = p2[0] = myreg->lo;
+              p3[0] = p4[0] = myreg->hi;
+              p1[1] = myreg->radiuslo * sin(RADINC * i) + myreg->c1;
+              p1[2] = myreg->radiuslo * cos(RADINC * i) + myreg->c2;
+              p2[1] = myreg->radiuslo * sin(RADINC * (i+1)) + myreg->c1;
+              p2[2] = myreg->radiuslo * cos(RADINC * (i+1)) + myreg->c2;
+              p3[1] = myreg->radiushi * sin(RADINC * i) + myreg->c1;
+              p3[2] = myreg->radiushi * cos(RADINC * i) + myreg->c2;
+              p4[1] = myreg->radiushi * sin(RADINC * (i+1)) + myreg->c1;
+              p4[2] = myreg->radiushi * cos(RADINC * (i+1)) + myreg->c2;
+              myreg->forward_transform(p1[0], p1[1], p1[2]);
+              myreg->forward_transform(p2[0], p2[1], p2[2]);
+              myreg->forward_transform(p3[0], p3[1], p3[2]);
+              myreg->forward_transform(p4[0], p4[1], p4[2]);
               if (!myreg->open_faces[0]) image->draw_triangle(p1, p2, lo, reg.color);
               if (!myreg->open_faces[1]) image->draw_triangle(p3, p4, hi, reg.color);
               if (!myreg->open_faces[2]) {
@@ -1911,16 +1940,20 @@ void DumpImage::create_image()
               }
 
             } else if (myreg->axis == 'y') {
-              p1[1] = p2[1] = myreg->lo + dy;
-              p3[1] = p4[1] = myreg->hi + dy;
-              p1[0] = myreg->radiuslo * sin(RADINC * i) + myreg->c1 + dx;
-              p1[2] = myreg->radiuslo * cos(RADINC * i) + myreg->c2 + dz;
-              p2[0] = myreg->radiuslo * sin(RADINC * (i+1)) + myreg->c1 + dx;
-              p2[2] = myreg->radiuslo * cos(RADINC * (i+1)) + myreg->c2 + dz;
-              p3[0] = myreg->radiushi * sin(RADINC * i) + myreg->c1 + dx;
-              p3[2] = myreg->radiushi * cos(RADINC * i) + myreg->c2 + dz;
-              p4[0] = myreg->radiushi * sin(RADINC * (i+1)) + myreg->c1 + dx;
-              p4[2] = myreg->radiushi * cos(RADINC * (i+1)) + myreg->c2 + dz;
+              p1[1] = p2[1] = myreg->lo;
+              p3[1] = p4[1] = myreg->hi;
+              p1[0] = myreg->radiuslo * sin(RADINC * i) + myreg->c1;
+              p1[2] = myreg->radiuslo * cos(RADINC * i) + myreg->c2;
+              p2[0] = myreg->radiuslo * sin(RADINC * (i+1)) + myreg->c1;
+              p2[2] = myreg->radiuslo * cos(RADINC * (i+1)) + myreg->c2;
+              p3[0] = myreg->radiushi * sin(RADINC * i) + myreg->c1;
+              p3[2] = myreg->radiushi * cos(RADINC * i) + myreg->c2;
+              p4[0] = myreg->radiushi * sin(RADINC * (i+1)) + myreg->c1;
+              p4[2] = myreg->radiushi * cos(RADINC * (i+1)) + myreg->c2;
+              myreg->forward_transform(p1[0], p1[1], p1[2]);
+              myreg->forward_transform(p2[0], p2[1], p2[2]);
+              myreg->forward_transform(p3[0], p3[1], p3[2]);
+              myreg->forward_transform(p4[0], p4[1], p4[2]);
               if (!myreg->open_faces[0]) image->draw_triangle(p1, p2, lo, reg.color);
               if (!myreg->open_faces[1]) image->draw_triangle(p3, p4, hi, reg.color);
               if (!myreg->open_faces[2]) {
@@ -1928,16 +1961,20 @@ void DumpImage::create_image()
                 image->draw_triangle(p2, p4, p3, reg.color);
               }
             } else {  // if (myreg->axis == 'z')
-              p1[2] = p2[2] = myreg->lo + dz;
-              p3[2] = p4[2] = myreg->hi + dz;
-              p1[0] = myreg->radiuslo * sin(RADINC * i) + myreg->c1 + dx;
-              p1[1] = myreg->radiuslo * cos(RADINC * i) + myreg->c2 + dy;
-              p2[0] = myreg->radiuslo * sin(RADINC * (i+1)) + myreg->c1 + dx;
-              p2[1] = myreg->radiuslo * cos(RADINC * (i+1)) + myreg->c2 + dy;
-              p3[0] = myreg->radiushi * sin(RADINC * i) + myreg->c1 + dx;
-              p3[1] = myreg->radiushi * cos(RADINC * i) + myreg->c2 + dy;
-              p4[0] = myreg->radiushi * sin(RADINC * (i+1)) + myreg->c1 + dx;
-              p4[1] = myreg->radiushi * cos(RADINC * (i+1)) + myreg->c2 + dy;
+              p1[2] = p2[2] = myreg->lo;
+              p3[2] = p4[2] = myreg->hi;
+              p1[0] = myreg->radiuslo * sin(RADINC * i) + myreg->c1;
+              p1[1] = myreg->radiuslo * cos(RADINC * i) + myreg->c2;
+              p2[0] = myreg->radiuslo * sin(RADINC * (i+1)) + myreg->c1;
+              p2[1] = myreg->radiuslo * cos(RADINC * (i+1)) + myreg->c2;
+              p3[0] = myreg->radiushi * sin(RADINC * i) + myreg->c1;
+              p3[1] = myreg->radiushi * cos(RADINC * i) + myreg->c2;
+              p4[0] = myreg->radiushi * sin(RADINC * (i+1)) + myreg->c1;
+              p4[1] = myreg->radiushi * cos(RADINC * (i+1)) + myreg->c2;
+              myreg->forward_transform(p1[0], p1[1], p1[2]);
+              myreg->forward_transform(p2[0], p2[1], p2[2]);
+              myreg->forward_transform(p3[0], p3[1], p3[2]);
+              myreg->forward_transform(p4[0], p4[1], p4[2]);
               if (!myreg->open_faces[0]) image->draw_triangle(p1, p2, lo, reg.color);
               if (!myreg->open_faces[1]) image->draw_triangle(p3, p4, hi, reg.color);
               if (!myreg->open_faces[2]) {
@@ -1947,6 +1984,7 @@ void DumpImage::create_image()
             }
           }
         }
+
       } else if (regstyle == "cylinder") {
         auto *myreg = dynamic_cast<RegCylinder *>(reg.ptr);
         // inconsistent style. should not happen.
@@ -1954,60 +1992,72 @@ void DumpImage::create_image()
 
         double lo[3], hi[3];
         if (myreg->axis == 'x') {
-          lo[0] = myreg->lo + dx;
-          lo[1] = myreg->c1 + dy;
-          lo[2] = myreg->c2 + dz;
-          hi[0] = myreg->hi + dx;
-          hi[1] = myreg->c1 + dy;
-          hi[2] = myreg->c2 + dz;
+          lo[0] = myreg->lo;
+          lo[1] = myreg->c1;
+          lo[2] = myreg->c2;
+          hi[0] = myreg->hi;
+          hi[1] = myreg->c1;
+          hi[2] = myreg->c2;
         } else if (myreg->axis == 'y') {
-          lo[0] = myreg->c1 + dx;
-          lo[1] = myreg->lo + dy;
-          lo[2] = myreg->c2 + dz;
-          hi[0] = myreg->c1 + dx;
-          hi[1] = myreg->hi + dy;
-          hi[2] = myreg->c2 + dz;
+          lo[0] = myreg->c1;
+          lo[1] = myreg->lo;
+          lo[2] = myreg->c2;
+          hi[0] = myreg->c1;
+          hi[1] = myreg->hi;
+          hi[2] = myreg->c2;
         } else { // myreg->axis == 'z'
-          lo[0] = myreg->c1 + dx;
-          lo[1] = myreg->c2 + dy;
-          lo[2] = myreg->lo + dz;
-          hi[0] = myreg->c1 + dx;
-          hi[1] = myreg->c2 + dy;
-          hi[2] = myreg->hi + dz;
+          lo[0] = myreg->c1;
+          lo[1] = myreg->c2;
+          lo[2] = myreg->lo;
+          hi[0] = myreg->c1;
+          hi[1] = myreg->c2;
+          hi[2] = myreg->hi;
         }
 
         double p1[3], p2[3], p3[3], p4[3];
         if (reg.style == FRAME) {
           for (int i = 0; i < RESOLUTION; ++i) {
             if (myreg->axis == 'x') {
-              p1[0] = p2[0] = myreg->lo + dx;
-              p3[0] = p4[0] = myreg->hi + dx;
-              p1[1] = p3[1] = myreg->radius * sin(RADINC * i) + myreg->c1 + dy;
-              p1[2] = p3[2] = myreg->radius * cos(RADINC * i) + myreg->c2 + dz;
-              p2[1] = p4[1] = myreg->radius * sin(RADINC * (i+1)) + myreg->c1 + dy;
-              p2[2] = p4[2] = myreg->radius * cos(RADINC * (i+1)) + myreg->c2 + dz;
+              p1[0] = p2[0] = myreg->lo;
+              p3[0] = p4[0] = myreg->hi;
+              p1[1] = p3[1] = myreg->radius * sin(RADINC * i) + myreg->c1;
+              p1[2] = p3[2] = myreg->radius * cos(RADINC * i) + myreg->c2;
+              p2[1] = p4[1] = myreg->radius * sin(RADINC * (i+1)) + myreg->c1;
+              p2[2] = p4[2] = myreg->radius * cos(RADINC * (i+1)) + myreg->c2;
+              myreg->forward_transform(p1[0], p1[1], p1[2]);
+              myreg->forward_transform(p2[0], p2[1], p2[2]);
+              myreg->forward_transform(p3[0], p3[1], p3[2]);
+              myreg->forward_transform(p4[0], p4[1], p4[2]);
               image->draw_cylinder(p1, p2, reg.color, reg.diameter, 3);
               image->draw_cylinder(p3, p4, reg.color, reg.diameter, 3);
               image->draw_cylinder(p1, p3, reg.color, reg.diameter, 3);
               image->draw_cylinder(p2, p4, reg.color, reg.diameter, 3);
             } else if (myreg->axis == 'y') {
-              p1[1] = p2[1] = myreg->lo + dy;
-              p3[1] = p4[1] = myreg->hi + dy;
-              p1[0] = p3[0] = myreg->radius * sin(RADINC * i) + myreg->c1 + dx;
-              p1[2] = p3[2] = myreg->radius * cos(RADINC * i) + myreg->c2 + dz;
-              p2[0] = p4[0] = myreg->radius * sin(RADINC * (i+1)) + myreg->c1 + dx;
-              p2[2] = p4[2] = myreg->radius * cos(RADINC * (i+1)) + myreg->c2 + dz;
+              p1[1] = p2[1] = myreg->lo;
+              p3[1] = p4[1] = myreg->hi;
+              p1[0] = p3[0] = myreg->radius * sin(RADINC * i) + myreg->c1;
+              p1[2] = p3[2] = myreg->radius * cos(RADINC * i) + myreg->c2;
+              p2[0] = p4[0] = myreg->radius * sin(RADINC * (i+1)) + myreg->c1;
+              p2[2] = p4[2] = myreg->radius * cos(RADINC * (i+1)) + myreg->c2;
+              myreg->forward_transform(p1[0], p1[1], p1[2]);
+              myreg->forward_transform(p2[0], p2[1], p2[2]);
+              myreg->forward_transform(p3[0], p3[1], p3[2]);
+              myreg->forward_transform(p4[0], p4[1], p4[2]);
               image->draw_cylinder(p1, p2, reg.color, reg.diameter, 3);
               image->draw_cylinder(p3, p4, reg.color, reg.diameter, 3);
               image->draw_cylinder(p1, p3, reg.color, reg.diameter, 3);
               image->draw_cylinder(p2, p4, reg.color, reg.diameter, 3);
             } else { // if (myreg->axis == 'z')
-              p1[2] = p2[2] = myreg->lo + dz;
-              p3[2] = p4[2] = myreg->hi + dz;
-              p1[0] = p3[0] = myreg->radius * sin(RADINC * i) + myreg->c1 + dx;
-              p1[1] = p3[1] = myreg->radius * cos(RADINC * i) + myreg->c2 + dy;
-              p2[0] = p4[0] = myreg->radius * sin(RADINC * (i+1)) + myreg->c1 + dx;
-              p2[1] = p4[1] = myreg->radius * cos(RADINC * (i+1)) + myreg->c2 + dy;
+              p1[2] = p2[2] = myreg->lo;
+              p3[2] = p4[2] = myreg->hi;
+              p1[0] = p3[0] = myreg->radius * sin(RADINC * i) + myreg->c1;
+              p1[1] = p3[1] = myreg->radius * cos(RADINC * i) + myreg->c2;
+              p2[0] = p4[0] = myreg->radius * sin(RADINC * (i+1)) + myreg->c1;
+              p2[1] = p4[1] = myreg->radius * cos(RADINC * (i+1)) + myreg->c2;
+              myreg->forward_transform(p1[0], p1[1], p1[2]);
+              myreg->forward_transform(p2[0], p2[1], p2[2]);
+              myreg->forward_transform(p3[0], p3[1], p3[2]);
+              myreg->forward_transform(p4[0], p4[1], p4[2]);
               image->draw_cylinder(p1, p2, reg.color, reg.diameter, 3);
               image->draw_cylinder(p3, p4, reg.color, reg.diameter, 3);
               image->draw_cylinder(p1, p3, reg.color, reg.diameter, 3);
@@ -2017,12 +2067,16 @@ void DumpImage::create_image()
         } else if (reg.style == FILLED) {
           for (int i = 0; i < RESOLUTION; ++i) {
             if (myreg->axis == 'x') {
-              p1[0] = p2[0] = myreg->lo + dx;
-              p3[0] = p4[0] = myreg->hi + dx;
-              p1[1] = p3[1] = myreg->radius * sin(RADINC * i) + myreg->c1 + dy;
-              p1[2] = p3[2] = myreg->radius * cos(RADINC * i) + myreg->c2 + dz;
-              p2[1] = p4[1] = myreg->radius * sin(RADINC * (i+1)) + myreg->c1 + dy;
-              p2[2] = p4[2] = myreg->radius * cos(RADINC * (i+1)) + myreg->c2 + dz;
+              p1[0] = p2[0] = myreg->lo;
+              p3[0] = p4[0] = myreg->hi;
+              p1[1] = p3[1] = myreg->radius * sin(RADINC * i) + myreg->c1;
+              p1[2] = p3[2] = myreg->radius * cos(RADINC * i) + myreg->c2;
+              p2[1] = p4[1] = myreg->radius * sin(RADINC * (i+1)) + myreg->c1;
+              p2[2] = p4[2] = myreg->radius * cos(RADINC * (i+1)) + myreg->c2;
+              myreg->forward_transform(p1[0], p1[1], p1[2]);
+              myreg->forward_transform(p2[0], p2[1], p2[2]);
+              myreg->forward_transform(p3[0], p3[1], p3[2]);
+              myreg->forward_transform(p4[0], p4[1], p4[2]);
               if (!myreg->open_faces[0]) image->draw_triangle(p1, p2, lo, reg.color);
               if (!myreg->open_faces[1]) image->draw_triangle(p3, p4, hi, reg.color);
               if (!myreg->open_faces[2]) {
@@ -2030,12 +2084,16 @@ void DumpImage::create_image()
                 image->draw_triangle(p3, p4, p2, reg.color);
               }
             } else if (myreg->axis == 'y') {
-              p1[1] = p2[1] = myreg->lo + dy;
-              p3[1] = p4[1] = myreg->hi + dy;
-              p1[0] = p3[0] = myreg->radius * sin(RADINC * i) + myreg->c1 + dx;
-              p1[2] = p3[2] = myreg->radius * cos(RADINC * i) + myreg->c2 + dz;
-              p2[0] = p4[0] = myreg->radius * sin(RADINC * (i+1)) + myreg->c1 + dx;
-              p2[2] = p4[2] = myreg->radius * cos(RADINC * (i+1)) + myreg->c2 + dz;
+              p1[1] = p2[1] = myreg->lo;
+              p3[1] = p4[1] = myreg->hi;
+              p1[0] = p3[0] = myreg->radius * sin(RADINC * i) + myreg->c1;
+              p1[2] = p3[2] = myreg->radius * cos(RADINC * i) + myreg->c2;
+              p2[0] = p4[0] = myreg->radius * sin(RADINC * (i+1)) + myreg->c1;
+              p2[2] = p4[2] = myreg->radius * cos(RADINC * (i+1)) + myreg->c2;
+              myreg->forward_transform(p1[0], p1[1], p1[2]);
+              myreg->forward_transform(p2[0], p2[1], p2[2]);
+              myreg->forward_transform(p3[0], p3[1], p3[2]);
+              myreg->forward_transform(p4[0], p4[1], p4[2]);
               if (!myreg->open_faces[0]) image->draw_triangle(p1, p2, lo, reg.color);
               if (!myreg->open_faces[1]) image->draw_triangle(p3, p4, hi, reg.color);
               if (!myreg->open_faces[2]) {
@@ -2043,12 +2101,16 @@ void DumpImage::create_image()
                 image->draw_triangle(p3, p4, p2, reg.color);
               }
             } else { // if (myreg->axis == 'z')
-              p1[2] = p2[2] = myreg->lo + dz;
-              p3[2] = p4[2] = myreg->hi + dz;
-              p1[0] = p3[0] = myreg->radius * sin(RADINC * i) + myreg->c1 + dx;
-              p1[1] = p3[1] = myreg->radius * cos(RADINC * i) + myreg->c2 + dy;
-              p2[0] = p4[0] = myreg->radius * sin(RADINC * (i+1)) + myreg->c1 + dx;
-              p2[1] = p4[1] = myreg->radius * cos(RADINC * (i+1)) + myreg->c2 + dy;
+              p1[2] = p2[2] = myreg->lo;
+              p3[2] = p4[2] = myreg->hi;
+              p1[0] = p3[0] = myreg->radius * sin(RADINC * i) + myreg->c1;
+              p1[1] = p3[1] = myreg->radius * cos(RADINC * i) + myreg->c2;
+              p2[0] = p4[0] = myreg->radius * sin(RADINC * (i+1)) + myreg->c1;
+              p2[1] = p4[1] = myreg->radius * cos(RADINC * (i+1)) + myreg->c2;
+              myreg->forward_transform(p1[0], p1[1], p1[2]);
+              myreg->forward_transform(p2[0], p2[1], p2[2]);
+              myreg->forward_transform(p3[0], p3[1], p3[2]);
+              myreg->forward_transform(p4[0], p4[1], p4[2]);
               if (!myreg->open_faces[0]) image->draw_triangle(p1, p2, lo, reg.color);
               if (!myreg->open_faces[1]) image->draw_triangle(p3, p4, hi, reg.color);
               if (!myreg->open_faces[2]) {
@@ -2058,35 +2120,39 @@ void DumpImage::create_image()
             }
           }
         }
+
       } else if (regstyle == "ellipsoid") {
         auto *myreg = dynamic_cast<RegEllipsoid *>(reg.ptr);
         // inconsistent style. should not happen.
         if (!myreg) continue;
 
         double center[3];
-        center[0] = myreg->xc + dx;
-        center[1] = myreg->yc + dy;
-        center[2] = myreg->zc + dz;
+        center[0] = myreg->xc;
+        center[1] = myreg->yc;
+        center[2] = myreg->zc;
         double radius[3] = {myreg->a, myreg->b, myreg->c};
         if (reg.style == FRAME) {
-          ellipsoid2wireframe(image, 4, reg.color, reg.diameter, center, radius);
+          ellipsoid2wireframe(image, 4, reg.color, reg.diameter, center, radius, reg.ptr);
         } else if (reg.style == FILLED) {
-          ellipsoid2filled(image, 4, reg.color, center, radius);
+          ellipsoid2filled(image, 4, reg.color, center, radius, reg.ptr);
         }
+
       } else if (regstyle == "prism") {
         auto *myreg = dynamic_cast<RegPrism *>(reg.ptr);
         // inconsistent style. should not happen.
         if (!myreg) continue;
 
         double block[8][3];
-        block[0][0] = myreg->xlo + dx; block[0][1] = myreg->ylo + dy; block[0][2] = myreg->zlo + dz;
-        block[1][0] = myreg->xlo + myreg->xz + dx; block[1][1] = myreg->ylo + myreg->yz + dy; block[1][2] = myreg->zhi + dz;
-        block[2][0] = myreg->xlo + myreg->xy + myreg->xz + dx; block[2][1] = myreg->yhi + myreg->yz + dy; block[2][2] = myreg->zhi + dz;
-        block[3][0] = myreg->xlo + myreg->xy + dx; block[3][1] = myreg->yhi + dy; block[3][2] = myreg->zlo + dz;
-        block[4][0] = myreg->xhi + dx; block[4][1] = myreg->ylo + dy; block[4][2] = myreg->zlo + dz;
-        block[5][0] = myreg->xhi + myreg->xz + dx; block[5][1] = myreg->ylo + myreg->yz + dy; block[5][2] = myreg->zhi + dz;
-        block[6][0] = myreg->xhi + myreg->xy + myreg->xz + dx; block[6][1] = myreg->yhi + myreg->yz + dy; block[6][2] = myreg->zhi + dz;
-        block[7][0] = myreg->xhi + myreg->xy + dx; block[7][1] = myreg->yhi + dy; block[7][2] = myreg->zlo + dz;
+        block[0][0] = myreg->xlo; block[0][1] = myreg->ylo; block[0][2] = myreg->zlo;
+        block[1][0] = myreg->xlo + myreg->xz; block[1][1] = myreg->ylo + myreg->yz; block[1][2] = myreg->zhi;
+        block[2][0] = myreg->xlo + myreg->xy + myreg->xz; block[2][1] = myreg->yhi + myreg->yz; block[2][2] = myreg->zhi;
+        block[3][0] = myreg->xlo + myreg->xy; block[3][1] = myreg->yhi; block[3][2] = myreg->zlo;
+        block[4][0] = myreg->xhi; block[4][1] = myreg->ylo; block[4][2] = myreg->zlo;
+        block[5][0] = myreg->xhi + myreg->xz; block[5][1] = myreg->ylo + myreg->yz; block[5][2] = myreg->zhi;
+        block[6][0] = myreg->xhi + myreg->xy + myreg->xz; block[6][1] = myreg->yhi + myreg->yz; block[6][2] = myreg->zhi;
+        block[7][0] = myreg->xhi + myreg->xy; block[7][1] = myreg->yhi; block[7][2] = myreg->zlo;
+        for (int i = 0; i < 8; ++i)
+          reg.ptr->forward_transform(block[i][0], block[i][1], block[i][2]);
 
         if (reg.style == FRAME) {
           image->draw_cylinder(block[0],block[1],reg.color,reg.diameter,3);
@@ -2133,13 +2199,14 @@ void DumpImage::create_image()
         if (!myreg) continue;
 
         double center[3];
-        center[0] = myreg->xc + dx;
-        center[1] = myreg->yc + dy;
-        center[2] = myreg->zc + dz;
+        center[0] = myreg->xc;
+        center[1] = myreg->yc;
+        center[2] = myreg->zc;
         if (reg.style == FRAME) {
           double radius[3] = {myreg->radius,myreg->radius,myreg->radius};
-          ellipsoid2wireframe(image, 4, reg.color, reg.diameter, center, radius);
+          ellipsoid2wireframe(image, 4, reg.color, reg.diameter, center, radius, reg.ptr);
         } else if (reg.style == FILLED) {
+          myreg->forward_transform(center[0], center[1], center[2]);
           image->draw_sphere(center, reg.color, 2.0 * myreg->radius);
         }
       } else {

--- a/src/region.cpp
+++ b/src/region.cpp
@@ -232,6 +232,7 @@ void Region::pretransform()
     if (zstr) dz = input->variable->compute_equal(zvar);
   }
   if (rotateflag) theta = input->variable->compute_equal(tvar);
+  bbox_update();
 }
 
 /* ----------------------------------------------------------------------

--- a/src/region.cpp
+++ b/src/region.cpp
@@ -35,6 +35,7 @@ Region::Region(LAMMPS *lmp, int /*narg*/, char **arg) :
   id = utils::strdup(arg[0]);
   style = utils::strdup(arg[1]);
 
+  bboxflag = 0;
   varshape = 0;
   xstr = ystr = zstr = tstr = nullptr;
   dx = dy = dz = 0.0;

--- a/src/region.h
+++ b/src/region.h
@@ -17,8 +17,15 @@
 #include "pointers.h"    // IWYU pragma: export
 
 namespace LAMMPS_NS {
+class DumpImage;
+class RegIntersect;
+class RegUnion;
 
 class Region : protected Pointers {
+  friend DumpImage;
+  friend RegIntersect;
+  friend RegUnion;
+
  public:
   enum { CONSTANT, VARIABLE, NONE };
 
@@ -88,17 +95,20 @@ class Region : protected Pointers {
   virtual void length_restart_string(int &);
   virtual void reset_vel();
 
-  // implemented by each region, not called by other classes
+ protected:
+
+  // implemented by each region, generally not called by other classes
 
   virtual int inside(double, double, double) = 0;
   virtual int surface_interior(double *, double) = 0;
   virtual int surface_exterior(double *, double) = 0;
   virtual void shape_update() {}
+  virtual void bbox_update() {}
+
   virtual void pretransform();
   virtual void set_velocity_shape() {}
   virtual void velocity_contact_shape(double *, double *) {}
 
- protected:
   void add_contact(int, double *, double, double, double);
   void options(int, char **);
   void point_on_line_segment(double *, double *, double *, double *);

--- a/src/region.h
+++ b/src/region.h
@@ -95,7 +95,10 @@ class Region : protected Pointers {
   virtual void length_restart_string(int &);
   virtual void reset_vel();
 
- protected:
+  // track translation and rotation
+  void forward_transform(double &, double &, double &);
+
+protected:
 
   // implemented by each region, generally not called by other classes
 
@@ -112,7 +115,6 @@ class Region : protected Pointers {
   void add_contact(int, double *, double, double, double);
   void options(int, char **);
   void point_on_line_segment(double *, double *, double *, double *);
-  void forward_transform(double &, double &, double &);
   double point[3], runit[3];
 
  private:

--- a/src/region_block.cpp
+++ b/src/region_block.cpp
@@ -19,8 +19,8 @@
 #include "math_extra.h"
 #include "variable.h"
 
-#include <cstring>
 #include <algorithm>
+#include <cstring>
 
 using namespace LAMMPS_NS;
 
@@ -169,7 +169,7 @@ RegBlock::RegBlock(LAMMPS *lmp, int narg, char **arg) :
       extent_zlo = zlo;
       extent_zhi = zhi;
     }
-  } else bboxflag = 0;
+  }
 
   // particle could be close to all 6 planes
   // particle can only touch 3 planes

--- a/src/region_block.cpp
+++ b/src/region_block.cpp
@@ -20,10 +20,11 @@
 #include "variable.h"
 
 #include <cstring>
+#include <algorithm>
 
 using namespace LAMMPS_NS;
 
-static constexpr double BIG = 1.0e20;
+static constexpr double BIG = 1.0e200;
 
 /* ---------------------------------------------------------------------- */
 
@@ -154,18 +155,21 @@ RegBlock::RegBlock(LAMMPS *lmp, int narg, char **arg) :
   if (ylo > yhi) error->all(FLERR, "Illegal region block ylo: {} >= yhi: {}", ylo, yhi);
   if (zlo > zhi) error->all(FLERR, "Illegal region block zlo: {} >= zhi: {}", zlo, zhi);
 
-  // extent of block
+  // set extent of block
 
-  if (interior && !dynamic && !varshape) {
-    bboxflag = 1;
-    extent_xlo = xlo;
-    extent_xhi = xhi;
-    extent_ylo = ylo;
-    extent_yhi = yhi;
-    extent_zlo = zlo;
-    extent_zhi = zhi;
-  } else
-    bboxflag = 0;
+  if (interior) {
+    if (dynamic || varshape) {
+      RegBlock::bbox_update();
+    } else {
+      bboxflag = 1;
+      extent_xlo = xlo;
+      extent_xhi = xhi;
+      extent_ylo = ylo;
+      extent_yhi = yhi;
+      extent_zlo = zlo;
+      extent_zhi = zhi;
+    }
+  } else bboxflag = 0;
 
   // particle could be close to all 6 planes
   // particle can only touch 3 planes
@@ -437,7 +441,7 @@ int RegBlock::surface_exterior(double *x, double cutoff)
     change region shape via variable evaluation
 ------------------------------------------------------------------------- */
 
-void RegBlock::shape_update()    // addition
+void RegBlock::shape_update()
 {
   if (xlostyle == VARIABLE) xlo = xscale * input->variable->compute_equal(xlovar);
   if (xhistyle == VARIABLE) xhi = xscale * input->variable->compute_equal(xhivar);
@@ -506,6 +510,53 @@ void RegBlock::shape_update()    // addition
   MathExtra::copy3(corners[1][1], corners[5][1]);
   MathExtra::copy3(corners[1][2], corners[5][2]);
   MathExtra::copy3(corners[0][2], corners[5][3]);
+}
+
+/* update the boundary information based on the corners */
+
+void RegBlock::bbox_update()
+{
+  if (interior) {
+    if (varshape || dynamic) {
+      double pos[3];
+      double xmin = BIG;
+      double xmax = -BIG;
+      double ymin = BIG;
+      double ymax = -BIG;
+      double zmin = BIG;
+      double zmax = -BIG;
+
+      // the corners of face[0] and face[1] cover the full extent of the region
+      // transform and get min/max in x-, y-, and z-direction for each corner
+
+      for (int i = 0; i < 4; ++i) {
+        MathExtra::copy3(corners[0][i], pos);
+        forward_transform(pos[0], pos[1], pos[2]);
+        xmin = std::min(xmin, pos[0]);
+        xmax = std::max(xmax, pos[0]);
+        ymin = std::min(ymin, pos[1]);
+        ymax = std::max(ymax, pos[1]);
+        zmin = std::min(zmin, pos[2]);
+        zmax = std::max(zmax, pos[2]);
+        MathExtra::copy3(corners[1][i], pos);
+        forward_transform(pos[0], pos[1], pos[2]);
+        xmin = std::min(xmin, pos[0]);
+        xmax = std::max(xmax, pos[0]);
+        ymin = std::min(ymin, pos[1]);
+        ymax = std::max(ymax, pos[1]);
+        zmin = std::min(zmin, pos[2]);
+        zmax = std::max(zmax, pos[2]);
+      }
+
+      bboxflag = 1;
+      extent_xlo = xmin;
+      extent_xhi = xmax;
+      extent_ylo = ymin;
+      extent_yhi = ymax;
+      extent_zlo = zmin;
+      extent_zhi = zmax;
+    }
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/region_block.cpp
+++ b/src/region_block.cpp
@@ -158,10 +158,10 @@ RegBlock::RegBlock(LAMMPS *lmp, int narg, char **arg) :
   // set extent of block
 
   if (interior) {
+    bboxflag = 1;
     if (dynamic || varshape) {
       RegBlock::bbox_update();
     } else {
-      bboxflag = 1;
       extent_xlo = xlo;
       extent_xhi = xhi;
       extent_ylo = ylo;
@@ -548,7 +548,6 @@ void RegBlock::bbox_update()
         zmax = std::max(zmax, pos[2]);
       }
 
-      bboxflag = 1;
       extent_xlo = xmin;
       extent_xhi = xmax;
       extent_ylo = ymin;

--- a/src/region_block.h
+++ b/src/region_block.h
@@ -37,6 +37,7 @@ class RegBlock : public Region {
   int surface_interior(double *, double) override;
   int surface_exterior(double *, double) override;
   void shape_update() override;
+  void bbox_update() override;
 
  protected:
   double xlo, xhi, ylo, yhi, zlo, zhi;

--- a/src/region_cone.cpp
+++ b/src/region_cone.cpp
@@ -20,14 +20,16 @@
 #include "domain.h"
 #include "error.h"
 #include "input.h"
+#include "math_extra.h"
 #include "variable.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstring>
 
 using namespace LAMMPS_NS;
 
-static constexpr double BIG = 1.0e20;
+static constexpr double BIG = 1.0e200;
 
 /* ---------------------------------------------------------------------- */
 
@@ -264,33 +266,37 @@ RegCone::RegCone(LAMMPS *lmp, int narg, char **arg) :
   if (hi <= lo) error->all(FLERR, "Illegal cone length in region cone command");
 
   // extent of cone
-  maxradius = ((radiuslo > radiushi) ? radiuslo : radiushi);
+  maxradius = std::max(radiuslo, radiushi);
 
-  if (interior && !dynamic && !varshape) {
-    bboxflag = 1;
-    if (axis == 'x') {
-      extent_xlo = lo;
-      extent_xhi = hi;
-      extent_ylo = c1 - maxradius;
-      extent_yhi = c1 + maxradius;
-      extent_zlo = c2 - maxradius;
-      extent_zhi = c2 + maxradius;
-    }
-    if (axis == 'y') {
-      extent_xlo = c1 - maxradius;
-      extent_xhi = c1 + maxradius;
-      extent_ylo = lo;
-      extent_yhi = hi;
-      extent_zlo = c2 - maxradius;
-      extent_zhi = c2 + maxradius;
-    }
-    if (axis == 'z') {
-      extent_xlo = c1 - maxradius;
-      extent_xhi = c1 + maxradius;
-      extent_ylo = c2 - maxradius;
-      extent_yhi = c2 + maxradius;
-      extent_zlo = lo;
-      extent_zhi = hi;
+  if (interior) {
+    if (dynamic || varshape) {
+      RegCone::bbox_update();
+    } else {
+      bboxflag = 1;
+      if (axis == 'x') {
+        extent_xlo = lo;
+        extent_xhi = hi;
+        extent_ylo = c1 - maxradius;
+        extent_yhi = c1 + maxradius;
+        extent_zlo = c2 - maxradius;
+        extent_zhi = c2 + maxradius;
+      }
+      if (axis == 'y') {
+        extent_xlo = c1 - maxradius;
+        extent_xhi = c1 + maxradius;
+        extent_ylo = lo;
+        extent_yhi = hi;
+        extent_zlo = c2 - maxradius;
+        extent_zhi = c2 + maxradius;
+      }
+      if (axis == 'z') {
+        extent_xlo = c1 - maxradius;
+        extent_xhi = c1 + maxradius;
+        extent_ylo = c2 - maxradius;
+        extent_yhi = c2 + maxradius;
+        extent_zlo = lo;
+        extent_zhi = hi;
+      }
     }
   } else
     bboxflag = 0;
@@ -801,6 +807,107 @@ void RegCone::shape_update()
     if (rhistyle == VARIABLE) radiushi *= xscale;
     if (lostyle == VARIABLE) lo *= zscale;
     if (histyle == VARIABLE) hi *= zscale;
+  }
+}
+
+/* update the boundary information */
+
+void RegCone::bbox_update()
+{
+  if (varshape || dynamic) {
+    double corners[2][4][3], pos[3];
+    double xmin, xmax, ymin, ymax, zmin, zmax;
+
+    // define bounding box corners in region internal positions
+
+    if (axis == 'x') {
+      xmin = lo;
+      xmax = hi;
+      ymin = c1 - maxradius;
+      ymax = c1 + maxradius;
+      zmin = c2 - maxradius;
+      zmax = c2 + maxradius;
+    }
+    if (axis == 'y') {
+      xmin = c1 - maxradius;
+      xmax = c1 + maxradius;
+      ymin = lo;
+      ymax = hi;
+      zmin = c2 - maxradius;
+      zmax = c2 + maxradius;
+    }
+    if (axis == 'z') {
+      xmin = c1 - maxradius;
+      xmax = c1 + maxradius;
+      ymin = c2 - maxradius;
+      ymax = c2 + maxradius;
+      zmin = lo;
+      zmax = hi;
+    }
+
+    // face[0]
+
+    corners[0][0][0] = xmin;
+    corners[0][0][1] = ymin;
+    corners[0][0][2] = zmin;
+    corners[0][1][0] = xmin;
+    corners[0][1][1] = ymin;
+    corners[0][1][2] = zmax;
+    corners[0][2][0] = xmin;
+    corners[0][2][1] = ymax;
+    corners[0][2][2] = zmax;
+    corners[0][3][0] = xmin;
+    corners[0][3][1] = ymax;
+    corners[0][3][2] = zmin;
+
+    // face[1]
+
+    corners[1][0][0] = xmax;
+    corners[1][0][1] = ymin;
+    corners[1][0][2] = zmin;
+    corners[1][1][0] = xmax;
+    corners[1][1][1] = ymin;
+    corners[1][1][2] = zmax;
+    corners[1][2][0] = xmax;
+    corners[1][2][1] = ymax;
+    corners[1][2][2] = zmax;
+    corners[1][3][0] = xmax;
+    corners[1][3][1] = ymax;
+    corners[1][3][2] = zmin;
+
+    // the corners of face[0] and face[1] cover the full extent of the region
+    // transform and get min/max in x-, y-, and z-direction for each corner
+
+    xmin = ymin = zmin = BIG;
+    xmax = ymax = zmax = -BIG;
+
+    for (int i = 0; i < 4; ++i) {
+      MathExtra::copy3(corners[0][i], pos);
+      forward_transform(pos[0], pos[1], pos[2]);
+      xmin = std::min(xmin, pos[0]);
+      xmax = std::max(xmax, pos[0]);
+      ymin = std::min(ymin, pos[1]);
+      ymax = std::max(ymax, pos[1]);
+      zmin = std::min(zmin, pos[2]);
+      zmax = std::max(zmax, pos[2]);
+
+      MathExtra::copy3(corners[1][i], pos);
+      forward_transform(pos[0], pos[1], pos[2]);
+      xmin = std::min(xmin, pos[0]);
+      xmax = std::max(xmax, pos[0]);
+      ymin = std::min(ymin, pos[1]);
+      ymax = std::max(ymax, pos[1]);
+      zmin = std::min(zmin, pos[2]);
+      zmax = std::max(zmax, pos[2]);
+    }
+
+    bboxflag = 1;
+    extent_xlo = xmin;
+    extent_xhi = xmax;
+    extent_ylo = ymin;
+    extent_yhi = ymax;
+    extent_zlo = zmin;
+    extent_zhi = zmax;
   }
 }
 

--- a/src/region_cone.cpp
+++ b/src/region_cone.cpp
@@ -298,8 +298,7 @@ RegCone::RegCone(LAMMPS *lmp, int narg, char **arg) :
         extent_zhi = hi;
       }
     }
-  } else
-    bboxflag = 0;
+  }
 
   // particle could be close to cone surface and 2 ends
   // particle can only touch surface and 1 end

--- a/src/region_cone.cpp
+++ b/src/region_cone.cpp
@@ -269,10 +269,10 @@ RegCone::RegCone(LAMMPS *lmp, int narg, char **arg) :
   maxradius = std::max(radiuslo, radiushi);
 
   if (interior) {
+    bboxflag = 1;
     if (dynamic || varshape) {
       RegCone::bbox_update();
     } else {
-      bboxflag = 1;
       if (axis == 'x') {
         extent_xlo = lo;
         extent_xhi = hi;
@@ -900,7 +900,6 @@ void RegCone::bbox_update()
       zmax = std::max(zmax, pos[2]);
     }
 
-    bboxflag = 1;
     extent_xlo = xmin;
     extent_xhi = xmax;
     extent_ylo = ymin;

--- a/src/region_cone.h
+++ b/src/region_cone.h
@@ -36,6 +36,7 @@ class RegCone : public Region {
   int surface_interior(double *, double) override;
   int surface_exterior(double *, double) override;
   void shape_update() override;
+  void bbox_update() override;
 
  private:
   char axis;

--- a/src/region_cylinder.cpp
+++ b/src/region_cylinder.cpp
@@ -17,19 +17,21 @@
 #include "error.h"
 #include "input.h"
 #include "update.h"
+#include "math_extra.h"
 #include "variable.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstring>
 
 using namespace LAMMPS_NS;
 
-static constexpr double BIG = 1.0e20;
+static constexpr double BIG = 1.0e200;
 
 /* ---------------------------------------------------------------------- */
 
 RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
-    Region(lmp, narg, arg), c1str(nullptr), c2str(nullptr), rstr(nullptr)
+  Region(lmp, narg, arg), c1str(nullptr), c2str(nullptr), rstr(nullptr)
 {
   c1style = c2style = CONSTANT;
   options(narg - 8, &arg[8]);
@@ -54,6 +56,7 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
       c1 = yscale * utils::numeric(FLERR, arg[3], false, lmp);
       c1style = CONSTANT;
     }
+
     if (utils::strmatch(arg[4], "^v_")) {
       c2str = utils::strdup(arg[4] + 2);
       c2 = 0.0;
@@ -63,7 +66,9 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
       c2 = zscale * utils::numeric(FLERR, arg[4], false, lmp);
       c2style = CONSTANT;
     }
+
   } else if (axis == 'y') {
+
     if (utils::strmatch(arg[3], "^v_")) {
       c1str = utils::strdup(arg[3] + 2);
       c1 = 0.0;
@@ -73,6 +78,7 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
       c1 = xscale * utils::numeric(FLERR, arg[3], false, lmp);
       c1style = CONSTANT;
     }
+
     if (utils::strmatch(arg[4], "^v_")) {
       c2str = utils::strdup(arg[4] + 2);
       c2 = 0.0;
@@ -83,6 +89,7 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
       c2style = CONSTANT;
     }
   } else if (axis == 'z') {
+
     if (utils::strmatch(arg[3], "^v_")) {
       c1str = utils::strdup(arg[3] + 2);
       c1 = 0.0;
@@ -92,6 +99,7 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
       c1 = xscale * utils::numeric(FLERR, arg[3], false, lmp);
       c1style = CONSTANT;
     }
+
     if (utils::strmatch(arg[4], "^v_")) {
       c2str = utils::strdup(arg[4] + 2);
       c2 = 0.0;
@@ -195,44 +203,44 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
   // extent of cylinder
   // for variable radius, uses initial radius
 
-  if (interior && !dynamic && !varshape) {
-    bboxflag = 1;
-    if (axis == 'x') {
-      extent_xlo = lo;
-      extent_xhi = hi;
-      extent_ylo = c1 - radius;
-      extent_yhi = c1 + radius;
-      extent_zlo = c2 - radius;
-      extent_zhi = c2 + radius;
+  if (interior) {
+    if (dynamic || varshape) {
+      RegCylinder::bbox_update();
+    } else {
+      bboxflag = 1;
+      if (axis == 'x') {
+        extent_xlo = lo;
+        extent_xhi = hi;
+        extent_ylo = c1 - radius;
+        extent_yhi = c1 + radius;
+        extent_zlo = c2 - radius;
+        extent_zhi = c2 + radius;
+      }
+      if (axis == 'y') {
+        extent_xlo = c1 - radius;
+        extent_xhi = c1 + radius;
+        extent_ylo = lo;
+        extent_yhi = hi;
+        extent_zlo = c2 - radius;
+        extent_zhi = c2 + radius;
+      }
+      if (axis == 'z') {
+        extent_xlo = c1 - radius;
+        extent_xhi = c1 + radius;
+        extent_ylo = c2 - radius;
+        extent_yhi = c2 + radius;
+        extent_zlo = lo;
+        extent_zhi = hi;
+      }
     }
-    if (axis == 'y') {
-      extent_xlo = c1 - radius;
-      extent_xhi = c1 + radius;
-      extent_ylo = lo;
-      extent_yhi = hi;
-      extent_zlo = c2 - radius;
-      extent_zhi = c2 + radius;
-    }
-    if (axis == 'z') {
-      extent_xlo = c1 - radius;
-      extent_xhi = c1 + radius;
-      extent_ylo = c2 - radius;
-      extent_yhi = c2 + radius;
-      extent_zlo = lo;
-      extent_zhi = hi;
-    }
-  } else
-    bboxflag = 0;
+  }
 
   // particle could be close to cylinder surface and 2 ends
   // particle can only touch surface and 1 end
 
   cmax = 3;
   contact = new Contact[cmax];
-  if (interior)
-    tmax = 2;
-  else
-    tmax = 1;
+  tmax = (interior ? 2 : 1);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -781,6 +789,107 @@ void RegCylinder::shape_update()
     if (c1style == VARIABLE) c1 *= xscale;
     if (c2style == VARIABLE) c2 *= yscale;
     if (rstyle == VARIABLE) radius *= xscale;
+  }
+}
+
+/* update the boundary information */
+
+void RegCylinder::bbox_update()
+{
+  if (varshape || dynamic) {
+    double corners[2][4][3], pos[3];
+    double xmin, xmax, ymin, ymax, zmin, zmax;
+
+    // define bounding box corners in region internal positions
+
+    if (axis == 'x') {
+      xmin = lo;
+      xmax = hi;
+      ymin = c1 - radius;
+      ymax = c1 + radius;
+      zmin = c2 - radius;
+      zmax = c2 + radius;
+    }
+    if (axis == 'y') {
+      xmin = c1 - radius;
+      xmax = c1 + radius;
+      ymin = lo;
+      ymax = hi;
+      zmin = c2 - radius;
+      zmax = c2 + radius;
+    }
+    if (axis == 'z') {
+      xmin = c1 - radius;
+      xmax = c1 + radius;
+      ymin = c2 - radius;
+      ymax = c2 + radius;
+      zmin = lo;
+      zmax = hi;
+    }
+
+    // face[0]
+
+    corners[0][0][0] = xmin;
+    corners[0][0][1] = ymin;
+    corners[0][0][2] = zmin;
+    corners[0][1][0] = xmin;
+    corners[0][1][1] = ymin;
+    corners[0][1][2] = zmax;
+    corners[0][2][0] = xmin;
+    corners[0][2][1] = ymax;
+    corners[0][2][2] = zmax;
+    corners[0][3][0] = xmin;
+    corners[0][3][1] = ymax;
+    corners[0][3][2] = zmin;
+
+    // face[1]
+
+    corners[1][0][0] = xmax;
+    corners[1][0][1] = ymin;
+    corners[1][0][2] = zmin;
+    corners[1][1][0] = xmax;
+    corners[1][1][1] = ymin;
+    corners[1][1][2] = zmax;
+    corners[1][2][0] = xmax;
+    corners[1][2][1] = ymax;
+    corners[1][2][2] = zmax;
+    corners[1][3][0] = xmax;
+    corners[1][3][1] = ymax;
+    corners[1][3][2] = zmin;
+
+    // the corners of face[0] and face[1] cover the full extent of the region
+    // transform and get min/max in x-, y-, and z-direction for each corner
+
+    xmin = ymin = zmin = BIG;
+    xmax = ymax = zmax = -BIG;
+
+    for (int i = 0; i < 4; ++i) {
+      MathExtra::copy3(corners[0][i], pos);
+      forward_transform(pos[0], pos[1], pos[2]);
+      xmin = std::min(xmin, pos[0]);
+      xmax = std::max(xmax, pos[0]);
+      ymin = std::min(ymin, pos[1]);
+      ymax = std::max(ymax, pos[1]);
+      zmin = std::min(zmin, pos[2]);
+      zmax = std::max(zmax, pos[2]);
+
+      MathExtra::copy3(corners[1][i], pos);
+      forward_transform(pos[0], pos[1], pos[2]);
+      xmin = std::min(xmin, pos[0]);
+      xmax = std::max(xmax, pos[0]);
+      ymin = std::min(ymin, pos[1]);
+      ymax = std::max(ymax, pos[1]);
+      zmin = std::min(zmin, pos[2]);
+      zmax = std::max(zmax, pos[2]);
+    }
+
+    bboxflag = 1;
+    extent_xlo = xmin;
+    extent_xhi = xmax;
+    extent_ylo = ymin;
+    extent_yhi = ymax;
+    extent_zlo = zmin;
+    extent_zhi = zmax;
   }
 }
 

--- a/src/region_cylinder.cpp
+++ b/src/region_cylinder.cpp
@@ -204,10 +204,10 @@ RegCylinder::RegCylinder(LAMMPS *lmp, int narg, char **arg) :
   // for variable radius, uses initial radius
 
   if (interior) {
+    bboxflag = 1;
     if (dynamic || varshape) {
       RegCylinder::bbox_update();
     } else {
-      bboxflag = 1;
       if (axis == 'x') {
         extent_xlo = lo;
         extent_xhi = hi;
@@ -883,7 +883,6 @@ void RegCylinder::bbox_update()
       zmax = std::max(zmax, pos[2]);
     }
 
-    bboxflag = 1;
     extent_xlo = xmin;
     extent_xhi = xmax;
     extent_ylo = ymin;

--- a/src/region_cylinder.h
+++ b/src/region_cylinder.h
@@ -37,6 +37,7 @@ class RegCylinder : public Region {
   int surface_interior(double *, double) override;
   int surface_exterior(double *, double) override;
   void shape_update() override;
+  void bbox_update() override;
   void set_velocity_shape() override;
   void velocity_contact_shape(double *, double *) override;
 

--- a/src/region_ellipsoid.h
+++ b/src/region_ellipsoid.h
@@ -36,6 +36,7 @@ class RegEllipsoid : public Region {
   int surface_interior(double *, double) override;
   int surface_exterior(double *, double) override;
   void shape_update() override;
+  void bbox_update() override;
 
  private:
   double xc, yc, zc;

--- a/src/region_prism.cpp
+++ b/src/region_prism.cpp
@@ -23,11 +23,12 @@
 #include "math_extra.h"
 #include "variable.h"
 
+#include <algorithm>
 #include <cstring>
 
 using namespace LAMMPS_NS;
 
-static constexpr double BIG = 1.0e20;
+static constexpr double BIG = 1.0e200;
 
 /* ---------------------------------------------------------------------- */
 
@@ -193,19 +194,22 @@ RegPrism::RegPrism(LAMMPS *lmp, int narg, char **arg) : Region(lmp, narg, arg),
 
   // extent of prism
 
-  if (interior && !dynamic && !varshape) {
-    bboxflag = 1;
-    extent_xlo = MIN(xlo, xlo + xy);
-    extent_xlo = MIN(extent_xlo, extent_xlo + xz);
-    extent_ylo = MIN(ylo, ylo + yz);
-    extent_zlo = zlo;
+  if (interior) {
+    if (dynamic || varshape) {
+      RegPrism::bbox_update();
+    } else {
+      bboxflag = 1;
+      extent_xlo = MIN(xlo, xlo + xy);
+      extent_xlo = MIN(extent_xlo, extent_xlo + xz);
+      extent_ylo = MIN(ylo, ylo + yz);
+      extent_zlo = zlo;
 
-    extent_xhi = MAX(xhi, xhi + xy);
-    extent_xhi = MAX(extent_xhi, extent_xhi + xz);
-    extent_yhi = MAX(yhi, yhi + yz);
-    extent_zhi = zhi;
-  } else
-    bboxflag = 0;
+      extent_xhi = MAX(xhi, xhi + xy);
+      extent_xhi = MAX(extent_xhi, extent_xhi + xz);
+      extent_yhi = MAX(yhi, yhi + yz);
+      extent_zhi = zhi;
+    }
+  }
 
   // particle could be close to all 6 planes
   // particle can only touch 3 planes
@@ -547,20 +551,6 @@ void RegPrism::shape_update()
   if (yz != 0.0 && zlo == -BIG && zhi == BIG)
     error->all(FLERR, "Illegal region prism non-zero yz tilt with infinite z size");
 
-  // extent of prism
-
-  if (interior) {
-    extent_xlo = MIN(xlo, xlo + xy);
-    extent_xlo = MIN(extent_xlo, extent_xlo + xz);
-    extent_ylo = MIN(ylo, ylo + yz);
-    extent_zlo = zlo;
-
-    extent_xhi = MAX(xhi, xhi + xy);
-    extent_xhi = MAX(extent_xhi, extent_xhi + xz);
-    extent_yhi = MAX(yhi, yhi + yz);
-    extent_zhi = zhi;
-  }
-
   // h = transformation matrix from tilt coords (0-1) to box coords (xyz)
 
   h[0][0] = xhi - xlo;
@@ -631,6 +621,46 @@ void RegPrism::shape_update()
   MathExtra::cross3(c, b, face[5]);
 
   for (int i = 0; i < 6; i++) MathExtra::norm3(face[i]);
+}
+
+
+/* update the boundary information based on the corners */
+
+void RegPrism::bbox_update()
+{
+  if (interior) {
+    if (varshape || dynamic) {
+      double pos[3];
+      double xmin = BIG;
+      double xmax = -BIG;
+      double ymin = BIG;
+      double ymax = -BIG;
+      double zmin = BIG;
+      double zmax = -BIG;
+
+      // the min/max of the 8 corners the prism cover the full extent of the region
+      // transform and get min/max in x-, y-, and z-direction for each corner
+
+      for (int i = 0; i < 8; ++i) {
+        MathExtra::copy3(corners[i], pos);
+        forward_transform(pos[0], pos[1], pos[2]);
+        xmin = std::min(xmin, pos[0]);
+        xmax = std::max(xmax, pos[0]);
+        ymin = std::min(ymin, pos[1]);
+        ymax = std::max(ymax, pos[1]);
+        zmin = std::min(zmin, pos[2]);
+        zmax = std::max(zmax, pos[2]);
+      }
+
+      bboxflag = 1;
+      extent_xlo = xmin;
+      extent_xhi = xmax;
+      extent_ylo = ymin;
+      extent_yhi = ymax;
+      extent_zlo = zmin;
+      extent_zhi = zmax;
+    }
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/region_prism.cpp
+++ b/src/region_prism.cpp
@@ -195,10 +195,10 @@ RegPrism::RegPrism(LAMMPS *lmp, int narg, char **arg) : Region(lmp, narg, arg),
   // extent of prism
 
   if (interior) {
+    bboxflag = 1;
     if (dynamic || varshape) {
       RegPrism::bbox_update();
     } else {
-      bboxflag = 1;
       extent_xlo = MIN(xlo, xlo + xy);
       extent_xlo = MIN(extent_xlo, extent_xlo + xz);
       extent_ylo = MIN(ylo, ylo + yz);
@@ -652,7 +652,6 @@ void RegPrism::bbox_update()
         zmax = std::max(zmax, pos[2]);
       }
 
-      bboxflag = 1;
       extent_xlo = xmin;
       extent_xhi = xmax;
       extent_ylo = ymin;

--- a/src/region_prism.h
+++ b/src/region_prism.h
@@ -37,6 +37,7 @@ class RegPrism : public Region {
   int surface_interior(double *, double) override;
   int surface_exterior(double *, double) override;
   void shape_update() override;
+  void bbox_update() override;
 
  private:
   double xlo, xhi, ylo, yhi, zlo, zhi;

--- a/src/region_sphere.cpp
+++ b/src/region_sphere.cpp
@@ -25,7 +25,7 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 RegSphere::RegSphere(LAMMPS *lmp, int narg, char **arg) :
-    Region(lmp, narg, arg), xstr(nullptr), ystr(nullptr), zstr(nullptr), rstr(nullptr)
+  Region(lmp, narg, arg), xstr(nullptr), ystr(nullptr), zstr(nullptr), rstr(nullptr)
 {
   options(narg - 6, &arg[6]);
 
@@ -81,16 +81,19 @@ RegSphere::RegSphere(LAMMPS *lmp, int narg, char **arg) :
   // extent of sphere
   // for variable radius, uses initial radius and origin for variable center
 
-  if (interior && !dynamic && !varshape) {
-    bboxflag = 1;
-    extent_xlo = xc - radius;
-    extent_xhi = xc + radius;
-    extent_ylo = yc - radius;
-    extent_yhi = yc + radius;
-    extent_zlo = zc - radius;
-    extent_zhi = zc + radius;
-  } else
-    bboxflag = 0;
+  if (interior) {
+    if (dynamic || varshape) {
+      RegSphere::bbox_update();
+    } else {
+      bboxflag = 1;
+      extent_xlo = xc - radius;
+      extent_xhi = xc + radius;
+      extent_ylo = yc - radius;
+      extent_yhi = yc + radius;
+      extent_zlo = zc - radius;
+      extent_zhi = zc + radius;
+    }
+  }
 
   cmax = 1;
   contact = new Contact[cmax];
@@ -206,6 +209,29 @@ void RegSphere::shape_update()
   if (rstyle == VARIABLE) {
     radius = xscale * input->variable->compute_equal(rvar);
     if (radius < 0.0) error->one(FLERR, "Variable evaluation in region gave bad value");
+  }
+}
+
+/* update the boundary information */
+
+void RegSphere::bbox_update()
+{
+  if (varshape || dynamic) {
+    bboxflag = 1;
+    extent_xlo = xc - radius;
+    extent_xhi = xc + radius;
+    extent_ylo = yc - radius;
+    extent_yhi = yc + radius;
+    extent_zlo = zc - radius;
+    extent_zhi = zc + radius;
+    if (moveflag) {
+      extent_xlo += dx;
+      extent_xhi += dx;
+      extent_ylo += dy;
+      extent_yhi += dy;
+      extent_zlo += dz;
+      extent_zhi += dz;
+    }
   }
 }
 

--- a/src/region_sphere.cpp
+++ b/src/region_sphere.cpp
@@ -82,7 +82,7 @@ RegSphere::RegSphere(LAMMPS *lmp, int narg, char **arg) :
   // for variable radius, uses initial radius and origin for variable center
 
   if (interior) {
-      bboxflag = 1;
+    bboxflag = 1;
     if (dynamic || varshape) {
       RegSphere::bbox_update();
     } else {

--- a/src/region_sphere.cpp
+++ b/src/region_sphere.cpp
@@ -82,10 +82,10 @@ RegSphere::RegSphere(LAMMPS *lmp, int narg, char **arg) :
   // for variable radius, uses initial radius and origin for variable center
 
   if (interior) {
+      bboxflag = 1;
     if (dynamic || varshape) {
       RegSphere::bbox_update();
     } else {
-      bboxflag = 1;
       extent_xlo = xc - radius;
       extent_xhi = xc + radius;
       extent_ylo = yc - radius;
@@ -217,7 +217,6 @@ void RegSphere::shape_update()
 void RegSphere::bbox_update()
 {
   if (varshape || dynamic) {
-    bboxflag = 1;
     extent_xlo = xc - radius;
     extent_xhi = xc + radius;
     extent_ylo = yc - radius;

--- a/src/region_sphere.h
+++ b/src/region_sphere.h
@@ -35,6 +35,7 @@ class RegSphere : public Region {
   int surface_interior(double *, double) override;
   int surface_exterior(double *, double) override;
   void shape_update() override;
+  void bbox_update() override;
   void set_velocity_shape() override;
   void velocity_contact_shape(double *, double *) override;
 


### PR DESCRIPTION
**Summary**

This pull request improves support for dynamic (i.e. translating and rotating) regions and regions with variables defining the shape. In particular, it adds support for visualizing
those with dump image and for updating the bounding box and thus improving on the bugfix in commit 51c2d126a739001f68df5b182e2b0ebe66164c56

**Related Issue(s)**

N/A

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Backward Compatibility**

N/A

**Implementation Notes**

This makes extensive use of `Region::forward_transform()` to apply the effect of rotation and translation.

Fix styles `deposit`, `gcmc`, and `widom` are currently not compatible with dynamic regions, but could be made compatible by repeating the bounding box initialization from the constructor in whatever function is called before inserting particles.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
