### PR TITLE
ML-IAP bugfix

### DIFF
--- a/src/KOKKOS/pair_mliap_kokkos.cpp
+++ b/src/KOKKOS/pair_mliap_kokkos.cpp
@@ -563,7 +563,7 @@ int PairMLIAPKokkos<DeviceType>::pack_reverse_comm_kokkos(int nv, int first_up, 
       const int i = start/nf;
       const int gstart=(first_up+i)*nf;
       const int j = start%nf;
-      val(start+j) = static_cast<double>(to[gstart+j]);
+      val(start) = static_cast<double>(to[gstart+j]);
     }
   );
   return nv*nf;
@@ -631,7 +631,7 @@ void PairMLIAPKokkos<DeviceType>::unpack_reverse_comm_kokkos(int nv, DAT::tdual_
       const int i = start/nf;
       const int gstart=idx(i)*nf;
       const int j=i%nf;
-      to[gstart+j] += static_cast<CommType>(val(start+j));
+      to[gstart+j] += static_cast<CommType>(val(start));
     }
   );
 }

--- a/src/KOKKOS/pair_mliap_kokkos.cpp
+++ b/src/KOKKOS/pair_mliap_kokkos.cpp
@@ -630,7 +630,7 @@ void PairMLIAPKokkos<DeviceType>::unpack_reverse_comm_kokkos(int nv, DAT::tdual_
   Kokkos::parallel_for(nv*nf, KOKKOS_LAMBDA (int start) {
       const int i = start/nf;
       const int gstart=idx(i)*nf;
-      const int j=i%nf;
+      const int j=start%nf;
       to[gstart+j] += static_cast<CommType>(val(start));
     }
   );

--- a/src/KOKKOS/pair_mliap_kokkos.cpp
+++ b/src/KOKKOS/pair_mliap_kokkos.cpp
@@ -429,7 +429,7 @@ int PairMLIAPKokkos<DeviceType>::pack_forward_comm_kokkos(
       const int i = start/nf;
       const int gstart=idx(i)*nf;
       const int j = start%nf;
-      val(start+j) = static_cast<double>(to[gstart+j]);
+      val(start) = static_cast<double>(to[gstart+j]);
     }
   );
   return nv*nf;
@@ -500,7 +500,7 @@ void PairMLIAPKokkos<DeviceType>::unpack_forward_comm_kokkos(
       const int i=start/nf;
       const int gstart=(first_up+i)*nf;
       const int j=start%nf;
-      to[gstart+j] = static_cast<CommType>(val(start+j));
+      to[gstart+j] = static_cast<CommType>(val(start));
     }
   );
 }


### PR DESCRIPTION
Follow-on PR to #4744 that fixes bugs introduced by the unrolled version. Apologies that I didn't catch them sooner - I'm frankly amazed the profiling didn't crash. However, looking back, the trajectories were stable but indeed wrong.

@bathmatt @fglines-nv 