### PR TITLE
Collected small changes and fixes

### DIFF
--- a/doc/src/dump_image.rst
+++ b/doc/src/dump_image.rst
@@ -258,11 +258,11 @@ determines whether a JPEG, PNG, TGA, or PPM file is created with the
 *image* dump style.  If the suffix is ".jpg" or ".jpeg", then a `JPEG
 format <jpeg_format_>`_ file is created, if the suffix is ".png", then a
 `PNG format <png_format_>`_ file is created, if the suffix is ".tga",
-then an uncompressed 24-bit RGB `TGA or TARGA format <tga_format_>`_
+then an compressed 24-bit RGB `TGA or TARGA format <tga_format_>`_
 file is created, else a `PPM (aka NETPBM) format <ppm_format_>`_ file is
 created.  The JPEG, PNG, and TGA files are binary; PPM has a text mode
 header followed by binary data. JPEG images have lossy compression, PNG
-has lossless compression, and TGA and PPM files are uncompressed but can
+and TGA have lossless compression, and PPM files are uncompressed but can
 be compressed with a supported compression program, if LAMMPS has been
 compiled with :ref:`compression support <gzip>` and a supported suffix
 is used.

--- a/doc/src/dump_image.rst
+++ b/doc/src/dump_image.rst
@@ -262,7 +262,7 @@ determines whether a JPEG, PNG, TGA, or PPM file is created with the
 *image* dump style.  If the suffix is ".jpg" or ".jpeg", then a `JPEG
 format <jpeg_format_>`_ file is created, if the suffix is ".png", then a
 `PNG format <png_format_>`_ file is created, if the suffix is ".tga",
-then an compressed 24-bit RGB `TGA or TARGA format <tga_format_>`_
+then a compressed 24-bit RGB `TGA or TARGA format <tga_format_>`_
 file is created, else a `PPM (aka NETPBM) format <ppm_format_>`_ file is
 created.  The JPEG, PNG, and TGA files are binary; PPM has a text mode
 header followed by binary data. JPEG images have lossy compression, PNG

