### PR TITLE
Bugfix when compiling fix_electron_stopping_kokkos with Kokkos HIP

### DIFF
--- a/src/KOKKOS/fix_electron_stopping_kokkos.h
+++ b/src/KOKKOS/fix_electron_stopping_kokkos.h
@@ -59,7 +59,7 @@ class FixElectronStoppingKokkos : public FixElectronStopping {
   typename AT::t_kkacc_1d_3 f;
   typename AT::t_kkfloat_1d_3 v;
   typename AT::t_int_1d_randomread type;
-  typename AT::t_int_1d_randomread tag;
+  typename AT::t_tagint_1d tag;
   typename AT::t_int_1d_const d_mask;
   typename AT::t_kkfloat_1d_randomread d_mass;
   typename AT::t_kkfloat_1d_const d_rmass;

--- a/src/KOKKOS/fix_electron_stopping_kokkos.h
+++ b/src/KOKKOS/fix_electron_stopping_kokkos.h
@@ -59,7 +59,7 @@ class FixElectronStoppingKokkos : public FixElectronStopping {
   typename AT::t_kkacc_1d_3 f;
   typename AT::t_kkfloat_1d_3 v;
   typename AT::t_int_1d_randomread type;
-  typename AT::t_tagint_1d tag;
+  typename AT::t_tagint_1d_const tag;
   typename AT::t_int_1d_const d_mask;
   typename AT::t_kkfloat_1d_randomread d_mass;
   typename AT::t_kkfloat_1d_const d_rmass;


### PR DESCRIPTION
**Summary**

fix_electron_stopping.cpp fails to compile with Kokkos_hip. This bugfix just recasts the "tag" typename to the ArrayType expected by LAMMPS.

Steps to reproduce on Tuolumne:

```
module load cmake/3.29.2
module load craype-accel-amd-gfx942
module load PrgEnv-amd

export MPICH_GPU_SUPPORT_ENABLED=1
export MPICH_OFI_NIC_POLICY=GPU

export CRAYPE_LINK_TYPE=dynamic

export CRAYPE_MPICH_GTL_DIR=${CRAY_MPICH_ROOTDIR}/gtl/lib
export CRAYPE_MPICH_GTL_LIBS=-lmpi_gtl_hsa

export HSA_XNACK=1

export LD_LIBRARY_PATH=${CRAY_LD_LIBRARY_PATH}:${LD_LIBRARY_PATH}

export LD_PRELOAD=/usr/lib64/liblapack.so

cmake ../cmake -D CMAKE_C_COMPILER=hipcc -D CMAKE_CXX_COMPILER=hipcc -D CMAKE_Fortran_COMPILER=amdflang -C ../cmake/presets/kokkos-hip.cmake -D CMAKE_CXX_FLAGS="-I${MPICH_DIR}/include" -D MPI_CXX_LIBRARIES="-L${MPICH_DIR}/lib -lmpi -L${CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_hsa" -D LAMMPS_SIZES=bigbig -C ../cmake/presets/most.cmake -D Kokkos_ARCH_ZEN3=yes -D Kokkos_ARCH_AMD_GFX942_APU=yes -D Kokkos_ENABLE_HIP=ON -D Kokkos_ENABLE_ROCTHRUST=ON -D LAMMPS_EXCEPTIONS=yes -D BUILD_SHARED_LIBS=yes

make -j$(nproc)
```

**Related Issue(s)**

Couldn't find if this is an open issue.

**Author(s)**

Dionysios Sema, MIT

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Implementation Notes**

Compilation passes with ROCm. Not tested for CUDA.

**Post Submission Checklist**

- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] One or more example input decks are included



