### PR TITLE
Fix infinite loop crash in BondHybrid and PairHybrid copy_svector

### DIFF
--- a/src/bond_hybrid.cpp
+++ b/src/bond_hybrid.cpp
@@ -469,7 +469,7 @@ void BondHybrid::copy_svector(int type)
   // there is only one style in bond style hybrid for a bond type
   Bond *this_style = styles[map[type]];
 
-  for (int l = 0; this_style->single_extra; ++l) { svector[l] = this_style->svector[l]; }
+  for (int l = 0; l < this_style->single_extra; ++l) { svector[l] = this_style->svector[l]; }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/pair_hybrid.cpp
+++ b/src/pair_hybrid.cpp
@@ -971,7 +971,7 @@ void PairHybrid::copy_svector(int itype, int jtype)
   // there is only one style in pair style hybrid for a pair of atom types
   Pair *this_style = styles[map[itype][jtype][0]];
 
-  for (int l = 0; this_style->single_extra; ++l) {
+  for (int l = 0; l < this_style->single_extra; ++l) {
     svector[l] = this_style->svector[l];
   }
 }


### PR DESCRIPTION
**Summary**

This PR fixes a critical bug in `BondHybrid::copy_svector` and `PairHybrid::copy_svector` that caused an infinite loop and subsequent segmentation fault (crash) due to out-of-bounds memory access.

The issue was caused by an incorrect `for` loop termination condition:
```cpp
// Old (Incorrect)
for (int l = 0; this_style->single_extra; ++l) 

// New (Correct)
for (int l = 0; l < this_style->single_extra; ++l)
```

The original code checked the constant value this_style->single_extra instead of comparing it against the loop iterator l. This caused the program to crash on the first invocation of these functions when single_extra was non-zero.

This bug appears to be specific to the base BondHybrid and PairHybrid classes. I verified that other hybrid styles (e.g., hybrid/overlay) correctly implement this loop, which likely explains why this issue persisted unnoticed for some time.

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->

**Author(s)**

<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request. If this pull request adds new files to the distribution, please also provide a suitable "long-lived" e-mail address (ideally something that can outlive your institution's e-mail, in case you change jobs) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this contributed code.-->

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

<!--Please update the following sentence as needed in case you were using AI tools to
generate code.  Please mention which specific AI tool or tools you were using and which
parts of the code were AI generated versus the parts written by a human.  The use of AI
tools for checking spelling and syntax does not need to be reported.-->

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Backward Compatibility**

This change is a bug fix and does not break backward compatibility. It ensures the code behaves as originally intended.

**Implementation Notes**

The fix involves changing the loop condition from `this_style->single_extra` to `l < this_style->single_extra` in both `bond_hybrid.cpp` and `pair_hybrid.cpp`. This ensures the loop iterates exactly single_extra times.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [ ] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