--- a/doc/src/dump_image.rst
+++ b/doc/src/dump_image.rst
@@ -212,13 +212,13 @@ Examples
 Description
 """""""""""
 
-Dump a high-quality rendered image of the atom configuration every :math:`N`
-timesteps and save the images either as a sequence of JPEG or PNG or
-PPM files, or as a single movie file.  The options for this command as
-well as the :doc:`dump_modify <dump_modify>` command control what is
-included in the image or movie and how it appears.  A series of such
-images can easily be manually converted into an animated movie of your
-simulation or the process can be automated without writing the
+Dump a high-quality rendered image of the atom configuration every
+:math:`N` timesteps and save the images either as a sequence of JPEG,
+PNG, TGA, or PPM files, or as a single movie file.  The options for this
+command as well as the :doc:`dump_modify <dump_modify>` command control
+what is included in the image or movie and how it appears.  A series of
+such images can easily be manually converted into an animated movie of
+your simulation or the process can be automated without writing the
 intermediate files using the dump movie style; see further details
 below.  Other dump styles store snapshots of numerical data associated
 with atoms in various formats, as discussed on the :doc:`dump <dump>`
@@ -254,20 +254,23 @@ with examples is provided in the :doc:`Howto_viz` howto.
 Only atoms in the specified group are rendered in the image.  The
 :doc:`dump_modify region and thresh <dump_modify>` commands can also
 alter what atoms are included in the image.  The filename suffix
-determines whether a JPEG, PNG, or PPM file is created with the *image*
-dump style.  If the suffix is ".jpg" or ".jpeg", then a `JPEG format
-<jpeg_format_>`_ file is created, if the suffix is ".png", then a `PNG
-format <png_format_>`_ is created, else a `PPM (aka NETPBM) format
-<ppm_format_>`_ file is created.  The JPEG and PNG files are binary; PPM
-has a text mode header followed by binary data. JPEG images have lossy
-compression, PNG has lossless compression, and PPM files are
-uncompressed but can be compressed with a supported compression program,
-if LAMMPS has been compiled with :ref:`compression support <gzip>` and a
-supported suffix is used.
+determines whether a JPEG, PNG, TGA, or PPM file is created with the
+*image* dump style.  If the suffix is ".jpg" or ".jpeg", then a `JPEG
+format <jpeg_format_>`_ file is created, if the suffix is ".png", then a
+`PNG format <png_format_>`_ file is created, if the suffix is ".tga",
+then an uncompressed 24-bit RGB `TGA or TARGA format <tga_format_>`_
+file is created, else a `PPM (aka NETPBM) format <ppm_format_>`_ file is
+created.  The JPEG, PNG, and TGA files are binary; PPM has a text mode
+header followed by binary data. JPEG images have lossy compression, PNG
+has lossless compression, and TGA and PPM files are uncompressed but can
+be compressed with a supported compression program, if LAMMPS has been
+compiled with :ref:`compression support <gzip>` and a supported suffix
+is used.
 
 .. _jpeg_format: https://jpeg.org/jpeg/
 .. _png_format: https://en.wikipedia.org/wiki/Portable_Network_Graphics
 .. _ppm_format: https://en.wikipedia.org/wiki/Netpbm
+.. _tga_format: https://en.wikipedia.org/wiki/Truevision_TGA
 
 Similarly, the format of the resulting movie is chosen with the *movie*
 dump style. This is handled by the underlying FFmpeg converter and thus

--- a/doc/src/dump_image.rst
+++ b/doc/src/dump_image.rst
@@ -251,6 +251,10 @@ Here are five sample images, rendered as JPEG or PNG files.
 A detailed discussion of advanced graphics settings and workflows
 with examples is provided in the :doc:`Howto_viz` howto.
 
+.. versionadded:: TBD
+
+   support for writing compressed TGA files
+
 Only atoms in the specified group are rendered in the image.  The
 :doc:`dump_modify region and thresh <dump_modify>` commands can also
 alter what atoms are included in the image.  The filename suffix

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -3883,6 +3883,7 @@ textrm
 tfac
 tfmc
 tfMC
+tga
 tgnpt
 tgnvt
 th

--- a/examples/GRAPHICS/.gitignore
+++ b/examples/GRAPHICS/.gitignore
@@ -1,0 +1,10 @@
+*.png
+*.tga
+*.ppm
+*.mp4
+*.mkv
+*.avi
+*.mpg
+*.mpeg
+*.jpg
+*.jpeg

--- a/examples/GRAPHICS/README
+++ b/examples/GRAPHICS/README
@@ -10,5 +10,6 @@ automatically as they are created.
 
 Here is a list of the inputs and which graphics features they demonstrate
 
-- in.cubes-and-pyramids:    visualization of body particles
+- in.cubes-and-pyramids:    visualization of body particles, uses progress bar
 - in.breakable:             using autobond, color-by-property, adding objects and text
+- in.water-arrows:          box of water molecules, uses many kinds of arrows

--- a/examples/GRAPHICS/data.cubes-and-pyramids
+++ b/examples/GRAPHICS/data.cubes-and-pyramids
@@ -1,7 +1,7 @@
 LAMMPS data file for polygons: cubes, moment of inertia I = m edge^2/ 6
 2 atoms
 2 bodies
-1 atom types
+2 atom types
 0 6 xlo xhi
 0 6 ylo yhi
 0 6 zlo zhi
@@ -9,7 +9,7 @@ LAMMPS data file for polygons: cubes, moment of inertia I = m edge^2/ 6
 Atoms
 
 1 1 1 1 1.5 1.5 1.5
-2 1 1 1 4.0 4.0 4.0
+2 2 1 1 4.0 4.0 4.0
 
 Bodies
 

--- a/examples/GRAPHICS/h2o.mol
+++ b/examples/GRAPHICS/h2o.mol
@@ -1,0 +1,62 @@
+# Water molecule. SPC/E
+
+3 atoms
+2 bonds
+1 angles
+
+Coords
+
+1    1.12456   0.09298   1.27452
+2    1.53683   0.75606   1.89928
+3    0.49482   0.56390   0.65678
+
+Types
+
+1        1
+2        2
+3        2
+
+Charges
+
+1       -0.8472
+2        0.4236
+3        0.4236
+
+Bonds
+
+1   1      1      2
+2   1      1      3
+
+Angles
+
+1   1      2      1      3
+
+Shake Flags
+
+1 1
+2 1
+3 1
+
+Shake Atoms
+
+1 1 2 3
+2 1 2 3
+3 1 2 3
+
+Shake Bond Types
+
+1 1 1 1
+2 1 1 1
+3 1 1 1
+
+Special Bond Counts
+
+1 2 0 0
+2 1 1 0
+3 1 1 0
+
+Special Bonds
+
+1 2 3
+2 1 3
+3 1 2

--- a/examples/GRAPHICS/in.breakable
+++ b/examples/GRAPHICS/in.breakable
@@ -86,9 +86,17 @@ fix labels all graphics/labels  500 text "LAMMPS Tutorial 2 - Stretching CNT usi
                                     text "Atoms with bonds  1: $(c_count[1])  2: $(c_count[2])  3: $(c_count[3])  4: $(c_count[4])" &
                                     32.5 7.5 5.0 size 24 fontcolor white backcolor silver
 
-dump viz all image 500 myimage.*.png c_nbond type size 1600 300 zoom 12.5 shiny 0.2 autobond 1.8 0.4 &
+dump viz all image 500 breakable.*.png c_nbond type size 1600 300 zoom 12.5 shiny 0.2 autobond 1.8 0.4 &
         adiam 0.8 box no 0.01 view 0 90 fsaa yes ssao yes 1325123 0.6 axes yes 0.5 0.1 &
         fix arrows const 0 0  fix labels const 0 0 fix vel const 0 0
+
+# comment out the dump image command above and uncomment the lines below to create a movie
+#
+#dump viz all movie 500 breakable.mp4 c_nbond type size 1600 300 zoom 12.5 shiny 0.2 autobond 1.8 0.4 &
+#        adiam 0.8 box no 0.01 view 0 90 fsaa yes ssao yes 1325123 0.6 axes yes 0.5 0.1 &
+#        fix arrows const 0 0  fix labels const 0 0 fix vel const 0 0
+#dump_modify viz framerate 8
+
 dump_modify viz pad 5 backcolor darkgray backcolor2 gray &
         fcolor arrows firebrick fcolor vel midnightblue acolor 1 lightslategray &
         amap 0 5 sa 1 5 midnightblue royalblue cadetblue lightslategray blue

--- a/examples/GRAPHICS/in.cubes-and-pyramids
+++ b/examples/GRAPHICS/in.cubes-and-pyramids
@@ -1,17 +1,19 @@
 # 3d rounded cubes and tetragonal pyramids
 
-variable    r     index 3
-variable    steps index 1000
+variable    r     index 4
+variable    steps index 10050
+variable    out   index 100  # graphics output every this many steps
 
 units       lj
 dimension   3
 boundary p p p
 
 atom_style  body rounded/polyhedron 1 10
+read_data   data.cubes-and-pyramids extra/atom/types 2
 
-read_data   data.cubes-and-pyramids extra/atom/types 1
-
-set atom 2 type 2
+# data file consists of one cube "atom" and one pyramid "atom"
+# the cube is atom type 1 the pyramid atom type 2
+# add two atom types so we can set colors for the progress bar
 
 replicate   $r $r $r
 
@@ -35,18 +37,22 @@ neigh_modify every 1 delay 0 check yes
 
 timestep     0.001
 
-fix          1 all npt/body temp 1.2 1.2 0.1 iso 0.02 0.2 1.0
-
+fix          1 all npt/body temp 1.2 1.2 0.1 iso 0.02 0.05 1.0
 compute      p2 all pressure 1_temp
-
-dump         2 all image 1000 image-bodies.*.png type type size 600 600 shiny 0.4 box yes 0.025 &
-             zoom 2.0 view 80 15 fsaa yes ssao yes 315123 0.8  body type 0.2 3
-
-dump_modify  2 pad 6 backcolor darkgray backcolor2 gray boxcolor silver &
-                     acolor 1 steelblue acolor 2 orange
 thermo_style custom step ke pe etotal c_p2 c_1_temp
-
 thermo       1000
+
+variable progress equal step/v_steps
+fix pbar all graphics/objects ${out} progbar 3 4 y 24.0 12.0 -1.4 30.0 0.5 v_progress 10
+
+dump         2 all image ${out} cubes-and-pyramids.*.png type type size 600 600 shiny 0.4 &
+                         box yes 0.025 axes no 0.5 0.1 zoom 1.5 view 80 0 fsaa yes ssao yes 315123 0.4 &
+                         body type 0.2 3 fix pbar type 0 0
+#            set cylinder diameter--^  ^-- set viz style (1 only faces, 2 cylinders, 3 both)
+dump_modify  2 pad 6 backcolor darkgray backcolor2 gray boxcolor white &
+                     acolor 1 steelblue acolor 2 orange  acolor 3 slategray  acolor 4 red
+#                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#                                                        || colors for progress bar ||
 
 run          ${steps}
 

--- a/examples/GRAPHICS/in.water-arrows
+++ b/examples/GRAPHICS/in.water-arrows
@@ -1,0 +1,71 @@
+units real
+atom_style full
+region box block -5 5 -5 5 -5 5
+create_box 2 box bond/types 1 angle/types 1 &
+            extra/bond/per/atom 2 extra/angle/per/atom 1 extra/special/per/atom 2
+
+mass 1 15.9994
+mass 2 1.008
+
+pair_style lj/cut/coul/cut 8.0
+pair_coeff 1 1 0.1553 3.166
+pair_coeff 2 2 0.0    1.0
+
+bond_style zero
+bond_coeff 1 1.0
+
+angle_style zero
+angle_coeff 1 109.47
+
+# load SPC/E water and fill box
+molecule water h2o.mol
+create_atoms 0 random 50 34564 NULL mol water 25367 overlap 1.33
+
+fix rigid all shake 0.001 10 10000 b 1 a 1
+minimize 0.0 0.0 1000 10000
+
+reset_timestep 0
+timestep 1.0
+velocity all create 300.0 5463576
+unfix rigid
+fix integrate all nvt temp 300 300 100.0
+fix rigid all shake 0.001 10 10000 b 1 a 1
+
+# add yellow arrows showing the molecular dipole moment at the COM of the water molecules
+compute molchunk all chunk/atom molecule
+compute cpos all com/chunk molchunk wrap yes
+compute cdip all dipole/chunk molchunk
+fix vec all graphics/arrows 10 chunk molchunk cpos cdip 3 0.1
+
+# add light blue and transparent arrows to atoms showing the atomic velocity
+fix vel all graphics/arrows 10 velocity 50.0 0.066 autoscale 0.5
+
+# add purple arrows to 8 spatial bins in 3d showing the dipole per bin
+compute binchunk all chunk/atom bin/3d x lower 5.0 y lower 5.0 z lower 5.0
+compute bpos all property/chunk binchunk coord1 coord2 coord3
+compute bdip all dipole/chunk binchunk
+fix bin all graphics/arrows 10 chunk binchunk bpos bdip 3 0.2 autoscale 2.0
+
+# add green arrow to the center of the box showing the total dipole moment of the system
+compute dip all dipole
+variable scale equal 0.66
+# convert dipole vector component to bottom and tip coordinates of arrow
+variable dip1x equal -v_scale*c_dip[1]
+variable dip1y equal -v_scale*c_dip[2]
+variable dip1z equal -v_scale*c_dip[3]
+variable dip2x equal v_scale*c_dip[1]
+variable dip2y equal v_scale*c_dip[2]
+variable dip2z equal v_scale*c_dip[3]
+fix dipole all graphics/objects 1 arrow 1  v_dip1x v_dip1y v_dip1z v_dip2x v_dip2y v_dip2z 0.3 0.2
+
+dump viz all image 10 water-arrows-*.png element type size 600 600 zoom 1.3 shiny 0.2 bond atom 0.2 &
+                                     view 70 20 box yes 0.025 fsaa yes ssao yes 315465 0.8 &
+                                     fix dipole const 0 0  fix vec const 0 0  fix vel const 0 0 fix bin const 0 0
+#                                    all arrows from fixes use the "const" style so we set the color with dump_modify below
+dump_modify viz pad 9  boxcolor silver backcolor gray backcolor2 darkgray element O H adiam 1 0.5 adiam 2 0.3 bdiam 1 0.2 &
+                              fcolor dipole forestgreen fcolor vec goldenrod fcolor vel cyan ftrans vel 0.5 fcolor bin orchid
+
+thermo_style custom step temp press etotal pe
+
+thermo 100
+run 1000

--- a/src/BODY/fix_wall_body_polyhedron.cpp
+++ b/src/BODY/fix_wall_body_polyhedron.cpp
@@ -556,7 +556,7 @@ int FixWallBodyPolyhedron::sphere_against_wall(int i, double wall_pos,double* vw
     hi[0] = x[i][0];
     hi[1] = wall_pos;
     hi[2] = x[i][2];
-  } else if (wallstyle == ZPLANE) {
+  } else { // if (wallstyle == ZPLANE) {
     hi[0] = x[i][0];
     hi[1] = x[i][1];
     hi[2] = wall_pos;
@@ -673,7 +673,7 @@ int FixWallBodyPolyhedron::compute_distance_to_wall(int ibody, int edge_index, d
     hi[0] = xpi1[0];
     hi[1] = wall_pos;
     hi[2] = xpi1[2];
-  } else if (wallstyle == ZPLANE) {
+  } else { // if (wallstyle == ZPLANE) {
     hi[0] = xpi1[0];
     hi[1] = xpi1[1];
     hi[2] = wall_pos;

--- a/src/GRAPHICS/dump_image.cpp
+++ b/src/GRAPHICS/dump_image.cpp
@@ -104,10 +104,21 @@ DumpImage::DumpImage(LAMMPS *lmp, int narg, char **arg) :
   if (utils::strmatch(filename, "\\.jpg$") || utils::strmatch(filename, "\\.JPG$")
       || utils::strmatch(filename, "\\.jpeg$") || utils::strmatch(filename, "\\.JPEG$"))
     filetype = JPG;
-  else if  (utils::strmatch(filename, "\\.png$") || utils::strmatch(filename, "\\.PNG$"))
+  else if (utils::strmatch(filename, "\\.png$") || utils::strmatch(filename, "\\.PNG$"))
     filetype = PNG;
-  else if  (utils::strmatch(filename, "\\.tga$") || utils::strmatch(filename, "\\.TGA$"))
+  else if (utils::strmatch(filename, "\\.tga$") || utils::strmatch(filename, "\\.TGA$"))
     filetype = TGA;
+  else if (compressed && (utils::strmatch(filename, "\\.jpg\\.\\w+$") ||
+                          utils::strmatch(filename, "\\.JPG\\.\\w+$") ||
+                          utils::strmatch(filename, "\\.jpeg\\.\\w+$") ||
+                          utils::strmatch(filename, "\\.JPEG\\.\\w+$")))
+    error->all(FLERR, Error::NOLASTLINE, "Cannot use compression with JPEG images");
+  else if (compressed && (utils::strmatch(filename, "\\.png\\.\\w+$") ||
+                           utils::strmatch(filename, "\\.PNG\\.\\w+$")))
+    error->all(FLERR, Error::NOLASTLINE, "Cannot use compression with PNG images");
+  else if (compressed && (utils::strmatch(filename, "\\.tga\\.\\w+$") ||
+                          utils::strmatch(filename, "\\.TGA\\.\\w+$")))
+    error->all(FLERR, Error::NOLASTLINE, "Cannot use compression with TGA images");
   else filetype = PPM;
 
 #ifndef LAMMPS_JPEG

--- a/src/GRAPHICS/dump_image.cpp
+++ b/src/GRAPHICS/dump_image.cpp
@@ -106,6 +106,8 @@ DumpImage::DumpImage(LAMMPS *lmp, int narg, char **arg) :
     filetype = JPG;
   else if  (utils::strmatch(filename, "\\.png$") || utils::strmatch(filename, "\\.PNG$"))
     filetype = PNG;
+  else if  (utils::strmatch(filename, "\\.tga$") || utils::strmatch(filename, "\\.TGA$"))
+    filetype = TGA;
   else filetype = PPM;
 
 #ifndef LAMMPS_JPEG
@@ -942,6 +944,7 @@ void DumpImage::write()
   if (me == 0) {
     if (filetype == JPG) image->write_JPG(fp);
     else if (filetype == PNG) image->write_PNG(fp);
+    else if (filetype == TGA) image->write_TGA(fp);
     else image->write_PPM(fp);
     if (multifile) {
       fclose(fp);

--- a/src/GRAPHICS/dump_image.h
+++ b/src/GRAPHICS/dump_image.h
@@ -48,7 +48,7 @@ class DumpImage : public DumpCustom {
 
  protected:
   int filetype;
-  enum { PPM, JPG, PNG };    // file type constants
+  enum { PPM, JPG, PNG, TGA };    // file type constants
 
   int atomflag;         // 0/1 for draw atoms
   int acolor, adiam;    // what determines color/diam of atoms

--- a/src/GRAPHICS/fix_graphics_arrows.cpp
+++ b/src/GRAPHICS/fix_graphics_arrows.cpp
@@ -58,6 +58,7 @@ FixGraphicsArrows::FixGraphicsArrows(LAMMPS *lmp, int narg, char **arg) :
   scale = 1.0;
   autoscale = false;
   autovalue = 1.0;
+  xvar = yvar = zvar = -1;
 
   int iarg = 7;
   if (strcmp(arg[4], "dipole") == 0) {

--- a/src/GRAPHICS/fix_graphics_isosurface.cpp
+++ b/src/GRAPHICS/fix_graphics_isosurface.cpp
@@ -438,6 +438,8 @@ FixGraphicsIsosurface::FixGraphicsIsosurface(LAMMPS *lmp, int narg, char **arg) 
   pflag = NUMBER;
   binary = 0;
   pad = 0;
+  pvar = -1;
+  pindex = -1;
 
   // parse mandatory args
 
@@ -998,11 +1000,12 @@ void FixGraphicsIsosurface::end_of_step()
         }
       }
       if (!binary) fprintf(fp, "endsolid %s\n", title.c_str());
-      fclose(fp);
+      fclose(fp);    // NOLINT
       delete[] filecurrent;
     } else {
       MPI_Send(stldata, 12 * numobjs, MPI_FLOAT, 0, 0, world);
     }
+    delete[] stldata;
   }
 }
 

--- a/src/GRAPHICS/fix_graphics_labels.cpp
+++ b/src/GRAPHICS/fix_graphics_labels.cpp
@@ -137,8 +137,7 @@ unsigned char *read_image(FILE *fp, int &width, int &height, const std::string &
     unsigned char sig[8];
 
     // read and check PNG file signature
-    fread(sig, sizeof(unsigned char), 8, fp);
-    if (!png_check_sig(sig, 8)) return nullptr;
+    if ((fread(sig, sizeof(unsigned char), 8, fp) != 8) || !png_check_sig(sig, 8)) return nullptr;
 
     // set up reading from file
     png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
@@ -227,7 +226,8 @@ unsigned char *read_image(FILE *fp, int &width, int &height, const std::string &
     } while (buffer[0] == '#');
 
     int rv = sscanf(buffer, "%d%d", &width, &height);
-    if (rv != 2) return nullptr;
+    // don't read invalid or oversize images
+    if ((rv != 2) || (width < 1) || (height < 1) || ((width * height) > (1 << 30))) return nullptr;
 
     int tmp = 0;
     ptr = fgets(buffer, 128, fp);
@@ -277,8 +277,6 @@ unsigned char *read_image(FILE *fp, int &width, int &height, const std::string &
 
     return pixmap;
   }
-  info = "Unknown image file format.";
-  return nullptr;
 }
 }    // namespace
 
@@ -287,6 +285,7 @@ unsigned char *read_image(FILE *fp, int &width, int &height, const std::string &
 #define PARSE_VARIABLE(value, name, index)      \
   if (strstr(arg[index], "v_") == arg[index]) { \
     varflag = 1;                                \
+    delete[] name;                              \
     name = utils::strdup(arg[index] + 2);       \
   } else                                        \
     value = utils::numeric(FLERR, arg[index], false, lmp)
@@ -719,9 +718,9 @@ void FixGraphicsLabels::end_of_step()
       if (txt.notrans) {
         imgparms[n][7] = imgparms[n][8] = imgparms[n][9] = -1.0;
       } else {
-        imgparms[n][7] = (double)txt.transcolor[0] / 255.0;
-        imgparms[n][8] = (double)txt.transcolor[1] / 255.0;
-        imgparms[n][9] = (double)txt.transcolor[2] / 255.0;
+        imgparms[n][7] = (double) txt.transcolor[0] / 255.0;
+        imgparms[n][8] = (double) txt.transcolor[1] / 255.0;
+        imgparms[n][9] = (double) txt.transcolor[2] / 255.0;
       }
 
       imgparms[n][10] = txt.scale;

--- a/src/GRAPHICS/fix_graphics_objects.cpp
+++ b/src/GRAPHICS/fix_graphics_objects.cpp
@@ -39,6 +39,7 @@ enum { X = 0, Y, Z };
 #define PARSE_VARIABLE(value, name, index)      \
   if (strstr(arg[index], "v_") == arg[index]) { \
     varflag = 1;                                \
+    delete[] name;                              \
     name = utils::strdup(arg[index] + 2);       \
   } else                                        \
     value = utils::numeric(FLERR, arg[index], false, lmp)

--- a/src/GRAPHICS/image.cpp
+++ b/src/GRAPHICS/image.cpp
@@ -1650,8 +1650,8 @@ void Image::write_TGA(FILE *fp, bool compressed)
           old[2] = pix[2];
         }
 
-        if ((old[0] != pix[0]) || (old[1] != pix[1]) || (old[2] != pix[2]) || (len == 127)) {
-          --len;
+        if (memcmp(old, pix, 3) || (len == 127) || (j == tgawidth - 1)) {
+          if (j != tgawidth - 1) --len;
           len |= 0x80U;
           fputc(len, fp);
           // TGA stores RGB as BGR
@@ -1664,12 +1664,6 @@ void Image::write_TGA(FILE *fp, bool compressed)
           len = 1;
         } else ++len;
       }
-      --len;
-      len |= 0x80U;
-      fputc(len, fp);
-      fputc(old[2], fp);
-      fputc(old[1], fp);
-      fputc(old[0], fp);
     }
   } else {
     header.datatypecode = 2;    // uncompressed RGB

--- a/src/GRAPHICS/image.cpp
+++ b/src/GRAPHICS/image.cpp
@@ -1617,7 +1617,7 @@ void Image::write_PNG(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
-void Image::write_TGA(FILE *fp)
+void Image::write_TGA(FILE *fp, bool compressed)
 {
   if (!fp) return;
 
@@ -1627,25 +1627,65 @@ void Image::write_TGA(FILE *fp)
 
   TGAHeader header;
   memset(&header, 0, sizeof(header));
-  header.datatypecode = 2;    // uncompressed RGB
   header.width[0] = static_cast<unsigned char>(tgawidth & 0xFF);
   header.width[1] = static_cast<unsigned char>((tgawidth & 0xFF00) >> 8);
   header.height[0] = static_cast<unsigned char>(tgaheight & 0xFF);
   header.height[1] = static_cast<unsigned char>((tgaheight & 0xFF00) >> 8);
   header.bitsperpixel = 3 * 8 * sizeof(unsigned char);
-  fwrite(&header, sizeof(header), 1, fp);
 
-  unsigned char *pix;
-  for (int i=0; i < tgaheight; ++i) {
-    for (int j = 0; j < tgawidth; ++j) {
-      pix = &writeBuffer[i*3*tgawidth + 3*j];
-      // TGA stores RGB as BGR
-      fputc(pix[2], fp);
-      fputc(pix[1], fp);
-      fputc(pix[0], fp);
+  if (compressed) {
+    header.datatypecode = 10;    // RLE compressed RGB
+    fwrite(&header, sizeof(header), 1, fp);
+
+    unsigned char *pix;
+    unsigned char old[3];
+    unsigned char len;
+    for (int i=0; i < tgaheight; ++i) {
+      len = 0;
+      for (int j = 0; j < tgawidth; ++j) {
+        pix = &writeBuffer[i*3*tgawidth + 3*j];
+        if (len == 0) {
+          old[0] = pix[0];
+          old[1] = pix[1];
+          old[2] = pix[2];
+        }
+
+        if ((old[0] != pix[0]) || (old[1] != pix[1]) || (old[2] != pix[2]) || (len == 127)) {
+          --len;
+          len |= 0x80U;
+          fputc(len, fp);
+          // TGA stores RGB as BGR
+          fputc(old[2], fp);
+          fputc(old[1], fp);
+          fputc(old[0], fp);
+          old[0] = pix[0];
+          old[1] = pix[1];
+          old[2] = pix[2];
+          len = 1;
+        } else ++len;
+      }
+      --len;
+      len |= 0x80U;
+      fputc(len, fp);
+      fputc(old[2], fp);
+      fputc(old[1], fp);
+      fputc(old[0], fp);
+    }
+  } else {
+    header.datatypecode = 2;    // uncompressed RGB
+    fwrite(&header, sizeof(header), 1, fp);
+
+    unsigned char *pix;
+    for (int i=0; i < tgaheight; ++i) {
+      for (int j = 0; j < tgawidth; ++j) {
+        pix = &writeBuffer[i*3*tgawidth + 3*j];
+        // TGA stores RGB as BGR
+        fputc(pix[2], fp);
+        fputc(pix[1], fp);
+        fputc(pix[0], fp);
+      }
     }
   }
-
   TGAFooter footer{0, 0, "TRUEVISION-XFILE."};
   fwrite(&footer, sizeof(footer), 1, fp);
 }

--- a/src/GRAPHICS/image.cpp
+++ b/src/GRAPHICS/image.cpp
@@ -57,6 +57,27 @@ enum { CONTINUOUS, DISCRETE, SEQUENTIAL };
 enum { ABSOLUTE, FRACTIONAL };
 enum { NO, YES };
 
+struct TGAHeader {
+  unsigned char idlength;
+  unsigned char colormaptype;
+  unsigned char datatypecode;
+  unsigned char colormaporigin[2];
+  unsigned char colormaplength[2];
+  unsigned char colormapdepth;
+  unsigned char x_origin[2];
+  unsigned char y_origin[2];
+  unsigned char width[2];
+  unsigned char height[2];
+  unsigned char bitsperpixel;
+  unsigned char imagedescriptor;
+};
+
+struct TGAFooter {
+  unsigned int extoffset;
+  unsigned int devoffset;
+  char signature[18];
+};
+
 ////////////////////////////////////////////////////////////////////////
 // the following regular Bayer threshold matrix can be created for any
 // power of 2 ranks with the following python code.
@@ -1498,6 +1519,8 @@ void Image::compute_SSAO()
 void Image::write_JPG(FILE *fp)
 {
 #ifdef LAMMPS_JPEG
+  if (!fp) return;
+
   const int aafactor = fsaa ? 2 : 1;
   struct jpeg_compress_struct cinfo;
   struct jpeg_error_mgr jerr;
@@ -1533,6 +1556,8 @@ void Image::write_JPG(FILE *fp)
 void Image::write_PNG(FILE *fp)
 {
 #ifdef LAMMPS_PNG
+  if (!fp) return;
+
   const int aafactor = fsaa ? 2 : 1;
   const int pngwidth = width/aafactor;
   const int pngheight = height/aafactor;
@@ -1592,8 +1617,45 @@ void Image::write_PNG(FILE *fp)
 
 /* ---------------------------------------------------------------------- */
 
+void Image::write_TGA(FILE *fp)
+{
+  if (!fp) return;
+
+  const int aafactor = fsaa ? 2 : 1;
+  const int tgaheight = height/aafactor;
+  const int tgawidth = width/aafactor;
+
+  TGAHeader header;
+  memset(&header, 0, sizeof(header));
+  header.datatypecode = 2;    // uncompressed RGB
+  header.width[0] = static_cast<unsigned char>(tgawidth & 0xFF);
+  header.width[1] = static_cast<unsigned char>((tgawidth & 0xFF00) >> 8);
+  header.height[0] = static_cast<unsigned char>(tgaheight & 0xFF);
+  header.height[1] = static_cast<unsigned char>((tgaheight & 0xFF00) >> 8);
+  header.bitsperpixel = 3 * 8 * sizeof(unsigned char);
+  fwrite(&header, sizeof(header), 1, fp);
+
+  unsigned char *pix;
+  for (int i=0; i < tgaheight; ++i) {
+    for (int j = 0; j < tgawidth; ++j) {
+      pix = &writeBuffer[i*3*tgawidth + 3*j];
+      // TGA stores RGB as BGR
+      fputc(pix[2], fp);
+      fputc(pix[1], fp);
+      fputc(pix[0], fp);
+    }
+  }
+
+  TGAFooter footer{0, 0, "TRUEVISION-XFILE."};
+  fwrite(&footer, sizeof(footer), 1, fp);
+}
+
+/* ---------------------------------------------------------------------- */
+
 void Image::write_PPM(FILE *fp)
 {
+  if (!fp) return;
+
   const int aafactor = fsaa ? 2 : 1;
   const int ppmheight = height/aafactor;
   const int ppmwidth = width/aafactor;

--- a/src/GRAPHICS/image.cpp
+++ b/src/GRAPHICS/image.cpp
@@ -2356,7 +2356,6 @@ int ColorMap::reset(int narg, char **arg)
   delete [] mentry;
   mentry = new MapEntry[nentry];
 
-  int expandflag = 0;
   int n = 5;
   for (int i = 0; i < nentry; i++) {
     if (mstyle == CONTINUOUS) {

--- a/src/GRAPHICS/image.h
+++ b/src/GRAPHICS/image.h
@@ -47,7 +47,7 @@ class Image : protected Pointers {
   void merge();
   void write_JPG(FILE *);
   void write_PNG(FILE *);
-  void write_TGA(FILE *);
+  void write_TGA(FILE *, bool compressed = true);
   void write_PPM(FILE *);
   void view_params(double, double, double, double, double, double);
 

--- a/src/GRAPHICS/image.h
+++ b/src/GRAPHICS/image.h
@@ -47,6 +47,7 @@ class Image : protected Pointers {
   void merge();
   void write_JPG(FILE *);
   void write_PNG(FILE *);
+  void write_TGA(FILE *);
   void write_PPM(FILE *);
   void view_params(double, double, double, double, double, double);
 

--- a/src/GRAPHICS/image_objects.cpp
+++ b/src/GRAPHICS/image_objects.cpp
@@ -112,19 +112,13 @@ std::vector<triangle> transform(const std::vector<triangle> &triangles, const ve
 // ^        ^  ^
 // bot    mid tip
 
-ArrowObj::ArrowObj(double _tipl, double _tipw, double radius, int res)
+ArrowObj::ArrowObj(double _tipl, double _tipw, double radius, int res) :
+    tiplength(_tipl), tipwidth(_tipw), diameter(2.0 * radius), resolution(res)
 {
   triangles.clear();
 
   // we want at least 2 iterations.
   if (res < 2) return;
-
-  // store settings for arrow template
-
-  tiplength = _tipl;
-  tipwidth = _tipw;
-  diameter = 2.0 * radius;
-  resolution = res;
 
   vec3 tip{0.5, 0.0, 0.0};
   vec3 mid{0.5 - tiplength, 0.0, 0.0};


### PR DESCRIPTION
**Summary**

This pull request combines multiple small changes and fixes that do not warrant a pull request of their own.

**Related Issue(s)**

N/A

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Backward Compatibility**

N/A

**Implementation Notes**

The following individual changes are included:
- apply code improvements and bugfixes to address issues reported by Coverity Scan and Clang Static Analyzer
- add more commented examples to `examples/GRAPHICS` folder showing how to use advanced graphics features in LAMMPS
- add support to write RLE compressed binary TGA files as an alternative to PPM, especially on Windows. This is a simple file format that does not require an external library
- add logic to prohibit using PNG, JPEG, and TGA in combination with a compression extension. There is no benefit from compressing already compressed files and our file format detection logic would fail to detect them as PNG, JPEG, or TGA plus compression anyway and write out a compressed NetPBM file (which *is* supported).

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
