### PR TITLE
Collected small changes and fixes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -174,6 +174,10 @@
 
 # docs
 /doc/*                  @akohlmey
+/doc/src/Howto_viz.rst  @akohlmey
+/doc/src/Howto_spc.rst  @akohlmey
+/doc/src/Howto_tip*.rst @akohlmey
+/examples/GRAPHICS/     @akohlmey
 /examples/plugin/       @akohlmey
 /examples/PACKAGES/pace/plugin/  @akohlmey
 

--- a/.github/release_steps.md
+++ b/.github/release_steps.md
@@ -212,6 +212,26 @@ gh release upload patch_4Feb2025 LAMMPS-Win10-64bit-GUI-4Feb2025.exe
 The symbolic link is used to have a consistent naming scheme for the packages
 attached to the GitHub release page.
 
+#### LAMMPS Online Manual
+
+Creating the online docs requires setting some environment variables to have
+the extra box at the bottom of the navigation bar included that allows to
+switch between release, stable, and develop branch versions of the manual.
+Also the search box should use Google search instead of the javascript search.
+
+``` sh
+cd lammps-release
+make -C doc clean
+make -C doc upgrade
+env LAMMPS_WEBSITE_BUILD=1 LAMMPS_WEBSITE_BUILD_VERSION=release LAMMPS_WEBSITE_BASEURL="https://docs.lammps.org/" \
+    make -C doc html WEB_SEARCH=YES
+make -C doc pdf
+mv doc/Manual.pdf doc/html
+rsync -arpv doc/html/ www.lammps.org:/var/www/lammps/docs/release-new
+
+Then log into www.lammps.org and move the current folder away and
+the new folder in its place and update permissions.
+
 #### Clean up:
 
 ``` sh
@@ -243,6 +263,7 @@ and installed (e.g. to `$HOME/.local`) as static libraries only:
 - jpeg
 - zlib
 - png
+- voro++ (for VORONOI package)
 - Qt (for LAMMPS-GUI)
 
 When configuring LAMMPS the `cmake/presets/clang.cmake` should be used
@@ -298,8 +319,8 @@ Check out the LAMMPS website repo
 https://github.com/lammps/lammps-website.git and edit the file
 `src/download.txt` for the new release.  Test translation with `make
 html` and review `html/download.html` Then add and commit to git and
-push the changes to GitHub.  The Temple Jenkis cluster will
-automatically update https://www.lammps.org/download.html accordingly.
+push the changes to GitHub.  A cron job will automatically update
+https://www.lammps.org/ accordingly if there are changes.
 
 Also notify Steve of the release so he can update `src/bug.txt` on the
 website from the available release notes.
@@ -373,11 +394,10 @@ git tag -s -m 'Update 2 for Stable LAMMPS version 29 August 2024' stable_29Aug20
 git push git@github.com:lammps/lammps.git --tags maintenance stable
 ```
 
-Associate draft release notes with new tag and publish as "latest release".
-
-On https://ci.lammps.org/ go to "dev", "stable" and manually execute
-the "update\_release" task. This will update https://docs.lammps.org/stable
-and prepare a stable tarball.
+Associate draft release notes with new tag and prepare and upload
+various source and binary packages. Publish as "latest release"
+only when all uploads are complete as they cannot be changed after
+they are published since we are creating "immutable" releases now.
 
 ### Build and upload binary packages and source tarball to GitHub
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -193,7 +193,10 @@ endif()
 
 # do not include the (obsolete) MPI C++ bindings which makes for leaner object files
 # and avoids namespace conflicts. Put this early to increase its visbility.
-set(MPI_CXX_SKIP_MPICXX TRUE CACHE BOOL "Skip MPI C++ Bindings" FORCE)
+# do not apply when compiling SCAFACOS since it uses the obsolete bindings
+if (NOT PKG_SCAFACOS)
+  set(MPI_CXX_SKIP_MPICXX TRUE CACHE BOOL "Skip MPI C++ Bindings" FORCE)
+endif()
 
 ########################################################################
 # User input options                                                   #

--- a/cmake/Modules/Packages/SCAFACOS.cmake
+++ b/cmake/Modules/Packages/SCAFACOS.cmake
@@ -3,7 +3,7 @@ enable_language(C)
 
 find_package(GSL REQUIRED)
 find_package(PkgConfig QUIET)
-find_package(MPI REQUIRED)
+find_package(MPI REQUIRED COMPONENTS C MPICXX CXX Fortran)
 set(DOWNLOAD_SCAFACOS_DEFAULT ON)
 if(PKG_CONFIG_FOUND)
   pkg_check_modules(SCAFACOS QUIET scafacos)
@@ -19,6 +19,8 @@ if(DOWNLOAD_SCAFACOS)
   mark_as_advanced(SCAFACOS_URL)
   mark_as_advanced(SCAFACOS_MD5)
   GetFallbackURL(SCAFACOS_URL SCAFACOS_FALLBACK)
+  set(SCAFACOS_CXX_FLAGS "${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}} ${CMAKE_CXX_FLAGS}")
+  set(SCAFACOS_C_FLAGS "${CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE}} ${CMAKE_C_FLAGS}")
 
   include(ExternalProject)
   ExternalProject_Add(scafacos_build
@@ -32,6 +34,8 @@ if(DOWNLOAD_SCAFACOS)
                                              CXX=${CMAKE_MPI_CXX_COMPILER}
                                              CC=${CMAKE_MPI_C_COMPILER}
                                              F77=
+                                             CFLAGS=${SCAFACOS_C_FLAGS}
+                                             CXXFLAGS=${SCAFACOS_CXX_FLAGS}
     BUILD_BYPRODUCTS
       <INSTALL_DIR>/lib/libfcs.a
       <INSTALL_DIR>/lib/libfcs_direct.a
@@ -55,7 +59,7 @@ if(DOWNLOAD_SCAFACOS)
   set_target_properties(LAMMPS::SCAFACOS PROPERTIES
     IMPORTED_LOCATION "${INSTALL_DIR}/lib/libfcs.a"
     INTERFACE_INCLUDE_DIRECTORIES "${INSTALL_DIR}/include"
-    INTERFACE_LINK_LIBRARIES "${INSTALL_DIR}/lib/libfcs.a;${INSTALL_DIR}/lib/libfcs_direct.a;${INSTALL_DIR}/lib/libfcs_ewald.a;${INSTALL_DIR}/lib/libfcs_fmm.a;${INSTALL_DIR}/lib/libfcs_p2nfft.a;${INSTALL_DIR}/lib/libfcs_p3m.a;GSL::gsl;${INSTALL_DIR}/lib/libfcs_near.a;${INSTALL_DIR}/lib/libfcs_gridsort.a;${INSTALL_DIR}/lib/libfcs_resort.a;${INSTALL_DIR}/lib/libfcs_redist.a;${INSTALL_DIR}/lib/libfcs_common.a;${INSTALL_DIR}/lib/libfcs_pnfft.a;${INSTALL_DIR}/lib/libfcs_pfft.a;${INSTALL_DIR}/lib/libfcs_fftw3_mpi.a;${INSTALL_DIR}/lib/libfcs_fftw3.a;MPI::MPI_Fortran;MPI::MPI_C")
+    INTERFACE_LINK_LIBRARIES "${INSTALL_DIR}/lib/libfcs.a;${INSTALL_DIR}/lib/libfcs_direct.a;${INSTALL_DIR}/lib/libfcs_ewald.a;${INSTALL_DIR}/lib/libfcs_fmm.a;${INSTALL_DIR}/lib/libfcs_p2nfft.a;${INSTALL_DIR}/lib/libfcs_p3m.a;GSL::gsl;${INSTALL_DIR}/lib/libfcs_near.a;${INSTALL_DIR}/lib/libfcs_gridsort.a;${INSTALL_DIR}/lib/libfcs_resort.a;${INSTALL_DIR}/lib/libfcs_redist.a;${INSTALL_DIR}/lib/libfcs_common.a;${INSTALL_DIR}/lib/libfcs_pnfft.a;${INSTALL_DIR}/lib/libfcs_pfft.a;${INSTALL_DIR}/lib/libfcs_fftw3_mpi.a;${INSTALL_DIR}/lib/libfcs_fftw3.a;MPI::MPI_CXX;MPI::MPI_Fortran;MPI::MPI_C;${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES}")
   target_link_libraries(lammps PRIVATE LAMMPS::SCAFACOS)
   add_dependencies(LAMMPS::SCAFACOS scafacos_build)
 else()

--- a/doc/doxygen/Doxyfile.in
+++ b/doc/doxygen/Doxyfile.in
@@ -431,6 +431,8 @@ INPUT                  = @LAMMPS_SOURCE_DIR@/utils.cpp                 \
                          @LAMMPS_SOURCE_DIR@/text_file_reader.h        \
                          @LAMMPS_SOURCE_DIR@/potential_file_reader.cpp \
                          @LAMMPS_SOURCE_DIR@/potential_file_reader.h   \
+                         @LAMMPS_SOURCE_DIR@/label_map.cpp             \
+                         @LAMMPS_SOURCE_DIR@/label_map.h               \
                          @LAMMPS_SOURCE_DIR@/my_page.cpp               \
                          @LAMMPS_SOURCE_DIR@/my_page.h                 \
                          @LAMMPS_SOURCE_DIR@/my_pool_chunk.cpp         \

--- a/doc/src/Developer_utils.rst
+++ b/doc/src/Developer_utils.rst
@@ -561,6 +561,9 @@ A file that would be parsed by the reader code fragment looks like this:
 Type label support
 ------------------
 
+Overview
+^^^^^^^^
+
 The :cpp:class:`LabelMap <LAMMPS_NS::LabelMap>` class provides a two way
 mapping between symbolic type labels in input and output files and
 numeric types as they are used by LAMMPS internally.  Instead of
@@ -572,11 +575,12 @@ constituent atom types with hyphens, this can significantly improve
 readability, maintainability, and re-usability of inputs and reduces the
 chance of errors.
 
-The LabelMap class supports lookups from symbolic to numeric and vice
-versa.  It also provides automatic type inference for interactions based
-on their constituent atom types.  For instance, based on the atom type
-labels, the corresponding bond, angle, dihedral, or improper types can
-be inferred.
+The LabelMap class also provides automatic type inference for bonded
+interactions based on their constituent atom types.  For instance, based
+on the atom type labels, the corresponding bond, angle, dihedral, or
+improper types can be inferred provided the corresponding type lables
+follow the convention that they are composed of the symbolic atom types
+connected by hyphens.
 
 Integration with utils namespace
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -597,7 +601,7 @@ interact with the LabelMap class:
 
 These functions enable seamless integration of type labels throughout LAMMPS,
 allowing commands that accept type specifications to work with both numeric
-indices and symbolic labels.
+indices and symbolic labels. Below are some code examples.
 
 Finding types from labels and vice versa
 """"""""""""""""""""""""""""""""""""""""
@@ -607,7 +611,7 @@ Finding types from labels and vice versa
    #include "label_map.h"
    #include "atom.h"
 
-   // Access the label map (assumes atom->lmap exists and is initialized)
+   // assuming this code is used inside a class that is derived from LAMMPS_NS::Pointers
    LabelMap *lmap = atom->lmap;
 
    // Forward lookup: Get numeric type from label
@@ -638,7 +642,7 @@ Inferring bonded types from atom types
    // Infer bond type from numeric atom types
    int bt1 = lmap->infer_bondtype(1, 2);  // Returns 1 (C-H bond)
    int bt2 = lmap->infer_bondtype(1, 1);  // Returns 2 (C-C bond)
-   int bt3 = lmap->infer_bondtype(1, 3);  // Returns 3 (C-N bond)
+   int bt3 = lmap->infer_bondtype(3, 1);  // Returns 3 (C-N bond, symmetric match)
 
    // Infer bond type from atom type labels (handles symmetry automatically)
    int bt4 = lmap->infer_bondtype({"C", "H"});  // Returns 1 (C-H)

--- a/doc/src/Developer_utils.rst
+++ b/doc/src/Developer_utils.rst
@@ -615,13 +615,13 @@ Finding types from labels and vice versa
    LabelMap *lmap = atom->lmap;
 
    // Forward lookup: Get numeric type from label
-   int ctype = lmap->find("C", Atom::ATOM);    // Returns atom type for "C"
-   int htype = lmap->find("H", Atom::ATOM);    // Returns atom type for "H"
-   int missing = lmap->find("X", Atom::ATOM);  // Returns -1 (not found)
+   int ctype = lmap->find_type("C", Atom::ATOM);    // Returns atom type for "C"
+   int htype = lmap->find_type("H", Atom::ATOM);    // Returns atom type for "H"
+   int missing = lmap->find_type("X", Atom::ATOM);  // Returns -1 (not found)
 
    // Reverse lookup: Get label from numeric type
-   const std::string &label1 = lmap->find(1, Atom::ATOM);  // Returns label for type 1
-   const std::string &label2 = lmap->find(2, Atom::BOND);  // Returns bond label for type 2
+   const std::string &label1 = lmap->find_label(1, Atom::ATOM);  // Returns label for type 1
+   const std::string &label2 = lmap->find_label(2, Atom::BOND);  // Returns bond label for type 2
 
    // Check if all types have labels
    bool complete = lmap->is_complete(Atom::ATOM);  // Returns true if all atom types labeled

--- a/doc/src/Developer_utils.rst
+++ b/doc/src/Developer_utils.rst
@@ -578,7 +578,7 @@ chance of errors.
 The LabelMap class also provides automatic type inference for bonded
 interactions based on their constituent atom types.  For instance, based
 on the atom type labels, the corresponding bond, angle, dihedral, or
-improper types can be inferred provided the corresponding type lables
+improper types can be inferred provided the corresponding type labels
 follow the convention that they are composed of the symbolic atom types
 connected by hyphens.
 

--- a/doc/src/Developer_utils.rst
+++ b/doc/src/Developer_utils.rst
@@ -599,13 +599,10 @@ These functions enable seamless integration of type labels throughout LAMMPS,
 allowing commands that accept type specifications to work with both numeric
 indices and symbolic labels.
 
-Usage examples
-^^^^^^^^^^^^^^
-
-**Example 1: Basic type label lookup**
+Finding types from labels and vice versa
+""""""""""""""""""""""""""""""""""""""""
 
 .. code-block:: c++
-   :caption: Finding types from labels and vice versa
 
    #include "label_map.h"
    #include "atom.h"
@@ -625,10 +622,10 @@ Usage examples
    // Check if all types have labels
    bool complete = lmap->is_complete(Atom::ATOM);  // Returns true if all atom types labeled
 
-**Example 2: Inferring bonded types from atom types**
+Inferring bonded types from atom types
+""""""""""""""""""""""""""""""""""""""
 
 .. code-block:: c++
-   :caption: Using infer_bondtype() with numeric and label-based lookups
 
    #include "label_map.h"
    #include "atom.h"
@@ -648,10 +645,10 @@ Usage examples
    int bt5 = lmap->infer_bondtype({"H", "C"});  // Returns 1 (symmetric match)
    int bt6 = lmap->infer_bondtype({"C", "N"});  // Returns 3 (C-N)
 
-**Example 2: Using utils functions with type labels**
+Validating and expanding type labels
+""""""""""""""""""""""""""""""""""""
 
 .. code-block:: c++
-   :caption: Validating and expanding type labels with utils functions
 
    #include "utils.h"
    #include "lammps.h"
@@ -683,6 +680,9 @@ Usage examples
    // Expands "C:H" to numeric range, e.g., "1:2" -> lo=1, hi=2
 
 ----------
+
+LabelMap class reference
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. doxygenclass:: LAMMPS_NS::LabelMap
    :project: progguide

--- a/doc/src/Developer_utils.rst
+++ b/doc/src/Developer_utils.rst
@@ -558,6 +558,193 @@ A file that would be parsed by the reader code fragment looks like this:
 
 ----------
 
+Type label mapping
+------------------
+
+The :cpp:class:`LabelMap <LAMMPS_NS::LabelMap>` class provides a powerful
+abstraction for mapping between symbolic type labels and numeric type indices
+in LAMMPS simulations. Instead of referring to atom types, bond types, angle
+types, dihedral types, and improper types by numeric indices (1, 2, 3, ...),
+users can assign meaningful string labels (e.g., "C", "H", "N", "C-H", "H-C-H")
+that improve readability and maintainability of input scripts.
+
+This feature is particularly useful for:
+
+* Complex molecular systems with many atom types
+* Making input scripts self-documenting
+* Avoiding errors from renumbering types
+* Reusing force field definitions across different systems
+
+Type labels are set using the ``labelmap`` command in LAMMPS input scripts:
+
+.. code-block:: LAMMPS
+
+   # Assign atom type labels
+   labelmap atom 1 C 2 H 3 N 4 O
+
+   # Assign bond type labels (hyphen-delimited format)
+   labelmap bond 1 C-H 2 C-C 3 C-N
+
+   # Assign angle type labels
+   labelmap angle 1 H-C-H 2 C-C-H 3 C-N-C
+
+Interaction types (bonds, angles, dihedrals, impropers) use a **hyphen-delimited
+format** that combines constituent atom type labels. For example, a bond between
+carbon and hydrogen atoms can be labeled "C-H", and an angle formed by
+H-C-H atoms can be labeled "H-C-H".
+
+The LabelMap class supports **bidirectional lookup**:
+
+* Forward lookup: Convert a type label string to its numeric type index
+* Reverse lookup: Convert a numeric type index to its label string
+
+It also provides **automatic type inference** for interactions based on their
+constituent atom types. For instance, given atom type labels, the class can
+infer the corresponding bond, angle, dihedral, or improper type from the
+hyphen-delimited format. This handles symmetric matching automatically (e.g.,
+"C-H" matches "H-C" for bonds).
+
+Integration with utils namespace
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Several utility functions in the ``utils`` namespace work with type labels and
+interact with the LabelMap class:
+
+* :cpp:func:`utils::is_type() <LAMMPS_NS::utils::is_type>` - Validates whether
+  a string is a valid type label. Returns 1 for valid labels, 0 for numeric
+  types, -1 for invalid strings. Type labels cannot start with digits, '*', or
+  '#', and cannot contain whitespace or UTF-8 characters.
+
+* :cpp:func:`utils::expand_type() <LAMMPS_NS::utils::expand_type>` - Converts
+  a type label string to its numeric equivalent using the LabelMap. Returns
+  ``nullptr`` if no label map exists or if the string is not a valid type label.
+
+* :cpp:func:`utils::bounds_typelabel() <LAMMPS_NS::utils::bounds_typelabel>` -
+  Extended version of ``utils::bounds()`` that accepts type labels in addition
+  to numeric ranges. Uses ``expand_type()`` internally to convert labels to
+  numeric bounds before processing.
+
+These functions enable seamless integration of type labels throughout LAMMPS,
+allowing commands that accept type specifications to work with both numeric
+indices and symbolic labels.
+
+Usage examples
+^^^^^^^^^^^^^^
+
+**Example 1: Basic type label lookup**
+
+.. code-block:: c++
+   :caption: Finding types from labels and vice versa
+
+   #include "label_map.h"
+   #include "atom.h"
+
+   // Access the label map (assumes atom->lmap exists and is initialized)
+   LabelMap *lmap = atom->lmap;
+
+   // Forward lookup: Get numeric type from label
+   int ctype = lmap->find("C", Atom::ATOM);    // Returns atom type for "C"
+   int htype = lmap->find("H", Atom::ATOM);    // Returns atom type for "H"
+   int missing = lmap->find("X", Atom::ATOM);  // Returns -1 (not found)
+
+   // Reverse lookup: Get label from numeric type
+   const std::string &label1 = lmap->find(1, Atom::ATOM);  // Returns label for type 1
+   const std::string &label2 = lmap->find(2, Atom::BOND);  // Returns bond label for type 2
+
+   // Check if all types have labels
+   bool complete = lmap->is_complete(Atom::ATOM);  // Returns true if all atom types labeled
+
+**Example 2: Inferring bond types from atom types**
+
+.. code-block:: c++
+   :caption: Using infer_bondtype() with numeric and label-based lookups
+
+   #include "label_map.h"
+   #include "atom.h"
+
+   LabelMap *lmap = atom->lmap;
+
+   // Assume we have: labelmap atom 1 C 2 H 3 N
+   // And: labelmap bond 1 C-H 2 C-C 3 C-N
+
+   // Infer bond type from numeric atom types
+   int bt1 = lmap->infer_bondtype(1, 2);  // Returns 1 (C-H bond)
+   int bt2 = lmap->infer_bondtype(1, 1);  // Returns 2 (C-C bond)
+   int bt3 = lmap->infer_bondtype(1, 3);  // Returns 3 (C-N bond)
+
+   // Infer bond type from atom type labels (handles symmetry automatically)
+   int bt4 = lmap->infer_bondtype({"C", "H"});  // Returns 1 (C-H)
+   int bt5 = lmap->infer_bondtype({"H", "C"});  // Returns 1 (symmetric match)
+   int bt6 = lmap->infer_bondtype({"C", "N"});  // Returns 3 (C-N)
+
+**Example 3: Inferring angle and dihedral types**
+
+.. code-block:: c++
+   :caption: Using infer_angletype() and infer_dihedraltype()
+
+   #include "label_map.h"
+   #include "atom.h"
+
+   LabelMap *lmap = atom->lmap;
+
+   // Assume: labelmap angle 1 H-C-H 2 C-C-H 3 C-N-C
+   // And: labelmap dihedral 1 H-C-C-H 2 C-C-N-H
+
+   // Infer angle type from numeric atom types
+   int at1 = lmap->infer_angletype(2, 1, 2);  // Returns 1 (H-C-H)
+   int at2 = lmap->infer_angletype(1, 1, 2);  // Returns 2 (C-C-H)
+
+   // Infer angle type from labels (supports bidirectional matching)
+   int at3 = lmap->infer_angletype({"H", "C", "H"});  // Returns 1
+   int at4 = lmap->infer_angletype({"H", "C", "H"});  // Returns 1 (same angle reversed)
+
+   // Infer dihedral type from labels
+   int dt1 = lmap->infer_dihedraltype({"H", "C", "C", "H"});  // Returns 1
+   int dt2 = lmap->infer_dihedraltype({"H", "C", "C", "H"});  // Returns 1 (bidirectional)
+   int dt3 = lmap->infer_dihedraltype({"C", "C", "N", "H"});  // Returns 2
+
+**Example 4: Using utils functions with type labels**
+
+.. code-block:: c++
+   :caption: Validating and expanding type labels with utils functions
+
+   #include "utils.h"
+   #include "lammps.h"
+
+   using namespace LAMMPS_NS;
+
+   LAMMPS *lmp = /* ... */;
+
+   // Validate type label strings
+   int result1 = utils::is_type("C");     // Returns 1 (valid label)
+   int result2 = utils::is_type("123");   // Returns 0 (numeric type)
+   int result3 = utils::is_type("*");     // Returns -1 (invalid - starts with *)
+   int result4 = utils::is_type("C H");   // Returns -1 (invalid - contains whitespace)
+
+   // Convert type label to numeric string
+   char *numstr = utils::expand_type(__FILE__, __LINE__, "C", Atom::ATOM, lmp);
+   if (numstr) {
+       // Use the numeric type string
+       delete[] numstr;  // Must delete after use
+   }
+
+   // Convert type label to integer
+   int type = utils::expand_type_int(__FILE__, __LINE__, "C", Atom::ATOM, lmp, true);
+   // The 'true' argument enables range verification
+
+   // Use bounds_typelabel for ranges with label support
+   int lo, hi;
+   utils::bounds_typelabel(__FILE__, __LINE__, "C:H", 1, 10, lo, hi, lmp, Atom::ATOM);
+   // Expands "C:H" to numeric range, e.g., "1:2" -> lo=1, hi=2
+
+----------
+
+.. doxygenclass:: LAMMPS_NS::LabelMap
+   :project: progguide
+   :members:
+
+----------
+
 Memory pool classes
 -------------------
 

--- a/doc/src/Developer_utils.rst
+++ b/doc/src/Developer_utils.rst
@@ -558,66 +558,37 @@ A file that would be parsed by the reader code fragment looks like this:
 
 ----------
 
-Type label mapping
+Type label support
 ------------------
 
-The :cpp:class:`LabelMap <LAMMPS_NS::LabelMap>` class provides a powerful
-abstraction for mapping between symbolic type labels and numeric type indices
-in LAMMPS simulations. Instead of referring to atom types, bond types, angle
-types, dihedral types, and improper types by numeric indices (1, 2, 3, ...),
-users can assign meaningful string labels (e.g., "C", "H", "N", "C-H", "H-C-H")
-that improve readability and maintainability of input scripts.
+The :cpp:class:`LabelMap <LAMMPS_NS::LabelMap>` class provides a two way
+mapping between symbolic type labels in input and output files and
+numeric types as they are used by LAMMPS internally.  Instead of
+changing the numeric types in files to satisfy the requirements from
+LAMMPS for a given application, the symbolic types can remain and only
+the label map needs to be adjusted.  When following the convention that
+the labels for bonded interactions are created by joining the
+constituent atom types with hyphens, this can significantly improve
+readability, maintainability, and re-usability of inputs and reduces the
+chance of errors.
 
-This feature is particularly useful for:
-
-* Complex molecular systems with many atom types
-* Making input scripts self-documenting
-* Avoiding errors from renumbering types
-* Reusing force field definitions across different systems
-
-Type labels are set using the ``labelmap`` command in LAMMPS input scripts:
-
-.. code-block:: LAMMPS
-
-   # Assign atom type labels
-   labelmap atom 1 C 2 H 3 N 4 O
-
-   # Assign bond type labels (hyphen-delimited format)
-   labelmap bond 1 C-H 2 C-C 3 C-N
-
-   # Assign angle type labels
-   labelmap angle 1 H-C-H 2 C-C-H 3 C-N-C
-
-Interaction types (bonds, angles, dihedrals, impropers) use a **hyphen-delimited
-format** that combines constituent atom type labels. For example, a bond between
-carbon and hydrogen atoms can be labeled "C-H", and an angle formed by
-H-C-H atoms can be labeled "H-C-H".
-
-The LabelMap class supports **bidirectional lookup**:
-
-* Forward lookup: Convert a type label string to its numeric type index
-* Reverse lookup: Convert a numeric type index to its label string
-
-It also provides **automatic type inference** for interactions based on their
-constituent atom types. For instance, given atom type labels, the class can
-infer the corresponding bond, angle, dihedral, or improper type from the
-hyphen-delimited format. This handles symmetric matching automatically (e.g.,
-"C-H" matches "H-C" for bonds).
+The LabelMap class supports lookups from symbolic to numeric and vice
+versa.  It also provides automatic type inference for interactions based
+on their constituent atom types.  For instance, based on the atom type
+labels, the corresponding bond, angle, dihedral, or improper types can
+be inferred.
 
 Integration with utils namespace
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Several utility functions in the ``utils`` namespace work with type labels and
 interact with the LabelMap class:
 
 * :cpp:func:`utils::is_type() <LAMMPS_NS::utils::is_type>` - Validates whether
-  a string is a valid type label. Returns 1 for valid labels, 0 for numeric
-  types, -1 for invalid strings. Type labels cannot start with digits, '*', or
-  '#', and cannot contain whitespace or UTF-8 characters.
+  a string is a valid type label.
 
 * :cpp:func:`utils::expand_type() <LAMMPS_NS::utils::expand_type>` - Converts
-  a type label string to its numeric equivalent using the LabelMap. Returns
-  ``nullptr`` if no label map exists or if the string is not a valid type label.
+  a type label string to its numeric equivalent using the LabelMap.
 
 * :cpp:func:`utils::bounds_typelabel() <LAMMPS_NS::utils::bounds_typelabel>` -
   Extended version of ``utils::bounds()`` that accepts type labels in addition
@@ -654,7 +625,7 @@ Usage examples
    // Check if all types have labels
    bool complete = lmap->is_complete(Atom::ATOM);  // Returns true if all atom types labeled
 
-**Example 2: Inferring bond types from atom types**
+**Example 2: Inferring bonded types from atom types**
 
 .. code-block:: c++
    :caption: Using infer_bondtype() with numeric and label-based lookups
@@ -677,33 +648,7 @@ Usage examples
    int bt5 = lmap->infer_bondtype({"H", "C"});  // Returns 1 (symmetric match)
    int bt6 = lmap->infer_bondtype({"C", "N"});  // Returns 3 (C-N)
 
-**Example 3: Inferring angle and dihedral types**
-
-.. code-block:: c++
-   :caption: Using infer_angletype() and infer_dihedraltype()
-
-   #include "label_map.h"
-   #include "atom.h"
-
-   LabelMap *lmap = atom->lmap;
-
-   // Assume: labelmap angle 1 H-C-H 2 C-C-H 3 C-N-C
-   // And: labelmap dihedral 1 H-C-C-H 2 C-C-N-H
-
-   // Infer angle type from numeric atom types
-   int at1 = lmap->infer_angletype(2, 1, 2);  // Returns 1 (H-C-H)
-   int at2 = lmap->infer_angletype(1, 1, 2);  // Returns 2 (C-C-H)
-
-   // Infer angle type from labels (supports bidirectional matching)
-   int at3 = lmap->infer_angletype({"H", "C", "H"});  // Returns 1
-   int at4 = lmap->infer_angletype({"H", "C", "H"});  // Returns 1 (same angle reversed)
-
-   // Infer dihedral type from labels
-   int dt1 = lmap->infer_dihedraltype({"H", "C", "C", "H"});  // Returns 1
-   int dt2 = lmap->infer_dihedraltype({"H", "C", "C", "H"});  // Returns 1 (bidirectional)
-   int dt3 = lmap->infer_dihedraltype({"C", "C", "N", "H"});  // Returns 2
-
-**Example 4: Using utils functions with type labels**
+**Example 2: Using utils functions with type labels**
 
 .. code-block:: c++
    :caption: Validating and expanding type labels with utils functions
@@ -722,19 +667,19 @@ Usage examples
    int result4 = utils::is_type("C H");   // Returns -1 (invalid - contains whitespace)
 
    // Convert type label to numeric string
-   char *numstr = utils::expand_type(__FILE__, __LINE__, "C", Atom::ATOM, lmp);
+   char *numstr = utils::expand_type(FLERR, "C", Atom::ATOM, lmp);
    if (numstr) {
        // Use the numeric type string
        delete[] numstr;  // Must delete after use
    }
 
    // Convert type label to integer
-   int type = utils::expand_type_int(__FILE__, __LINE__, "C", Atom::ATOM, lmp, true);
+   int type = utils::expand_type_int(FLERR, "C", Atom::ATOM, lmp, true);
    // The 'true' argument enables range verification
 
    // Use bounds_typelabel for ranges with label support
    int lo, hi;
-   utils::bounds_typelabel(__FILE__, __LINE__, "C:H", 1, 10, lo, hi, lmp, Atom::ATOM);
+   utils::bounds_typelabel(FLERR, "C:H", 1, 10, lo, hi, lmp, Atom::ATOM);
    // Expands "C:H" to numeric range, e.g., "1:2" -> lo=1, hi=2
 
 ----------

--- a/doc/src/Howto_viz.rst
+++ b/doc/src/Howto_viz.rst
@@ -34,6 +34,81 @@ rarely needed these days.
 
 ------------------------
 
+Basic workflow for loading LAMMPS trajectories in VMD
+=====================================================
+
+VMD can read native LAMMPS dump files (in text format not binary) and
+several other dump styles.  The native LAMMPS format is preferred since
+it contains simulation box information.  VMD does not support reading
+data files directly, but `the TopoTools plugin
+<https://www.ks.uiuc.edu/Research/vmd/plugins/topotools/>`_ does.  This
+step is usually necessary, since the LAMMPS dump files do not contain
+information about the molecular topology and elements and that
+information can be obtained from the data file.  There also is the
+`pbctools plugin
+<https://www.ks.uiuc.edu/Research/vmd/plugins/pbctools/>`_ that
+"repairing" bonds that are broken because one of its atom passed through
+a periodic boundary.  Because of using the plugins, the following
+commands need to be typed into the VMD console to read a trajectory.
+The following commands are based on the ``peptide`` example to which the
+command ``dump 1 all atom 10 dump.peptide`` (note the use of the group
+"all" to match the number of atoms in the data file. VMD does not
+support cases where the number of atoms change or you are trying to read
+in a subset of a system unless *all* files contain the same subset.
+
+.. code-block:: Tcl
+
+   # load data file including its coordinates
+   topo readlammpsdata data.peptide full
+   # atom style full is the default ^^^^ and can be omitted
+
+   # try to infer missing atom properties from available information
+   topo guessatom lammps data
+
+   # now add one of more dump files
+   mol addfile dump.peptide type lammpstrj waitfor all
+   # we tell VMD which file type ^^^^^^^^^ if the filename does not end in .lammpstrj
+
+   # jump to the first frame with the data file coordinates
+   animate goto 0
+   # if needed  use the following command to try and repair broken bonds
+   # pbc join fragment -now
+
+   # unwrap the entire trajectory to repair all broken bonds
+   # this is faster and more accurate than running `pbc join` for all frames
+   pbc unwrap -all
+   pbc wrap -all -compound fragment -orthorhombic
+   #       remove for triclinic box ^^^^^^^^^^^^^
+
+   # delete the coordinate frame from the data file
+   animate delete beg 0 end 0 top
+   # write out the topology information without coordinates to a PSF file
+   animate write psf peptide.psf top
+   # and the processed trajectory data to a DCD file for future use
+   animate write dcd peptide.dcd top waitfor all
+
+   ###############################################################
+   # the steps up to this line only need to be run once
+   ###############################################################
+   # set visualization defaults
+   display perspective orthographic
+   mol default style Licorice
+   mol default material Diffuse
+   display backgroundgradient on
+
+   # delete molecule and load psf and dcd file
+   mol delete top
+   mol new peptide.psf
+   mol addfile peptide.dcd waitfor all
+   pbc box
+
+To automate this process, you can also save these commands to a file,
+e.g. ``peptide.vmd`` and then load this file from the VMD "File" menu
+with "Load Visualization State..."  or type in the command console
+``play peptide.vmd``.
+
+------------------------
+
 Advanced graphics features in the *dump image* command
 ======================================================
 

--- a/doc/src/Howto_viz.rst
+++ b/doc/src/Howto_viz.rst
@@ -46,15 +46,17 @@ step is usually necessary, since the LAMMPS dump files do not contain
 information about the molecular topology and elements and that
 information can be obtained from the data file.  There also is the
 `pbctools plugin
-<https://www.ks.uiuc.edu/Research/vmd/plugins/pbctools/>`_ that
-"repairing" bonds that are broken because one of its atom passed through
-a periodic boundary.  Because of using the plugins, the following
-commands need to be typed into the VMD console to read a trajectory.
-The following commands are based on the ``peptide`` example to which the
-command ``dump 1 all atom 10 dump.peptide`` (note the use of the group
-"all" to match the number of atoms in the data file. VMD does not
-support cases where the number of atoms change or you are trying to read
-in a subset of a system unless *all* files contain the same subset.
+<https://www.ks.uiuc.edu/Research/vmd/plugins/pbctools/>`_ that can be
+used for "repairing" bonds that are broken because one of its atom
+passed through a periodic boundary.  Because of using the plugins, the
+following commands need to be typed into the VMD console to read a
+trajectory.  The following commands are based on the ``peptide`` example
+to which the command ``dump 1 all atom 10 dump.peptide`` was added.
+Note the use of the group "all" in contrast to the commented out dump
+commands that use the group "peptide".  This is to match the number of
+atoms in the data file.  VMD does not support cases where the number of
+atoms change or you are trying to read in a subset of a system unless
+*all* files contain the same subset.
 
 .. code-block:: Tcl
 

--- a/doc/src/Manual.rst
+++ b/doc/src/Manual.rst
@@ -81,9 +81,9 @@ The manual is organized into three parts:
 
 .. _user_documentation:
 
-************
+**********
 User Guide
-************
+**********
 
 .. toctree::
    :maxdepth: 2
@@ -106,9 +106,9 @@ User Guide
 
 .. _programmer_documentation:
 
-******************
+****************
 Programmer Guide
-******************
+****************
 
 .. toctree::
    :maxdepth: 2

--- a/doc/src/create_atoms.rst
+++ b/doc/src/create_atoms.rst
@@ -80,10 +80,10 @@ Examples
    create_atoms Pt box
 
    labelmap atom 1 C 2 Si
-   create_atoms C region regsphere basis Si C
+   create_atoms C region regsphere basis 1 Si
 
-   create_atoms 3 region regsphere basis 2 3
-   create_atoms 3 region regsphere basis 2 3 ratio 0.5 74637
+   create_atoms 2 region regsphere basis 2 3
+   create_atoms 1 region regsphere basis 2 2 ratio 0.5 74637
    create_atoms 3 single 0 0 5 group newatom
    create_atoms 1 box var v set x xpos set y ypos
    create_atoms 2 random 50 12345 NULL overlap 2.0 maxtry 50
@@ -120,7 +120,8 @@ added to the specified atom *type* (e.g., if *type* = 2 and the file
 specifies atom types 1, 2, and 3, then each created molecule will have
 atom types 3, 4, and 5).
 
-.. note::
+.. admonition:: Atoms outside the box
+   :class: note
 
    You cannot use this command to create atoms that are outside the
    simulation box; they will just be ignored by LAMMPS.  This is true
@@ -378,10 +379,20 @@ This is the meaning of the other optional keywords.
 
 The *basis* keyword is only used when atoms (not molecules) are being
 created.  It specifies an atom type that will be assigned to specific
-basis atoms as they are created.  See the :doc:`lattice <lattice>`
-command for specifics on how basis atoms are defined for the unit cell
-of the lattice.  By default, all created atoms are assigned the
-argument *type* as their atom type.
+basis atoms as they are created that *overrides* the default atom type.
+See the :doc:`lattice <lattice>` command for specifics on how basis
+atoms are defined for the unit cell of the lattice.  By default, all
+created atoms are assigned the argument *type* as their atom type.  To
+illustrate this please see the following 4 example *create_atom* command
+lines that all create the same system:
+
+.. code-block:: LAMMPS
+
+   lattice diamond 4.36
+   create_atoms 1 box basis 1 1 basis 2 2 basis 3 1 basis 4 2 basis 5 1 basis 6 2 basis 7 1 basis 8 2
+   create_atoms 2 box basis 1 1 basis 2 2 basis 3 1 basis 4 2 basis 5 1 basis 6 2 basis 7 1 basis 8 2
+   create_atoms 1 box basis 2 2 basis 4 2 basis 6 2 basis 8 2
+   create_atoms 2 box basis 1 1 basis 3 1 basis 5 1 basis 7 1
 
 The *ratio* and *subset* keywords can be used in conjunction with the
 *box* or *region* styles to limit the total number of particles

--- a/doc/src/fix_bond_react.rst
+++ b/doc/src/fix_bond_react.rst
@@ -396,20 +396,21 @@ Wildcard atoms match to any atom type in the simulation.  Wildcard atoms
 can be used to reduce the number of reaction templates needed to model a
 set of similar reactions.  Wildcard atoms are specified in the Wildcards
 section of the map file.  The atom types of wildcard atoms in the
-simulation are not updated.  Any bond, angle, dihedral, or improper, that
-is defined in the reaction templates and contains a wildcard atom, will be
-updated by inferring its type from its constituent atom types.  To use
-wildcard atoms, a specific :doc:`type label <Howto_type_labels>` format is
-necessary to infer the types of higher-order interactions.  Bond, angle,
-dihedral, and improper type labels must contain their constituent atom
-types delimited by hyphens, e.g., ‘c2-c2-c2-n’ for a dihedral that contains
-three atoms of type 'c2' and one atom of 'n'.  Certain symmetries are
-considered to account for equivalent ways of writing higher-order
-interactions.  Type labels for bonds, angles, and dihedrals are assumed to
-be equivalent to those written in reverse order.  For example, an angle
-with type label 'c1-c2-n' is equivalent to 'n-c2-c1'.  Symmetries for
-impropers are more complex and are described on the doc page for each
-improper style in the 'Symmetry convention' section.
+simulation are not updated.  Any bond, angle, dihedral, or improper,
+that is defined in the reaction templates and contains a wildcard atom,
+will be updated by inferring its type from its constituent atom types.
+To use wildcard atoms, a specific :doc:`type label <Howto_type_labels>`
+format is necessary to infer the types of higher-order interactions.
+Bond, angle, dihedral, and improper type labels must contain their
+constituent atom types delimited by hyphens, e.g., 'c2-c2-c2-n' for a
+dihedral that contains three atoms of type 'c2' and one atom of 'n'.
+Certain symmetries are considered to account for equivalent ways of
+writing higher-order interactions.  Type labels for bonds, angles, and
+dihedrals are assumed to be equivalent to those written in reverse
+order.  For example, an angle with type label 'c1-c2-n' is equivalent to
+'n-c2-c1'.  Symmetries for impropers are more complex and are described
+on the doc page for each improper style in the 'Symmetry convention'
+section.
 
 The post-reacted molecule template contains a sample of the reaction
 site and its surrounding topology after the reaction has occurred. It

--- a/doc/utils/sphinx-config/false_positives.txt
+++ b/doc/utils/sphinx-config/false_positives.txt
@@ -118,6 +118,7 @@ anglegrad
 anglelist
 angleoffset
 angletangrad
+angletype
 angmom
 angmomx
 angmomy
@@ -856,6 +857,7 @@ diffusivity
 dihedral
 dihedrallist
 dihedrals
+dihedraltype
 Dihedrals
 dihydride
 Dij
@@ -2114,6 +2116,7 @@ llammps
 lld
 LLVM
 lm
+lmap
 lmp
 lmpptr
 lmpqst

--- a/examples/GRAPHICS/README
+++ b/examples/GRAPHICS/README
@@ -11,5 +11,10 @@ automatically as they are created.
 Here is a list of the inputs and which graphics features they demonstrate
 
 - in.cubes-and-pyramids:    visualization of body particles, uses progress bar
+                            https://www.youtube.com/shorts/OYn_VVodnIg
+
 - in.breakable:             using autobond, color-by-property, adding objects and text
+                            https://www.youtube.com/watch?v=f4hfPs7aCmI
+
 - in.water-arrows:          box of water molecules, uses many kinds of arrows
+                            https://www.youtube.com/shorts/4Cm5p0SfgNU

--- a/src/BROWNIAN/fix_brownian.cpp
+++ b/src/BROWNIAN/fix_brownian.cpp
@@ -34,10 +34,9 @@ using namespace FixConst;
 FixBrownian::FixBrownian(LAMMPS *lmp, int narg, char **arg) : FixBrownianBase(lmp, narg, arg)
 {
   if (dipole_flag || gamma_t_eigen_flag || gamma_r_eigen_flag || gamma_r_flag || rot_temp_flag ||
-      planar_rot_flag) {
-    error->all(FLERR, "Illegal fix brownian command.");
-  }
-  if (!gamma_t_flag) { error->all(FLERR, "Illegal fix brownian command."); }
+      planar_rot_flag)
+    error->all(FLERR, "Using keyword(s) not compatible with fix {}", style);
+  if (!gamma_t_flag) error->all(FLERR, "Keyword gamma_t is required for fix {}", style);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/BROWNIAN/fix_brownian_asphere.cpp
+++ b/src/BROWNIAN/fix_brownian_asphere.cpp
@@ -37,17 +37,14 @@ using namespace FixConst;
 FixBrownianAsphere::FixBrownianAsphere(LAMMPS *lmp, int narg, char **arg) :
     FixBrownianBase(lmp, narg, arg), avec(nullptr)
 {
-  if (!gamma_t_eigen_flag || !gamma_r_eigen_flag) {
-    error->all(FLERR, "Illegal fix brownian command.");
-  }
-
-  if (gamma_t_flag || gamma_r_flag) error->all(FLERR, "Illegal fix brownian command.");
+  if (gamma_t_flag || gamma_r_flag)
+    error->all(FLERR, "Keywords gamma_t or gamma_r are not compatible with fix {}", style);
+  if (!gamma_t_eigen_flag || !gamma_r_eigen_flag)
+    error->all(FLERR, "Keywords gamma_t_eigen and gamma_r_eigen are required for fix {}", style);
 
   if (dipole_flag && !atom->mu_flag)
-    error->all(FLERR, "Fix brownian/asphere dipole requires atom attribute mu");
-
-  if (!atom->ellipsoid_flag)
-    error->all(FLERR, "Fix brownian/asphere requires atom style ellipsoid");
+    error->all(FLERR, "Fix {} dipole requires atom attribute mu", style);
+  if (!atom->ellipsoid_flag) error->all(FLERR, "Fix {} requires atom style ellipsoid", style);
 
   if (planar_rot_flag && (comm->me == 0)) {
     error->warning(FLERR, "Ignoring first two entries of gamma_r_eigen since rotation is planar.");

--- a/src/BROWNIAN/fix_brownian_base.cpp
+++ b/src/BROWNIAN/fix_brownian_base.cpp
@@ -98,7 +98,7 @@ FixBrownianBase::FixBrownianBase(LAMMPS *lmp, int narg, char **arg) :
       } else {
         gamma_t_tmp[2] = utils::numeric(FLERR, arg[iarg + 3], false, lmp);
       }
-      if ((gamma_t_tmp[0] <= 0.0) || (gamma_t_tmp[1] <= 0.0) || (gamma_t_tmp[2] < -0))
+      if ((gamma_t_tmp[0] <= 0.0) || (gamma_t_tmp[1] <= 0.0) || (gamma_t_tmp[2] <= 0.0))
         error->all(FLERR, iarg, "Fix {} gamma_t_eigen values must be > 0", style);
 
       gamma_t_eigen_flag = 1;

--- a/src/BROWNIAN/fix_brownian_base.cpp
+++ b/src/BROWNIAN/fix_brownian_base.cpp
@@ -48,18 +48,19 @@ FixBrownianBase::FixBrownianBase(LAMMPS *lmp, int narg, char **arg) :
   planar_rot_flag = 0;
   g2 = 0.0;
 
-  if (narg < 5) utils::missing_cmd_args(FLERR, "fix brownian", error);
+  std::string mystyle = fmt::format("fix {}", style);
+  if (narg < 5) utils::missing_cmd_args(FLERR, mystyle, error);
 
   temp = utils::numeric(FLERR, arg[3], false, lmp);
-  if (temp <= 0) error->all(FLERR, "Fix brownian temp must be > 0.0");
+  if (temp <= 0) error->all(FLERR, 3, "Fix {} temp must be > 0.0", style);
 
   seed = utils::inumeric(FLERR, arg[4], false, lmp);
-  if (seed <= 0) error->all(FLERR, "Fix brownian seed must be > 0");
+  if (seed <= 0) error->all(FLERR, 4, "Fix {} seed must be > 0", style);
 
   int iarg = 5;
   while (iarg < narg) {
     if (strcmp(arg[iarg], "rng") == 0) {
-      if (narg < iarg + 1) utils::missing_cmd_args(FLERR, "fix brownian rng", error);
+      if (narg < iarg + 2) utils::missing_cmd_args(FLERR, mystyle + " rng", error);
       if (strcmp(arg[iarg + 1], "uniform") == 0) {
         noise_flag = 1;
       } else if (strcmp(arg[iarg + 1], "gaussian") == 0) {
@@ -68,11 +69,11 @@ FixBrownianBase::FixBrownianBase(LAMMPS *lmp, int narg, char **arg) :
       } else if (strcmp(arg[iarg + 1], "none") == 0) {
         noise_flag = 0;
       } else {
-        error->all(FLERR, "Unknown fix brownian rng keyword {}", arg[iarg + 1]);
+        error->all(FLERR, iarg + 1, "Unknown fix {} rng keyword {}", style, arg[iarg + 1]);
       }
       iarg = iarg + 2;
     } else if (strcmp(arg[iarg], "dipole") == 0) {
-      if (narg < iarg + 3) utils::missing_cmd_args(FLERR, "fix brownian dipole", error);
+      if (narg < iarg + 4) utils::missing_cmd_args(FLERR, mystyle + " dipole", error);
 
       dipole_flag = 1;
       delete[] dipole_body;
@@ -84,27 +85,31 @@ FixBrownianBase::FixBrownianBase(LAMMPS *lmp, int narg, char **arg) :
       iarg = iarg + 4;
 
     } else if (strcmp(arg[iarg], "gamma_t_eigen") == 0) {
-      if (narg < iarg + 3) utils::missing_cmd_args(FLERR, "fix brownian gamma_t_eigen", error);
+      if (narg < iarg + 4) utils::missing_cmd_args(FLERR, mystyle + " gamma_t_eigen", error);
+
+      double gamma_t_tmp[3];
+      gamma_t_tmp[0] = utils::numeric(FLERR, arg[iarg + 1], false, lmp);
+      gamma_t_tmp[1] = utils::numeric(FLERR, arg[iarg + 2], false, lmp);
+      if (domain->dimension == 2) {
+        if (strcmp(arg[iarg + 3], "inf") != 0)
+          error->all(FLERR, iarg + 3, "Fix {} gamma_t_eigen third value must be inf for 2D system",
+                     style);
+        gamma_t_tmp[2] = 1.0;
+      } else {
+        gamma_t_tmp[2] = utils::numeric(FLERR, arg[iarg + 3], false, lmp);
+      }
+      if ((gamma_t_tmp[0] <= 0.0) || (gamma_t_tmp[1] <= 0.0) || (gamma_t_tmp[2] < -0))
+        error->all(FLERR, iarg, "Fix {} gamma_t_eigen values must be > 0", style);
 
       gamma_t_eigen_flag = 1;
       delete[] gamma_t_inv;
       delete[] gamma_t_invsqrt;
       gamma_t_inv = new double[3];
       gamma_t_invsqrt = new double[3];
-      gamma_t_inv[0] = 1. / utils::numeric(FLERR, arg[iarg + 1], false, lmp);
-      gamma_t_inv[1] = 1. / utils::numeric(FLERR, arg[iarg + 2], false, lmp);
-
-      if (domain->dimension == 2) {
-        if (strcmp(arg[iarg + 3], "inf") != 0) {
-          error->all(FLERR, "Fix brownian gamma_t_eigen third value must be inf for 2D system.");
-        }
-        gamma_t_inv[2] = 0;
-      } else {
-        gamma_t_inv[2] = 1.0 / utils::numeric(FLERR, arg[iarg + 3], false, lmp);
-      }
-
-      if (gamma_t_inv[0] < 0 || gamma_t_inv[1] < 0 || gamma_t_inv[2] < 0)
-        error->all(FLERR, "Fix brownian gamma_t_eigen values must be > 0.");
+      gamma_t_inv[0] = 1.0 / gamma_t_tmp[0];
+      gamma_t_inv[1] = 1.0 / gamma_t_tmp[1];
+      gamma_t_inv[2] = 1.0 / gamma_t_tmp[2];
+      if (domain->dimension == 2) gamma_t_inv[2] = 0.0;
 
       gamma_t_invsqrt[0] = sqrt(gamma_t_inv[0]);
       gamma_t_invsqrt[1] = sqrt(gamma_t_inv[1]);
@@ -112,7 +117,27 @@ FixBrownianBase::FixBrownianBase(LAMMPS *lmp, int narg, char **arg) :
       iarg = iarg + 4;
 
     } else if (strcmp(arg[iarg], "gamma_r_eigen") == 0) {
-      if (narg == iarg + 3) error->all(FLERR, "Illegal fix brownian command.");
+      if (narg < iarg + 4) utils::missing_cmd_args(FLERR, mystyle + " gamma_r_eigen", error);
+
+      double gamma_r_tmp[3];
+      if (domain->dimension == 2) {
+        if (strcmp(arg[iarg + 1], "inf") != 0)
+          error->all(FLERR, iarg + 1, "Fix {} gamma_r_eigen first value must be inf for 2D system",
+                     style);
+        gamma_r_tmp[0] = 1.0;
+
+        if (strcmp(arg[iarg + 2], "inf") != 0)
+          error->all(FLERR, iarg + 2, "Fix {} gamma_r_eigen second value must be inf for 2D system",
+                     style);
+        gamma_r_tmp[1] = 1.0;
+      } else {
+        gamma_r_tmp[0] = utils::numeric(FLERR, arg[iarg + 1], false, lmp);
+        gamma_r_tmp[1] = utils::numeric(FLERR, arg[iarg + 2], false, lmp);
+      }
+      gamma_r_tmp[2] = utils::numeric(FLERR, arg[iarg + 3], false, lmp);
+
+      if ((gamma_r_tmp[0] <= 0.0) || (gamma_r_tmp[1] <= 0) || (gamma_r_tmp[2] <= 0))
+        error->all(FLERR, iarg, "Fix {} gamma_r_eigen values must be > 0", style);
 
       gamma_r_eigen_flag = 1;
       delete[] gamma_r_inv;
@@ -120,65 +145,52 @@ FixBrownianBase::FixBrownianBase(LAMMPS *lmp, int narg, char **arg) :
       gamma_r_inv = new double[3];
       gamma_r_invsqrt = new double[3];
 
+      gamma_r_inv[0] = 1.0 / gamma_r_tmp[0];
+      gamma_r_inv[1] = 1.0 / gamma_r_tmp[1];
+      gamma_r_inv[2] = 1.0 / gamma_r_tmp[2];
       if (domain->dimension == 2) {
-        if (strcmp(arg[iarg + 1], "inf") != 0) {
-          error->all(FLERR, "Fix brownian gamma_r_eigen first value must be inf for 2D system.");
-        }
-        gamma_r_inv[0] = 0;
-
-        if (strcmp(arg[iarg + 2], "inf") != 0) {
-          error->all(FLERR, "Fix brownian gamma_r_eigen second value must be inf for 2D system.");
-        }
-        gamma_r_inv[1] = 0;
-      } else {
-
-        gamma_r_inv[0] = 1. / utils::numeric(FLERR, arg[iarg + 1], false, lmp);
-        gamma_r_inv[1] = 1. / utils::numeric(FLERR, arg[iarg + 2], false, lmp);
+        gamma_r_inv[0] = 0.0;
+        gamma_r_inv[1] = 0.0;
       }
-
-      gamma_r_inv[2] = 1. / utils::numeric(FLERR, arg[iarg + 3], false, lmp);
-
-      if (gamma_r_inv[0] < 0 || gamma_r_inv[1] < 0 || gamma_r_inv[2] < 0)
-        error->all(FLERR, "Fix brownian gamma_r_eigen values must be > 0.");
-
       gamma_r_invsqrt[0] = sqrt(gamma_r_inv[0]);
       gamma_r_invsqrt[1] = sqrt(gamma_r_inv[1]);
       gamma_r_invsqrt[2] = sqrt(gamma_r_inv[2]);
       iarg = iarg + 4;
 
     } else if (strcmp(arg[iarg], "gamma_t") == 0) {
-      if (narg == iarg + 1) { error->all(FLERR, "Illegal fix brownian command."); }
+      if (narg < iarg + 2) utils::missing_cmd_args(FLERR, mystyle + " gamma_t", error);
 
       gamma_t_flag = 1;
       gamma_t = utils::numeric(FLERR, arg[iarg + 1], false, lmp);
-      if (gamma_t <= 0) error->all(FLERR, "Fix brownian gamma_t must be > 0.");
+      if (gamma_t <= 0.0) error->all(FLERR, iarg + 1, "Fix {} gamma_t value must be > 0", style);
       iarg = iarg + 2;
 
     } else if (strcmp(arg[iarg], "gamma_r") == 0) {
-      if (narg == iarg + 1) { error->all(FLERR, "Illegal fix brownian command."); }
+      if (narg < iarg + 2) utils::missing_cmd_args(FLERR, mystyle + " gamma_r", error);
 
       gamma_r_flag = 1;
       gamma_r = utils::numeric(FLERR, arg[iarg + 1], false, lmp);
-      if (gamma_r <= 0) error->all(FLERR, "Fix brownian gamma_r must be > 0.");
+      if (gamma_r <= 0) error->all(FLERR, iarg + 1, "Fix {} gamma_r value must be > 0", style);
       iarg = iarg + 2;
 
     } else if (strcmp(arg[iarg], "rotation_temp") == 0) {
-      if (narg == iarg + 1) { error->all(FLERR, "Illegal fix brownian command."); }
+      if (narg < iarg + 2) utils::missing_cmd_args(FLERR, mystyle + " rotation_temp", error);
 
       rot_temp_flag = 1;
       rot_temp = utils::numeric(FLERR, arg[iarg + 1], false, lmp);
-      if (rot_temp <= 0) error->all(FLERR, "Fix brownian rotation_temp must be > 0.");
+      if (rot_temp <= 0)
+        error->all(FLERR, iarg + 1, "Fix {} rotation_temp value must be > 0", style);
       iarg = iarg + 2;
 
     } else if (strcmp(arg[iarg], "planar_rotation") == 0) {
 
       planar_rot_flag = 1;
       if (domain->dimension == 2)
-        error->all(FLERR, "The planar_rotation keyword is not allowed for 2D simulations");
+        error->all(FLERR, iarg, "The planar_rotation keyword is not allowed for 2D simulations");
       iarg = iarg + 1;
 
     } else {
-      error->all(FLERR, "Illegal fix brownian command.");
+      error->all(FLERR, iarg, "Unknown fix {} keyword {}", style, arg[iarg]);
     }
   }
   if (!rot_temp_flag) rot_temp = temp;

--- a/src/BROWNIAN/fix_brownian_sphere.cpp
+++ b/src/BROWNIAN/fix_brownian_sphere.cpp
@@ -35,12 +35,12 @@ using namespace FixConst;
 FixBrownianSphere::FixBrownianSphere(LAMMPS *lmp, int narg, char **arg) :
     FixBrownianBase(lmp, narg, arg)
 {
-  if (gamma_t_eigen_flag || gamma_r_eigen_flag) {
-    error->all(FLERR, "Illegal fix brownian/sphere command.");
-  }
-
-  if (!gamma_t_flag || !gamma_r_flag) error->all(FLERR, "Illegal fix brownian/sphere command.");
-  if (!atom->mu_flag) error->all(FLERR, "Fix brownian/sphere requires atom attribute mu");
+  if (gamma_t_eigen_flag || gamma_r_eigen_flag)
+    error->all(FLERR, "Keywords gamma_t_eigen or gamma_r_eigen are not compatible with fix {}",
+               style);
+  if (!gamma_t_flag || !gamma_r_flag)
+    error->all(FLERR, "Keywords gamma_t and gamma_r are required for fix {}", style);
+  if (!atom->mu_flag) error->all(FLERR, "Fix {} requires atom attribute mu", style);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/GRAPHICS/dump_image.cpp
+++ b/src/GRAPHICS/dump_image.cpp
@@ -101,23 +101,23 @@ DumpImage::DumpImage(LAMMPS *lmp, int narg, char **arg) :
 
   // set filetype based on filename suffix
 
-  if (utils::strmatch(filename, "\\.jpg$") || utils::strmatch(filename, "\\.JPG$")
-      || utils::strmatch(filename, "\\.jpeg$") || utils::strmatch(filename, "\\.JPEG$"))
+  if (utils::strmatch(filename, R"(\.jpg$)") || utils::strmatch(filename, R"(\.JPG$)") ||
+      utils::strmatch(filename, R"(\.jpeg$)") || utils::strmatch(filename, R"(\.JPEG$)"))
     filetype = JPG;
-  else if (utils::strmatch(filename, "\\.png$") || utils::strmatch(filename, "\\.PNG$"))
+  else if (utils::strmatch(filename, R"(\.png$)") || utils::strmatch(filename, R"(\.PNG$)"))
     filetype = PNG;
-  else if (utils::strmatch(filename, "\\.tga$") || utils::strmatch(filename, "\\.TGA$"))
+  else if (utils::strmatch(filename, R"(\.tga$)") || utils::strmatch(filename, R"(\.TGA$)"))
     filetype = TGA;
-  else if (compressed && (utils::strmatch(filename, "\\.jpg\\.\\w+$") ||
-                          utils::strmatch(filename, "\\.JPG\\.\\w+$") ||
-                          utils::strmatch(filename, "\\.jpeg\\.\\w+$") ||
-                          utils::strmatch(filename, "\\.JPEG\\.\\w+$")))
+  else if (compressed && (utils::strmatch(filename, R"(\.jpg\.\w+$)") ||
+                          utils::strmatch(filename, R"(\.JPG\.\w+$)") ||
+                          utils::strmatch(filename, R"(\.jpeg\.\w+$)") ||
+                          utils::strmatch(filename, R"(\.JPEG\.\w+$)")))
     error->all(FLERR, Error::NOLASTLINE, "Cannot use compression with JPEG images");
-  else if (compressed && (utils::strmatch(filename, "\\.png\\.\\w+$") ||
-                           utils::strmatch(filename, "\\.PNG\\.\\w+$")))
+  else if (compressed && (utils::strmatch(filename, R"(\.png\.\w+$)") ||
+                           utils::strmatch(filename, R"(\.PNG\.\w+$)")))
     error->all(FLERR, Error::NOLASTLINE, "Cannot use compression with PNG images");
-  else if (compressed && (utils::strmatch(filename, "\\.tga\\.\\w+$") ||
-                          utils::strmatch(filename, "\\.TGA\\.\\w+$")))
+  else if (compressed && (utils::strmatch(filename, R"(\.tga\.\w+$)") ||
+                          utils::strmatch(filename, R"(\.TGA\.\w+$)")))
     error->all(FLERR, Error::NOLASTLINE, "Cannot use compression with TGA images");
   else filetype = PPM;
 

--- a/src/REPLICA/fix_neb.cpp
+++ b/src/REPLICA/fix_neb.cpp
@@ -764,7 +764,7 @@ void FixNEB::inter_replica_comm()
   if (ireplica > 0) {
     if (me == 0) MPI_Waitall(2, requests, statuses);
 
-    MPI_Bcast(tagrecvall, nebatoms, MPI_INT, 0, world);
+    MPI_Bcast(tagrecvall, nebatoms, MPI_LMP_TAGINT, 0, world);
     MPI_Bcast(xrecvall[0], 3 * nebatoms, MPI_DOUBLE, 0, world);
 
     for (i = 0; i < nebatoms; i++) {
@@ -790,7 +790,7 @@ void FixNEB::inter_replica_comm()
   if (ireplica < nreplica - 1) {
     if (me == 0) MPI_Waitall(2, requests, statuses);
 
-    MPI_Bcast(tagrecvall, nebatoms, MPI_INT, 0, world);
+    MPI_Bcast(tagrecvall, nebatoms, MPI_LMP_TAGINT, 0, world);
     MPI_Bcast(xrecvall[0], 3 * nebatoms, MPI_DOUBLE, 0, world);
     MPI_Bcast(frecvall[0], 3 * nebatoms, MPI_DOUBLE, 0, world);
 

--- a/src/RIGID/fix_shake.cpp
+++ b/src/RIGID/fix_shake.cpp
@@ -109,10 +109,10 @@ FixShake::FixShake(LAMMPS *lmp, int narg, char **arg) :
   bool allow_typelabels = (atom->labelmapflag != 0);
   if (allow_typelabels) {
     for (int i = Atom::ATOM; i < Atom::DIHEDRAL; ++i) {
-      if ((atom->lmap->find("b", i) >= 0) ||
-          (atom->lmap->find("a", i) >= 0) ||
-          (atom->lmap->find("t", i) >= 0) ||
-          (atom->lmap->find("m", i) >= 0)) allow_typelabels = false;
+      if ((atom->lmap->find_type("b", i) >= 0) ||
+          (atom->lmap->find_type("a", i) >= 0) ||
+          (atom->lmap->find_type("t", i) >= 0) ||
+          (atom->lmap->find_type("m", i) >= 0)) allow_typelabels = false;
     }
     if (!allow_typelabels && (comm->me == 0))
       error->warning(FLERR, "At least one typelabel conflicts with a fix shake option: "

--- a/src/SPIN/fix_neb_spin.cpp
+++ b/src/SPIN/fix_neb_spin.cpp
@@ -890,7 +890,7 @@ void FixNEBSpin::inter_replica_comm()
   if (ireplica > 0) {
     if (me == 0) MPI_Waitall(2,requests,statuses);
 
-    MPI_Bcast(tagrecvall,nebatoms,MPI_INT,0,world);
+    MPI_Bcast(tagrecvall,nebatoms,MPI_LMP_TAGINT,0,world);
     MPI_Bcast(xrecvall[0],3*nebatoms,MPI_DOUBLE,0,world);
     MPI_Bcast(sprecvall[0],3*nebatoms,MPI_DOUBLE,0,world);
 
@@ -925,7 +925,7 @@ void FixNEBSpin::inter_replica_comm()
   if (ireplica < nreplica-1) {
     if (me == 0) MPI_Waitall(2,requests,statuses);
 
-    MPI_Bcast(tagrecvall,nebatoms,MPI_INT,0,world);
+    MPI_Bcast(tagrecvall,nebatoms,MPI_LMP_TAGINT,0,world);
     MPI_Bcast(xrecvall[0],3*nebatoms,MPI_DOUBLE,0,world);
     MPI_Bcast(frecvall[0],3*nebatoms,MPI_DOUBLE,0,world);
     MPI_Bcast(sprecvall[0],3*nebatoms,MPI_DOUBLE,0,world);

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -1267,7 +1267,7 @@ void Atom::data_atoms(int n, char *buf, tagint id_offset, tagint mol_offset,
           case 1: {    // type label
             if (!labelmapflag)
               error->one(FLERR, "Invalid line in {}: {}", location, utils::trim(buf));
-            type[nlocal - 1] = lmap->find(typestr, Atom::ATOM);
+            type[nlocal - 1] = lmap->find_type(typestr, Atom::ATOM);
             if (type[nlocal - 1] == -1)
               error->one(FLERR, "Invalid line in {}: {}", location, utils::trim(buf));
             break;
@@ -1374,7 +1374,7 @@ void Atom::data_bonds(int n, char *buf, int *count, tagint id_offset,
         }
         case 1: {    // type label
           if (!atom->labelmapflag) error->all(FLERR, "Invalid {}: {}", location, utils::trim(buf));
-          itype = lmap->find(typestr, Atom::BOND);
+          itype = lmap->find_type(typestr, Atom::BOND);
           if (itype == -1) error->all(FLERR, "Invalid {}: {}", location, utils::trim(buf));
           break;
         }
@@ -1469,7 +1469,7 @@ void Atom::data_angles(int n, char *buf, int *count, tagint id_offset,
         }
         case 1: {    // type label
           if (!atom->labelmapflag) error->all(FLERR, "Invalid {}: {}", location, utils::trim(buf));
-          itype = lmap->find(typestr, Atom::ANGLE);
+          itype = lmap->find_type(typestr, Atom::ANGLE);
           if (itype == -1) error->all(FLERR, "Invalid {}: {}", location, utils::trim(buf));
           break;
         }
@@ -1581,7 +1581,7 @@ void Atom::data_dihedrals(int n, char *buf, int *count, tagint id_offset,
         }
         case 1: {    // type label
           if (!atom->labelmapflag) error->all(FLERR, "Invalid {}: {}", location, utils::trim(buf));
-          itype = lmap->find(typestr, Atom::DIHEDRAL);
+          itype = lmap->find_type(typestr, Atom::DIHEDRAL);
           if (itype == -1) error->all(FLERR, "Invalid {}: {}", location, utils::trim(buf));
           break;
         }
@@ -1709,7 +1709,7 @@ void Atom::data_impropers(int n, char *buf, int *count, tagint id_offset,
         }
         case 1: {    // type label
           if (!atom->labelmapflag) error->all(FLERR, "Invalid {}: {}", location, utils::trim(buf));
-          itype = lmap->find(typestr, Atom::IMPROPER);
+          itype = lmap->find_type(typestr, Atom::IMPROPER);
           if (itype == -1) error->all(FLERR, "Invalid {}: {}", location, utils::trim(buf));
           break;
         }
@@ -1968,7 +1968,7 @@ void Atom::set_mass(const char *file, int line, const char *str, int type_offset
     case 1: {    // type label
       if (!atom->labelmapflag)
         error->all(file, line, "Invalid atom type in {}: {}", location, utils::trim(str));
-      itype = lmap->find(typestr, Atom::ATOM);
+      itype = lmap->find_type(typestr, Atom::ATOM);
       if (itype == -1)
         error->all(file, line, "Unknown atom type {} in {}: {}", typestr, location,
                    utils::trim(str));

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -16,28 +16,26 @@
 
 // common definitions and declarations for graphics support in LAMMPS
 
-namespace LAMMPS_NS {
-namespace Graphics {
-  enum {
-    NONE,
-    SPHERE,    // a single sphere with radius provided
-    LINE,      // a cylinder with diameter given through fflag2
-    TRI,       // a surface mesh as triangles or cylinder mesh based on fflag1, fflag2 sets diameter
-    CYLINDER,    // a cylinder with diameter given by fix, fflag1 choose caps, fflag2 adjusts diameter
-    TRIANGLE,    // a regular triangle, no settings apply
-    BOND,     // two connected cylinders with bond diameter, colored by atom types, fflag1 sets cap
-    ARROW,    // a cylinder with a conical tip and a flat cap at the bottom
-    CONE,     // a truncated cone with flat caps, fflag1 sets caps
-    PIXMAP    // a pointer to a pixmap buffer at x,y,z location
-  };    // used by some Body and Fix child classes
+namespace LAMMPS_NS::Graphics {
+enum {
+  NONE,
+  SPHERE,      // a single sphere with radius provided
+  LINE,        // a cylinder with diameter given through fflag2
+  TRI,         // a surface mesh as triangles or cylinder mesh based on fflag1, fflag2 sets diameter
+  CYLINDER,    // a cylinder with diameter given by fix, fflag1 choose caps, fflag2 adjusts diameter
+  TRIANGLE,    // a regular triangle, no settings apply
+  BOND,        // two connected cylinders with bond diameter, colored by atom types, fflag1 sets cap
+  ARROW,       // a cylinder with a conical tip and a flat cap at the bottom
+  CONE,        // a truncated cone with flat caps, fflag1 sets caps
+  PIXMAP       // a pointer to a pixmap buffer at x,y,z location
+};    // used by some Body and Fix child classes
 
-  // definitions for rendering caps and sides of a truncated cone
-  enum {
-    CONE_TOP = 1 << 0,                            // draw top cap of cone/cylinder
-    CONE_BOT = 1 << 1,                            // draw bottom cap of cone/cylinder
-    CONE_SIDE = 1 << 2,                           // draw side of cone/cylinder
-    CONE_ALL = CONE_TOP | CONE_BOT | CONE_SIDE    // all of the above
-  };
-}    // namespace Graphics
-}    // namespace LAMMPS_NS
+// definitions for rendering caps and sides of a truncated cone
+enum {
+  CONE_TOP = 1 << 0,                            // draw top cap of cone/cylinder
+  CONE_BOT = 1 << 1,                            // draw bottom cap of cone/cylinder
+  CONE_SIDE = 1 << 2,                           // draw side of cone/cylinder
+  CONE_ALL = CONE_TOP | CONE_BOT | CONE_SIDE    // all of the above
+};
+}    // namespace LAMMPS_NS::Graphics
 #endif

--- a/src/label_map.cpp
+++ b/src/label_map.cpp
@@ -385,6 +385,9 @@ bool LabelMap::is_complete(int mode) const
 
 int LabelMap::infer_bondtype(int type1, int type2)
 {
+  // check for out of range input
+  if ((type1 < 1) || (type1 > natomtypes) || (type2 < 1) || (type2 > natomtypes)) return -1;
+
   std::vector<std::string> mytypes(2);
   mytypes[0] = typelabel[type1-1];
   mytypes[1] = typelabel[type2-1];
@@ -421,6 +424,10 @@ int LabelMap::infer_bondtype(const std::vector<std::string> &mytypes)
 
 int LabelMap::infer_angletype(int type1, int type2, int type3)
 {
+  // check for out of range input
+  if ((type1 < 1) || (type1 > natomtypes) || (type2 < 1) || (type2 > natomtypes) || (type3 < 1) ||
+      (type3 > natomtypes))
+    return -1;
   // convert numeric atom types to type label
 
   std::vector<std::string> mytypes(3);
@@ -463,6 +470,10 @@ int LabelMap::infer_angletype(const std::vector<std::string> &mytypes)
 
 int LabelMap::infer_dihedraltype(int type1, int type2, int type3, int type4)
 {
+  // check for out of range input
+  if ((type1 < 1) || (type1 > natomtypes) || (type2 < 1) || (type2 > natomtypes) || (type3 < 1) ||
+      (type3 > natomtypes) || (type4 < 1) || (type4 > natomtypes))
+    return -1;
   // convert numeric atom types to type label
 
   std::vector<std::string> mytypes(4);
@@ -508,6 +519,10 @@ int LabelMap::infer_dihedraltype(const std::vector<std::string> &mytypes)
 
 int LabelMap::infer_impropertype(int type1, int type2, int type3, int type4)
 {
+  // check for out of range input
+  if ((type1 < 1) || (type1 > natomtypes) || (type2 < 1) || (type2 > natomtypes) || (type3 < 1) ||
+      (type3 > natomtypes) || (type4 < 1) || (type4 > natomtypes))
+    return -1;
   // convert numeric atom types to type label
 
   std::vector<std::string> mytypes(4);

--- a/src/label_map.cpp
+++ b/src/label_map.cpp
@@ -584,7 +584,7 @@ int LabelMap::infer_impropertype(const std::vector<std::string> &mytypes)
 int LabelMap::parse_typelabel(int ntypes, const std::string &label, std::vector<std::string> &types)
 {
   auto out = Tokenizer(label,"-").as_vector();
-  if (out.size() != ntypes) return -1;
+  if ((int)out.size() != ntypes) return -1;
   types = std::move(out);
   return 1;
 }

--- a/src/label_map.cpp
+++ b/src/label_map.cpp
@@ -390,7 +390,7 @@ int LabelMap::infer_bondtype(int type1, int type2)
   mytypes[1] = typelabel[type2-1];
   if (mytypes[0].empty() || mytypes[1].empty()) return -1;
 
-  return infer_bondtype(mytypes);
+  return infer_bondtype(std::move(mytypes));
 }
 
 /* ----------------------------------------------------------------------
@@ -430,7 +430,7 @@ int LabelMap::infer_angletype(int type1, int type2, int type3)
   for (size_t i = 0; i < 3; i++)
     if (mytypes[i].empty()) return -1;
 
-  return infer_angletype(mytypes);
+  return infer_angletype(std::move(mytypes));
 }
 
 /* ----------------------------------------------------------------------
@@ -473,7 +473,7 @@ int LabelMap::infer_dihedraltype(int type1, int type2, int type3, int type4)
   for (size_t i = 0; i < 4; i++)
     if (mytypes[i].empty()) return -1;
 
-  return infer_dihedraltype(mytypes);
+  return infer_dihedraltype(std::move(mytypes));
 }
 
 /* ----------------------------------------------------------------------
@@ -518,7 +518,7 @@ int LabelMap::infer_impropertype(int type1, int type2, int type3, int type4)
   for (int i = 0; i < 4; i++)
     if (mytypes[i].empty()) return -1;
 
-  return infer_impropertype(mytypes);
+  return infer_impropertype(std::move(mytypes));
 }
 
 /* ----------------------------------------------------------------------
@@ -580,7 +580,7 @@ int LabelMap::parse_typelabel(int ntypes, std::string label, std::vector<std::st
       start = label.find_first_not_of('-', end);
   }
   if (out.size() != ntypes) return -1;
-  types = out;
+  types = std::move(out);
   return 1;
 }
 

--- a/src/label_map.cpp
+++ b/src/label_map.cpp
@@ -19,6 +19,7 @@
 #include "error.h"
 #include "force.h"
 #include "improper.h"
+#include "tokenizer.h"
 
 #include <algorithm>
 #include <cstring>
@@ -582,14 +583,7 @@ int LabelMap::infer_impropertype(const std::vector<std::string> &mytypes)
 
 int LabelMap::parse_typelabel(int ntypes, const std::string &label, std::vector<std::string> &types)
 {
-  std::vector<std::string> out;
-  size_t start = label.find_first_not_of('-');
-
-  while (start != std::string::npos) {
-    size_t end = label.find('-', start);
-    out.emplace_back(label.substr(start, end - start));
-    start = label.find_first_not_of('-', end);
-  }
+  auto out = Tokenizer(label,"-").as_vector();
   if (out.size() != ntypes) return -1;
   types = std::move(out);
   return 1;

--- a/src/label_map.cpp
+++ b/src/label_map.cpp
@@ -272,7 +272,7 @@ int LabelMap::find_or_create(const std::string &mylabel, std::vector<std::string
    return -1 if type not yet defined
 ------------------------------------------------------------------------- */
 
-int LabelMap::find(const std::string &mylabel, int mode) const
+int LabelMap::find_type(const std::string &mylabel, int mode) const
 {
   switch (mode) {
     case Atom::ATOM:
@@ -300,7 +300,7 @@ int LabelMap::find(const std::string &mylabel, int mode) const
    return "" if type label does not exist
 ------------------------------------------------------------------------- */
 
-const std::string &LabelMap::find(int i, int mode) const
+const std::string &LabelMap::find_label(int i, int mode) const
 {
   switch (mode) {
     case Atom::ATOM:

--- a/src/label_map.cpp
+++ b/src/label_map.cpp
@@ -302,38 +302,33 @@ int LabelMap::find(const std::string &mylabel, int mode) const
 const std::string &LabelMap::find(int i, int mode) const
 {
   switch (mode) {
-  case Atom::ATOM:
-    if ((i > 0) && (i <= atom->ntypes)) {
-      if (is_complete(mode))
-        return typelabel[i-1];
-    }
-    break;
-  case Atom::BOND:
-    if ((i > 0) && (i <= atom->nbondtypes)) {
-      if (is_complete(mode))
-        return btypelabel[i-1];
-    }
-    break;
-  case Atom::ANGLE:
-    if ((i > 0) && (i <= atom->nangletypes)) {
-      if (is_complete(mode))
-        return atypelabel[i-1];
-    }
-    break;
-  case Atom::DIHEDRAL:
-    if ((i > 0) && (i <= atom->ndihedraltypes)) {
-      if (is_complete(mode))
-        return dtypelabel[i-1];
-    }
-    break;
-  case Atom::IMPROPER:
-    if ((i > 0) && (i <= atom->nimpropertypes)) {
-      if (is_complete(mode))
-        return itypelabel[i-1];
-    }
-    break;
-  default:
-    return empty;
+    case Atom::ATOM:
+      if ((i > 0) && (i <= atom->ntypes)) {
+        if (is_complete(mode)) return typelabel[i - 1];
+      }
+      break;
+    case Atom::BOND:
+      if ((i > 0) && (i <= atom->nbondtypes)) {
+        if (is_complete(mode)) return btypelabel[i - 1];
+      }
+      break;
+    case Atom::ANGLE:
+      if ((i > 0) && (i <= atom->nangletypes)) {
+        if (is_complete(mode)) return atypelabel[i - 1];
+      }
+      break;
+    case Atom::DIHEDRAL:
+      if ((i > 0) && (i <= atom->ndihedraltypes)) {
+        if (is_complete(mode)) return dtypelabel[i - 1];
+      }
+      break;
+    case Atom::IMPROPER:
+      if ((i > 0) && (i <= atom->nimpropertypes)) {
+        if (is_complete(mode)) return itypelabel[i - 1];
+      }
+      break;
+    default:
+      return empty;
   }
   return empty;
 }
@@ -388,9 +383,10 @@ int LabelMap::infer_bondtype(int type1, int type2)
   // check for out of range input
   if ((type1 < 1) || (type1 > natomtypes) || (type2 < 1) || (type2 > natomtypes)) return -1;
 
+  // convert numeric atom types to type label
   std::vector<std::string> mytypes(2);
-  mytypes[0] = typelabel[type1-1];
-  mytypes[1] = typelabel[type2-1];
+  mytypes[0] = typelabel[type1 - 1];
+  mytypes[1] = typelabel[type2 - 1];
   if (mytypes[0].empty() || mytypes[1].empty()) return -1;
 
   return infer_bondtype(mytypes);
@@ -404,17 +400,16 @@ int LabelMap::infer_bondtype(int type1, int type2)
 int LabelMap::infer_bondtype(const std::vector<std::string> &mytypes)
 {
   // search for matching bond type label with symmetry considerations
-
   std::vector<std::string> btypes(2);
   for (int i = 0; i < nbondtypes; i++) {
     int status = parse_typelabel(2, btypelabel[i], btypes);
-    if (status != -1)
+    if ((status != -1) && (btypes.size() == 2))
       if ((mytypes[0] == btypes[0] && mytypes[1] == btypes[1]) ||
-          (mytypes[0] == btypes[1] && mytypes[1] == btypes[0])) return i+1;
+          (mytypes[0] == btypes[1] && mytypes[1] == btypes[0]))
+        return i + 1;
   }
   return -1;
 }
-
 
 /* ----------------------------------------------------------------------
    infer angle type from three atom types
@@ -428,12 +423,12 @@ int LabelMap::infer_angletype(int type1, int type2, int type3)
   if ((type1 < 1) || (type1 > natomtypes) || (type2 < 1) || (type2 > natomtypes) || (type3 < 1) ||
       (type3 > natomtypes))
     return -1;
-  // convert numeric atom types to type label
 
+  // convert numeric atom types to type label
   std::vector<std::string> mytypes(3);
-  mytypes[0] = typelabel[type1-1];
-  mytypes[1] = typelabel[type2-1];
-  mytypes[2] = typelabel[type3-1];
+  mytypes[0] = typelabel[type1 - 1];
+  mytypes[1] = typelabel[type2 - 1];
+  mytypes[2] = typelabel[type3 - 1];
   for (size_t i = 0; i < 3; i++)
     if (mytypes[i].empty()) return -1;
 
@@ -456,11 +451,11 @@ int LabelMap::infer_angletype(const std::vector<std::string> &mytypes)
     status = parse_typelabel(3, atypelabel[i], atypes);
     if (status != -1 && mytypes[1] == atypes[1])
       if ((mytypes[0] == atypes[0] && mytypes[2] == atypes[2]) ||
-          (mytypes[0] == atypes[2] && mytypes[2] == atypes[0])) return i+1;
+          (mytypes[0] == atypes[2] && mytypes[2] == atypes[0]))
+        return i + 1;
   }
   return -1;
 }
-
 
 /* ----------------------------------------------------------------------
    infer dihedral type from four atom types
@@ -474,13 +469,13 @@ int LabelMap::infer_dihedraltype(int type1, int type2, int type3, int type4)
   if ((type1 < 1) || (type1 > natomtypes) || (type2 < 1) || (type2 > natomtypes) || (type3 < 1) ||
       (type3 > natomtypes) || (type4 < 1) || (type4 > natomtypes))
     return -1;
-  // convert numeric atom types to type label
 
+  // convert numeric atom types to type label
   std::vector<std::string> mytypes(4);
-  mytypes[0] = typelabel[type1-1];
-  mytypes[1] = typelabel[type2-1];
-  mytypes[2] = typelabel[type3-1];
-  mytypes[3] = typelabel[type4-1];
+  mytypes[0] = typelabel[type1 - 1];
+  mytypes[1] = typelabel[type2 - 1];
+  mytypes[2] = typelabel[type3 - 1];
+  mytypes[3] = typelabel[type4 - 1];
   for (size_t i = 0; i < 4; i++)
     if (mytypes[i].empty()) return -1;
 
@@ -502,10 +497,11 @@ int LabelMap::infer_dihedraltype(const std::vector<std::string> &mytypes)
   for (int i = 0; i < ndihedraltypes; i++) {
     status = parse_typelabel(4, dtypelabel[i], dtypes);
     if (status != -1)
-      if ((mytypes[0] == dtypes[0] && mytypes[1] == dtypes[1] &&
-          mytypes[2] == dtypes[2] && mytypes[3] == dtypes[3]) ||
-          (mytypes[3] == dtypes[0] && mytypes[2] == dtypes[1] &&
-           mytypes[1] == dtypes[2] && mytypes[0] == dtypes[3])) return i+1;
+      if ((mytypes[0] == dtypes[0] && mytypes[1] == dtypes[1] && mytypes[2] == dtypes[2] &&
+           mytypes[3] == dtypes[3]) ||
+          (mytypes[3] == dtypes[0] && mytypes[2] == dtypes[1] && mytypes[1] == dtypes[2] &&
+           mytypes[0] == dtypes[3]))
+        return i + 1;
   }
   return -1;
 }
@@ -523,13 +519,13 @@ int LabelMap::infer_impropertype(int type1, int type2, int type3, int type4)
   if ((type1 < 1) || (type1 > natomtypes) || (type2 < 1) || (type2 > natomtypes) || (type3 < 1) ||
       (type3 > natomtypes) || (type4 < 1) || (type4 > natomtypes))
     return -1;
-  // convert numeric atom types to type label
 
+  // convert numeric atom types to type label
   std::vector<std::string> mytypes(4);
-  mytypes[0] = typelabel[type1-1];
-  mytypes[1] = typelabel[type2-1];
-  mytypes[2] = typelabel[type3-1];
-  mytypes[3] = typelabel[type4-1];
+  mytypes[0] = typelabel[type1 - 1];
+  mytypes[1] = typelabel[type2 - 1];
+  mytypes[2] = typelabel[type3 - 1];
+  mytypes[3] = typelabel[type4 - 1];
   for (int i = 0; i < 4; i++)
     if (mytypes[i].empty()) return -1;
 
@@ -556,7 +552,7 @@ int LabelMap::infer_impropertype(const std::vector<std::string> &mytypes)
     status = parse_typelabel(4, itypelabel[i], itypes);
     if (status != -1) {
       for (int j = 0; j < 4; j++) {
-        if (force->improper->symmatoms[j] == 1) {
+        if (force->improper && (force->improper->symmatoms[j] == 1)) {
           if (mytypes[j] != itypes[j]) {
             status = -1;
             break;
@@ -567,14 +563,14 @@ int LabelMap::infer_impropertype(const std::vector<std::string> &mytypes)
         }
       }
       if (status == -1) continue;
-      std::sort(list1.begin(),list1.end());
-      std::sort(list2.begin(),list2.end());
+      std::sort(list1.begin(), list1.end());
+      std::sort(list2.begin(), list2.end());
       for (int j = 0; j < nlist; j++)
         if (list1[j] != list2[j]) {
           status = -1;
           break;
         }
-      if (status != -1) return i+1;
+      if (status != -1) return i + 1;
     }
   }
   return -1;
@@ -584,15 +580,15 @@ int LabelMap::infer_impropertype(const std::vector<std::string> &mytypes)
    return -1 if number of parsed strings is not equal to ntypes input
 ------------------------------------------------------------------------- */
 
-int LabelMap::parse_typelabel(int ntypes, std::string label, std::vector<std::string> &types)
+int LabelMap::parse_typelabel(int ntypes, const std::string &label, std::vector<std::string> &types)
 {
   std::vector<std::string> out;
   size_t start = label.find_first_not_of('-');
 
   while (start != std::string::npos) {
-      size_t end = label.find('-', start);
-      out.emplace_back(label.substr(start, end - start));
-      start = label.find_first_not_of('-', end);
+    size_t end = label.find('-', start);
+    out.emplace_back(label.substr(start, end - start));
+    start = label.find_first_not_of('-', end);
   }
   if (out.size() != ntypes) return -1;
   types = std::move(out);

--- a/src/label_map.cpp
+++ b/src/label_map.cpp
@@ -390,7 +390,7 @@ int LabelMap::infer_bondtype(int type1, int type2)
   mytypes[1] = typelabel[type2-1];
   if (mytypes[0].empty() || mytypes[1].empty()) return -1;
 
-  return infer_bondtype(std::move(mytypes));
+  return infer_bondtype(mytypes);
 }
 
 /* ----------------------------------------------------------------------
@@ -398,7 +398,7 @@ int LabelMap::infer_bondtype(int type1, int type2)
    assumes bond types are of the form "a-b" for atom types 'a' and 'b'
 ------------------------------------------------------------------------- */
 
-int LabelMap::infer_bondtype(std::vector<std::string> mytypes)
+int LabelMap::infer_bondtype(const std::vector<std::string> &mytypes)
 {
   // search for matching bond type label with symmetry considerations
 
@@ -430,7 +430,7 @@ int LabelMap::infer_angletype(int type1, int type2, int type3)
   for (size_t i = 0; i < 3; i++)
     if (mytypes[i].empty()) return -1;
 
-  return infer_angletype(std::move(mytypes));
+  return infer_angletype(mytypes);
 }
 
 /* ----------------------------------------------------------------------
@@ -439,7 +439,7 @@ int LabelMap::infer_angletype(int type1, int type2, int type3)
    assumes angle types of the form "a-b-c" for atom types 'a', 'b', 'c'
 ------------------------------------------------------------------------- */
 
-int LabelMap::infer_angletype(std::vector<std::string> mytypes)
+int LabelMap::infer_angletype(const std::vector<std::string> &mytypes)
 {
   // search for matching angle type label, with symmetry considerations
 
@@ -473,7 +473,7 @@ int LabelMap::infer_dihedraltype(int type1, int type2, int type3, int type4)
   for (size_t i = 0; i < 4; i++)
     if (mytypes[i].empty()) return -1;
 
-  return infer_dihedraltype(std::move(mytypes));
+  return infer_dihedraltype(mytypes);
 }
 
 /* ----------------------------------------------------------------------
@@ -482,7 +482,7 @@ int LabelMap::infer_dihedraltype(int type1, int type2, int type3, int type4)
    assumes dihedral types of the form "a-b-c-d"
 ------------------------------------------------------------------------- */
 
-int LabelMap::infer_dihedraltype(std::vector<std::string> mytypes)
+int LabelMap::infer_dihedraltype(const std::vector<std::string> &mytypes)
 {
   // search for matching dihedral type label
 
@@ -518,7 +518,7 @@ int LabelMap::infer_impropertype(int type1, int type2, int type3, int type4)
   for (int i = 0; i < 4; i++)
     if (mytypes[i].empty()) return -1;
 
-  return infer_impropertype(std::move(mytypes));
+  return infer_impropertype(mytypes);
 }
 
 /* ----------------------------------------------------------------------
@@ -528,7 +528,7 @@ int LabelMap::infer_impropertype(int type1, int type2, int type3, int type4)
    the symmetry of the improper is encoded in improper.symmatoms
 ------------------------------------------------------------------------- */
 
-int LabelMap::infer_impropertype(std::vector<std::string> mytypes)
+int LabelMap::infer_impropertype(const std::vector<std::string> &mytypes)
 {
   // search for matching improper type label
 

--- a/src/label_map.h
+++ b/src/label_map.h
@@ -23,28 +23,23 @@
 namespace LAMMPS_NS {
 
 /*! \class LabelMap
- *  \brief Manage type labels for atoms and bonded interactions (bonds, angles, dihedrals, impropers)
+ *  \brief Manage type labels for atoms, bonds, angles, dihedrals, and impropers
  *
  * The LabelMap class provides functionality to map between string labels and
  * numeric type indices for atoms, bonds, angles, dihedrals, and impropers in LAMMPS.
  * This enables users to reference types by symbolic names (e.g., "C", "H", "C-H")
  * instead of numeric indices, improving readability and maintainability of input scripts.
  *
- * Type labels for bonded interactions *may* use (but are not required to use) a
+ * Type labels for bonded interactions *may* (but are not required to) use a
  * hyphen-delimited format indicating the types of the constituent atoms.  Examples:
  * - Bond types: "atom1-atom2" (e.g., "C-H", "N-O")
  * - Angle types: "atom1-atom2-atom3" (e.g., "H-C-H", "C-N-C")
  * - Dihedral types: "atom1-atom2-atom3-atom4" (e.g., "C-C-N-H")
  * - Improper types: "atom1-atom2-atom3-atom4" (e.g., "C-N-C-C")
  *
- * The class supports bidirectional lookup (label ↔ type) and can infer bonded
- * interaction types from constituent atom types when using the hyphen-delimited format.
- *
- * Related utilities in the utils namespace:
- * - utils::is_type() - Validate type label strings
- * - utils::expand_type() - Convert type labels to numeric types
- * - utils::bounds_typelabel() - Process type range wildcards with type label support
- */
+ * The class supports bidirectional lookup (label <-> type) and can infer bonded
+ * interaction types from constituent atom types when using a hyphen-delimited
+ * format convention. */
 
 class LabelMap : protected Pointers {
   friend class AtomVec;
@@ -67,12 +62,12 @@ class LabelMap : protected Pointers {
 
   /*! Process labelmap command from input script
    *
-\verbatim embed:rst
+   \verbatim embed:rst
 
 Add or modify type label mappings from the LAMMPS
 :doc:`labelmap <labelmap>` input command.
 
-\endverbatim
+   \endverbatim
    *
    * \param  narg  Number of arguments
    * \param  arg   Array of argument strings */
@@ -80,14 +75,14 @@ Add or modify type label mappings from the LAMMPS
 
   /*! Copy another LabelMap into this one
    *
-\verbatim embed:rst
+   \verbatim embed:rst
 
 Merge type labels from another LabelMap instance into the current one.
 Currently used when combining data from multiple sources with
 :doc:`read_data add <read_data>` or when replicating the system with
 :doc:`replicate <replicate>`.
 
-\endverbatim
+   \endverbatim
    *
    * \param  lmap  Pointer to source LabelMap
    * \param  mode  Merge mode flag */
@@ -134,16 +129,16 @@ Currently used when combining data from multiple sources with
   /*! \name Interaction type inference from hyphen-delimited labels
    *
    * These methods infer bonded interaction types (bonds, angles, dihedrals, impropers)
-   * from constituent atom types using a hyphen-delimited format. They support
-   * bidirectional matching for symmetric interactions.
+   * from constituent atom types using a hyphen-delimited format.  This requires that
+   * type labels for bonded interactions were entered following this convention.
+   * The inference functions consider the symmetry of the interaction and thus atom
+   * types may be swapped accordingly and the bonded type will still be matched.
    * @{ */
 
   /*! Infer bond type from two numeric atom types
    *
    * Look up or create a bond type from two atom type indices by constructing
    * a hyphen-delimited label (e.g., "C-H") and searching the bond type labels.
-   * Since bonded interactions are symmetric, atype1 and atype2 may be swapped
-   * and still match the same bond type.
    *
    * \param  atype1  First atom type index
    * \param  atype2  Second atom type index
@@ -152,8 +147,9 @@ Currently used when combining data from multiple sources with
 
   /*! Infer bond type from atom type labels
    *
-   * Look up a bond type from a vector of two atom type label strings.
-   * Handles symmetric matching (e.g., "C-H" matches "H-C").
+   * \overload
+   *
+   * Look up a bond type from two atom type labels.
    *
    * \param  labels  Vector of two atom type label strings
    * \return         Bond type index, or -1 if not found */
@@ -163,8 +159,6 @@ Currently used when combining data from multiple sources with
    *
    * Look up or create an angle type from three atom type indices by
    * constructing a hyphen-delimited label (e.g., "H1-C1-H2").
-   * The first and the third atom types may be swapped and still
-   * match the same angle type.
    *
    * \param  atype1  First atom type index
    * \param  atype2  Second atom type index (center atom)
@@ -172,10 +166,11 @@ Currently used when combining data from multiple sources with
    * \return         Angle type index, or -1 if not found */
   int infer_angletype(int, int, int);
 
-  /*! Infer angle type from atom type labels
+  /*! Infer angle type from three atom type labels
    *
-   * Look up an angle type from a vector of three atom type label strings.
-   * Handles symmetric matching (e.g., "H1-C-H2" matches "H2-C-H1" in reverse).
+   * \overload
+   *
+   * Look up an angle type from three atom type labels.
    *
    * \param  labels  Vector of three atom type label strings
    * \return         Angle type index, or -1 if not found */
@@ -185,8 +180,6 @@ Currently used when combining data from multiple sources with
    *
    * Look up a dihedral type from four atom type indices by
    * constructing a hyphen-delimited label (e.g., "C-C-N-H").
-   * Atom types may be mirrored (i.e. swap atype1 with atype4
-   * and atype2 with atype3) and still match the same dihedral type.
    *
    * \param  atype1  First atom type index
    * \param  atype2  Second atom type index
@@ -197,8 +190,9 @@ Currently used when combining data from multiple sources with
 
   /*! Infer dihedral type from atom type labels
    *
-   * Look up a dihedral type from a vector of four atom type label strings.
-   * Handles bidirectional matching (forward and reverse sequences).
+   * \overload
+   *
+   * Look up a dihedral type from four atom type labels.
    *
    * \param  labels  Vector of four atom type label strings
    * \return         Dihedral type index, or -1 if not found */
@@ -206,7 +200,7 @@ Currently used when combining data from multiple sources with
 
   /*! Infer improper type from four numeric atom types
    *
-   * Look up or create an improper type from four atom type indices by
+   * Look up an improper type from four atom type indices by
    * constructing a hyphen-delimited label (e.g., "C-N-C-C").
    *
    * \param  atype1  First atom type index (center atom)
@@ -218,7 +212,9 @@ Currently used when combining data from multiple sources with
 
   /*! Infer improper type from atom type labels
    *
-   * Look up an improper type from a vector of four atom type label strings.
+   * \overload
+   *
+   * Look up an improper type from four atom type labels.
    *
    * \param  labels  Vector of four atom type label strings
    * \return         Improper type index, or -1 if not found */

--- a/src/label_map.h
+++ b/src/label_map.h
@@ -11,6 +11,8 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
+/*! \file label_map.h */
+
 #ifndef LMP_LABEL_MAP_H
 #define LMP_LABEL_MAP_H
 
@@ -20,6 +22,29 @@
 
 namespace LAMMPS_NS {
 
+/*! \class LabelMap
+ *  \brief Manage type labels for atoms and interactions (bonds, angles, dihedrals, impropers)
+ *
+ * The LabelMap class provides functionality to map between string labels and
+ * numeric type indices for atoms, bonds, angles, dihedrals, and impropers in LAMMPS.
+ * This enables users to reference types by symbolic names (e.g., "C", "H", "C-H")
+ * instead of numeric indices, improving readability and maintainability of input scripts.
+ *
+ * Type labels use a hyphen-delimited format for interaction types:
+ * - Bond types: "atom1-atom2" (e.g., "C-H", "N-O")
+ * - Angle types: "atom1-atom2-atom3" (e.g., "H-C-H", "C-N-C")
+ * - Dihedral types: "atom1-atom2-atom3-atom4" (e.g., "C-C-N-H")
+ * - Improper types: "atom1-atom2-atom3-atom4" (e.g., "C-N-C-C")
+ *
+ * The class supports bidirectional lookup (label ↔ type) and can infer
+ * interaction types from constituent atom types using the hyphen-delimited format.
+ *
+ * Related utilities in the utils namespace:
+ * - utils::is_type() - Validate type label strings
+ * - utils::expand_type() - Convert type labels to numeric types
+ * - utils::bounds_typelabel() - Process bounds with type label support
+ */
+
 class LabelMap : protected Pointers {
   friend class AtomVec;
   friend class DumpCustom;
@@ -28,76 +53,237 @@ class LabelMap : protected Pointers {
   friend class ReadData;
 
  public:
+  /*! Construct a LabelMap instance
+   *
+   * \param  lmp              Pointer to LAMMPS instance
+   * \param  natomtypes       Number of atom types
+   * \param  nbondtypes       Number of bond types
+   * \param  nangletypes      Number of angle types
+   * \param  ndihedraltypes   Number of dihedral types
+   * \param  nimpropertypes   Number of improper types */
   LabelMap(LAMMPS *lmp, int, int, int, int, int);
   ~LabelMap() override;
 
-  void modify_lmap(int, char **);              // labelmap command in the input script
-  void merge_lmap(LabelMap *, int);            // copy another lmap into this one
-  void create_lmap2lmap(LabelMap *, int);      // index mapping between two lmaps
-  int find(const std::string &, int) const;    // find numeric type of type label
-  const std::string &find(int, int) const;     // find type label for numeric type
-  bool is_complete(int) const;                 // check if all types are assigned
+  /*! Process labelmap command from input script
+   *
+   * Parse and store type label mappings from LAMMPS input commands.
+   * Supported syntax: labelmap <atom|bond|angle|dihedral|improper> <type> <label> ...
+   *
+   * \param  narg  Number of arguments
+   * \param  arg   Array of argument strings */
+  void modify_lmap(int, char **);
 
-  // infer interaction types from standard hyphen-delimited format
+  /*! Copy another LabelMap into this one
+   *
+   * Merge type labels from another LabelMap instance into the current one.
+   * Used when combining data from multiple sources.
+   *
+   * \param  lmap  Pointer to source LabelMap
+   * \param  mode  Merge mode flag */
+  void merge_lmap(LabelMap *, int);
 
-  // infer bond type from two numeric atom types or type labels
+  /*! Create index mapping between two LabelMaps
+   *
+   * Build a mapping structure (lmap2lmap) that translates type indices
+   * from another LabelMap to the current one based on matching labels.
+   *
+   * \param  lmap  Pointer to source LabelMap
+   * \param  mode  Mapping mode flag */
+  void create_lmap2lmap(LabelMap *, int);
+
+  /*! Find numeric type from type label
+   *
+   * Look up the numeric type index corresponding to a type label string.
+   *
+   * \param  mylabel  Type label string to search for
+   * \param  mode     Type category: Atom::ATOM, Atom::BOND, Atom::ANGLE,
+   *                  Atom::DIHEDRAL, or Atom::IMPROPER
+   * \return          Numeric type index (1-based), or -1 if not found */
+  int find(const std::string &, int) const;
+
+  /*! Find type label from numeric type
+   *
+   * Reverse lookup: retrieve the type label string for a given numeric type.
+   *
+   * \param  i     Numeric type index (1-based)
+   * \param  mode  Type category: Atom::ATOM, Atom::BOND, Atom::ANGLE,
+   *               Atom::DIHEDRAL, or Atom::IMPROPER
+   * \return       Reference to type label string, or empty string if not found */
+  const std::string &find(int, int) const;
+
+  /*! Check if all types have assigned labels
+   *
+   * Verify that every type in the specified category has a corresponding label.
+   *
+   * \param  mode  Type category: Atom::ATOM, Atom::BOND, Atom::ANGLE,
+   *               Atom::DIHEDRAL, or Atom::IMPROPER
+   * \return       True if all types have labels, false otherwise */
+  bool is_complete(int) const;
+
+  /*! \name Interaction type inference from hyphen-delimited labels
+   *
+   * These methods infer interaction types (bonds, angles, dihedrals, impropers)
+   * from constituent atom types using hyphen-delimited format. They support
+   * bidirectional matching for symmetric interactions.
+   * @{ */
+
+  /*! Infer bond type from two numeric atom types
+   *
+   * Look up or create a bond type from two atom type indices by constructing
+   * a hyphen-delimited label (e.g., "C-H") and searching the bond type labels.
+   *
+   * \param  atype1  First atom type index
+   * \param  atype2  Second atom type index
+   * \return         Bond type index, or -1 if not found */
   int infer_bondtype(int, int);
+
+  /*! Infer bond type from atom type labels
+   *
+   * Look up a bond type from a vector of two atom type label strings.
+   * Handles symmetric matching (e.g., "C-H" matches "H-C").
+   *
+   * \param  labels  Vector of two atom type label strings
+   * \return         Bond type index, or -1 if not found */
   int infer_bondtype(const std::vector<std::string> &);
 
-  // infer angle type from three numeric atom types or type labels
+  /*! Infer angle type from three numeric atom types
+   *
+   * Look up or create an angle type from three atom type indices by
+   * constructing a hyphen-delimited label (e.g., "H-C-H").
+   *
+   * \param  atype1  First atom type index
+   * \param  atype2  Second atom type index (center atom)
+   * \param  atype3  Third atom type index
+   * \return         Angle type index, or -1 if not found */
   int infer_angletype(int, int, int);
+
+  /*! Infer angle type from atom type labels
+   *
+   * Look up an angle type from a vector of three atom type label strings.
+   * Handles symmetric matching (e.g., "H-C-H" matches "H-C-H" in reverse).
+   *
+   * \param  labels  Vector of three atom type label strings
+   * \return         Angle type index, or -1 if not found */
   int infer_angletype(const std::vector<std::string> &);
 
-  // infer dihedral type from four numeric atom types or type labels
+  /*! Infer dihedral type from four numeric atom types
+   *
+   * Look up or create a dihedral type from four atom type indices by
+   * constructing a hyphen-delimited label (e.g., "C-C-N-H").
+   *
+   * \param  atype1  First atom type index
+   * \param  atype2  Second atom type index
+   * \param  atype3  Third atom type index
+   * \param  atype4  Fourth atom type index
+   * \return         Dihedral type index, or -1 if not found */
   int infer_dihedraltype(int, int, int, int);
+
+  /*! Infer dihedral type from atom type labels
+   *
+   * Look up a dihedral type from a vector of four atom type label strings.
+   * Handles bidirectional matching (forward and reverse sequences).
+   *
+   * \param  labels  Vector of four atom type label strings
+   * \return         Dihedral type index, or -1 if not found */
   int infer_dihedraltype(const std::vector<std::string> &);
 
-  // infer improper type from four numeric atom types or type labels
+  /*! Infer improper type from four numeric atom types
+   *
+   * Look up or create an improper type from four atom type indices by
+   * constructing a hyphen-delimited label (e.g., "C-N-C-C").
+   *
+   * \param  atype1  First atom type index (center atom)
+   * \param  atype2  Second atom type index
+   * \param  atype3  Third atom type index
+   * \param  atype4  Fourth atom type index
+   * \return         Improper type index, or -1 if not found */
   int infer_impropertype(int, int, int, int);
+
+  /*! Infer improper type from atom type labels
+   *
+   * Look up an improper type from a vector of four atom type label strings.
+   *
+   * \param  labels  Vector of four atom type label strings
+   * \return         Improper type index, or -1 if not found */
   int infer_impropertype(const std::vector<std::string> &);
 
-  // get strings within hyphen delimiters
+  /*! @} */
+
+  /*! Parse hyphen-delimited type label into components
+   *
+   * Split a hyphen-delimited label (e.g., "C-N-H") into individual type strings.
+   * Validates that the number of components matches the expected count.
+   *
+   * \param  ntypes  Expected number of components
+   * \param  label   Hyphen-delimited label string
+   * \param  types   Output vector to store component strings
+   * \return         0 on success, -1 if component count doesn't match ntypes */
   int parse_typelabel(int, const std::string &, std::vector<std::string> &);
 
-  // input/output for atom class label map
+  /*! \name I/O methods for label map persistence
+   * @{ */
 
+  /*! Write label map to data file
+   *
+   * Output all type labels to a LAMMPS data file in a format that can
+   * be read back by read_data command.
+   *
+   * \param  fp  File pointer for writing */
   void write_data(FILE *);
+
+  /*! Read label map from restart file
+   *
+   * Restore label map data from a LAMMPS restart file.
+   *
+   * \param  fp  File pointer for reading */
   void read_restart(FILE *fp);
+
+  /*! Write label map to restart file
+   *
+   * Save label map data to a LAMMPS restart file for later restoration.
+   *
+   * \param  fp  File pointer for writing */
   void write_restart(FILE *);
 
+  /*! @} */
+
  protected:
-  int natomtypes, nbondtypes, nangletypes, ndihedraltypes, nimpropertypes;
-  std::vector<std::string> typelabel, btypelabel, atypelabel;
-  std::vector<std::string> dtypelabel, itypelabel;
+  int natomtypes, nbondtypes, nangletypes, ndihedraltypes, nimpropertypes;    //!< Type counts
+  std::vector<std::string> typelabel, btypelabel, atypelabel;    //!< Label storage (atoms, bonds, angles)
+  std::vector<std::string> dtypelabel, itypelabel;               //!< Label storage (dihedrals, impropers)
 
-  std::unordered_map<std::string, int> typelabel_map;
-  std::unordered_map<std::string, int> btypelabel_map;
-  std::unordered_map<std::string, int> atypelabel_map;
-  std::unordered_map<std::string, int> dtypelabel_map;
-  std::unordered_map<std::string, int> itypelabel_map;
+  std::unordered_map<std::string, int> typelabel_map;       //!< Atom label → type mapping
+  std::unordered_map<std::string, int> btypelabel_map;      //!< Bond label → type mapping
+  std::unordered_map<std::string, int> atypelabel_map;      //!< Angle label → type mapping
+  std::unordered_map<std::string, int> dtypelabel_map;      //!< Dihedral label → type mapping
+  std::unordered_map<std::string, int> itypelabel_map;      //!< Improper label → type mapping
 
-  // per-type data struct mapping this label map to another
+  /*! \struct Lmap2Lmap
+   *  \brief Mapping structure between two LabelMaps
+   *
+   * Stores per-type index mappings from another LabelMap to this one,
+   * enabling type translation when merging or comparing different label maps. */
 
   struct Lmap2Lmap {
-    int *atom;
-    int *bond;
-    int *angle;
-    int *dihedral;
-    int *improper;
+    int *atom;        //!< Atom type mapping array
+    int *bond;        //!< Bond type mapping array
+    int *angle;       //!< Angle type mapping array
+    int *dihedral;    //!< Dihedral type mapping array
+    int *improper;    //!< Improper type mapping array
   };
 
-  Lmap2Lmap lmap2lmap;
+  Lmap2Lmap lmap2lmap;    //!< Instance of inter-map translation data
 
-  void reset_type_labels();
+  void reset_type_labels();    //!< Clear all type labels
   int find_or_create(const std::string &, std::vector<std::string> &,
-                     std::unordered_map<std::string, int> &);    // look up type or create new type
+                     std::unordered_map<std::string, int> &);    //!< Look up type or create new type
   int search(const std::string &,
-             const std::unordered_map<std::string, int> &) const;    // look up type index
-  char *read_string(FILE *);
-  void write_string(const std::string &, FILE *);
-  int read_int(FILE *);
+             const std::unordered_map<std::string, int> &) const;    //!< Look up type index
+  char *read_string(FILE *);                      //!< Read string from binary file
+  void write_string(const std::string &, FILE *); //!< Write string to binary file
+  int read_int(FILE *);                           //!< Read integer from binary file
 
-  void write_map(const std::string &);
+  void write_map(const std::string &);    //!< Write label map to file for debugging
 };
 
 }    // namespace LAMMPS_NS

--- a/src/label_map.h
+++ b/src/label_map.h
@@ -110,7 +110,7 @@ Currently used when combining data from multiple sources with
    * \param  mode     Type category: Atom::ATOM, Atom::BOND, Atom::ANGLE,
    *                  Atom::DIHEDRAL, or Atom::IMPROPER
    * \return          Numeric type index (1-based), or -1 if not found */
-  int find(const std::string &, int) const;
+  int find_type(const std::string &, int) const;
 
   /*! Find type label from numeric type
    *
@@ -120,7 +120,7 @@ Currently used when combining data from multiple sources with
    * \param  mode  Type category: Atom::ATOM, Atom::BOND, Atom::ANGLE,
    *               Atom::DIHEDRAL, or Atom::IMPROPER
    * \return       Reference to type label string, or empty string if not found */
-  const std::string &find(int, int) const;
+  const std::string &find_label(int, int) const;
 
   /*! Check if all types have assigned labels
    *

--- a/src/label_map.h
+++ b/src/label_map.h
@@ -23,26 +23,27 @@
 namespace LAMMPS_NS {
 
 /*! \class LabelMap
- *  \brief Manage type labels for atoms and interactions (bonds, angles, dihedrals, impropers)
+ *  \brief Manage type labels for atoms and bonded interactions (bonds, angles, dihedrals, impropers)
  *
  * The LabelMap class provides functionality to map between string labels and
  * numeric type indices for atoms, bonds, angles, dihedrals, and impropers in LAMMPS.
  * This enables users to reference types by symbolic names (e.g., "C", "H", "C-H")
  * instead of numeric indices, improving readability and maintainability of input scripts.
  *
- * Type labels use a hyphen-delimited format for interaction types:
+ * Type labels for bonded interactions *may* use (but are not required to use) a
+ * hyphen-delimited format indicating the types of the constituent atoms.  Examples:
  * - Bond types: "atom1-atom2" (e.g., "C-H", "N-O")
  * - Angle types: "atom1-atom2-atom3" (e.g., "H-C-H", "C-N-C")
  * - Dihedral types: "atom1-atom2-atom3-atom4" (e.g., "C-C-N-H")
  * - Improper types: "atom1-atom2-atom3-atom4" (e.g., "C-N-C-C")
  *
- * The class supports bidirectional lookup (label ↔ type) and can infer
- * interaction types from constituent atom types using the hyphen-delimited format.
+ * The class supports bidirectional lookup (label ↔ type) and can infer bonded
+ * interaction types from constituent atom types when using the hyphen-delimited format.
  *
  * Related utilities in the utils namespace:
  * - utils::is_type() - Validate type label strings
  * - utils::expand_type() - Convert type labels to numeric types
- * - utils::bounds_typelabel() - Process bounds with type label support
+ * - utils::bounds_typelabel() - Process type range wildcards with type label support
  */
 
 class LabelMap : protected Pointers {
@@ -56,18 +57,22 @@ class LabelMap : protected Pointers {
   /*! Construct a LabelMap instance
    *
    * \param  lmp              Pointer to LAMMPS instance
-   * \param  natomtypes       Number of atom types
-   * \param  nbondtypes       Number of bond types
-   * \param  nangletypes      Number of angle types
-   * \param  ndihedraltypes   Number of dihedral types
-   * \param  nimpropertypes   Number of improper types */
+   * \param  natomtypes       Number of atom types in map
+   * \param  nbondtypes       Number of bond types in map
+   * \param  nangletypes      Number of angle types in map
+   * \param  ndihedraltypes   Number of dihedral types in map
+   * \param  nimpropertypes   Number of improper types in map */
   LabelMap(LAMMPS *lmp, int, int, int, int, int);
   ~LabelMap() override;
 
   /*! Process labelmap command from input script
    *
-   * Parse and store type label mappings from LAMMPS input commands.
-   * Supported syntax: labelmap <atom|bond|angle|dihedral|improper> <type> <label> ...
+\verbatim embed:rst
+
+Add or modify type label mappings from the LAMMPS
+:doc:`labelmap <labelmap>` input command.
+
+\endverbatim
    *
    * \param  narg  Number of arguments
    * \param  arg   Array of argument strings */
@@ -75,8 +80,14 @@ class LabelMap : protected Pointers {
 
   /*! Copy another LabelMap into this one
    *
-   * Merge type labels from another LabelMap instance into the current one.
-   * Used when combining data from multiple sources.
+\verbatim embed:rst
+
+Merge type labels from another LabelMap instance into the current one.
+Currently used when combining data from multiple sources with
+:doc:`read_data add <read_data>` or when replicating the system with
+:doc:`replicate <replicate>`.
+
+\endverbatim
    *
    * \param  lmap  Pointer to source LabelMap
    * \param  mode  Merge mode flag */
@@ -122,8 +133,8 @@ class LabelMap : protected Pointers {
 
   /*! \name Interaction type inference from hyphen-delimited labels
    *
-   * These methods infer interaction types (bonds, angles, dihedrals, impropers)
-   * from constituent atom types using hyphen-delimited format. They support
+   * These methods infer bonded interaction types (bonds, angles, dihedrals, impropers)
+   * from constituent atom types using a hyphen-delimited format. They support
    * bidirectional matching for symmetric interactions.
    * @{ */
 
@@ -131,6 +142,8 @@ class LabelMap : protected Pointers {
    *
    * Look up or create a bond type from two atom type indices by constructing
    * a hyphen-delimited label (e.g., "C-H") and searching the bond type labels.
+   * Since bonded interactions are symmetric, atype1 and atype2 may be swapped
+   * and still match the same bond type.
    *
    * \param  atype1  First atom type index
    * \param  atype2  Second atom type index
@@ -149,7 +162,9 @@ class LabelMap : protected Pointers {
   /*! Infer angle type from three numeric atom types
    *
    * Look up or create an angle type from three atom type indices by
-   * constructing a hyphen-delimited label (e.g., "H-C-H").
+   * constructing a hyphen-delimited label (e.g., "H1-C1-H2").
+   * The first and the third atom types may be swapped and still
+   * match the same angle type.
    *
    * \param  atype1  First atom type index
    * \param  atype2  Second atom type index (center atom)
@@ -160,7 +175,7 @@ class LabelMap : protected Pointers {
   /*! Infer angle type from atom type labels
    *
    * Look up an angle type from a vector of three atom type label strings.
-   * Handles symmetric matching (e.g., "H-C-H" matches "H-C-H" in reverse).
+   * Handles symmetric matching (e.g., "H1-C-H2" matches "H2-C-H1" in reverse).
    *
    * \param  labels  Vector of three atom type label strings
    * \return         Angle type index, or -1 if not found */
@@ -168,8 +183,10 @@ class LabelMap : protected Pointers {
 
   /*! Infer dihedral type from four numeric atom types
    *
-   * Look up or create a dihedral type from four atom type indices by
+   * Look up a dihedral type from four atom type indices by
    * constructing a hyphen-delimited label (e.g., "C-C-N-H").
+   * Atom types may be mirrored (i.e. swap atype1 with atype4
+   * and atype2 with atype3) and still match the same dihedral type.
    *
    * \param  atype1  First atom type index
    * \param  atype2  Second atom type index
@@ -225,8 +242,7 @@ class LabelMap : protected Pointers {
 
   /*! Write label map to data file
    *
-   * Output all type labels to a LAMMPS data file in a format that can
-   * be read back by read_data command.
+   * Output all type labels as sections to a LAMMPS data file.
    *
    * \param  fp  File pointer for writing */
   void write_data(FILE *);
@@ -249,14 +265,15 @@ class LabelMap : protected Pointers {
 
  protected:
   int natomtypes, nbondtypes, nangletypes, ndihedraltypes, nimpropertypes;    //!< Type counts
-  std::vector<std::string> typelabel, btypelabel, atypelabel;    //!< Label storage (atoms, bonds, angles)
-  std::vector<std::string> dtypelabel, itypelabel;               //!< Label storage (dihedrals, impropers)
+  std::vector<std::string> typelabel, btypelabel,
+      atypelabel;                                     //!< Label storage (atoms, bonds, angles)
+  std::vector<std::string> dtypelabel, itypelabel;    //!< Label storage (dihedrals, impropers)
 
-  std::unordered_map<std::string, int> typelabel_map;       //!< Atom label → type mapping
-  std::unordered_map<std::string, int> btypelabel_map;      //!< Bond label → type mapping
-  std::unordered_map<std::string, int> atypelabel_map;      //!< Angle label → type mapping
-  std::unordered_map<std::string, int> dtypelabel_map;      //!< Dihedral label → type mapping
-  std::unordered_map<std::string, int> itypelabel_map;      //!< Improper label → type mapping
+  std::unordered_map<std::string, int> typelabel_map;     //!< Atom label → type mapping
+  std::unordered_map<std::string, int> btypelabel_map;    //!< Bond label → type mapping
+  std::unordered_map<std::string, int> atypelabel_map;    //!< Angle label → type mapping
+  std::unordered_map<std::string, int> dtypelabel_map;    //!< Dihedral label → type mapping
+  std::unordered_map<std::string, int> itypelabel_map;    //!< Improper label → type mapping
 
   /*! \struct Lmap2Lmap
    *  \brief Mapping structure between two LabelMaps
@@ -275,13 +292,14 @@ class LabelMap : protected Pointers {
   Lmap2Lmap lmap2lmap;    //!< Instance of inter-map translation data
 
   void reset_type_labels();    //!< Clear all type labels
-  int find_or_create(const std::string &, std::vector<std::string> &,
-                     std::unordered_map<std::string, int> &);    //!< Look up type or create new type
+  int find_or_create(
+      const std::string &, std::vector<std::string> &,
+      std::unordered_map<std::string, int> &);    //!< Look up type or create new type
   int search(const std::string &,
              const std::unordered_map<std::string, int> &) const;    //!< Look up type index
-  char *read_string(FILE *);                      //!< Read string from binary file
-  void write_string(const std::string &, FILE *); //!< Write string to binary file
-  int read_int(FILE *);                           //!< Read integer from binary file
+  char *read_string(FILE *);                         //!< Read string from binary file
+  void write_string(const std::string &, FILE *);    //!< Write string to binary file
+  int read_int(FILE *);                              //!< Read integer from binary file
 
   void write_map(const std::string &);    //!< Write label map to file for debugging
 };

--- a/src/label_map.h
+++ b/src/label_map.h
@@ -40,19 +40,24 @@ class LabelMap : protected Pointers {
 
   // infer interaction types from standard hyphen-delimited format
 
-  int infer_bondtype(int, int);                      // infer bond type from two atom types
-  int infer_bondtype(std::vector<std::string>);      // infer bond type from two atom type labels
+  // infer bond type from two numeric atom types or type labels
+  int infer_bondtype(int, int);
+  int infer_bondtype(const std::vector<std::string> &);
 
-  int infer_angletype(int, int, int);                // infer angle type from three atom types
-  int infer_angletype(std::vector<std::string>);     // infer angle type from three atom type labels
+  // infer angle type from three numeric atom types or type labels
+  int infer_angletype(int, int, int);
+  int infer_angletype(const std::vector<std::string> &);
 
-  int infer_dihedraltype(int, int, int, int);        // infer dihedral type from four atom types
-  int infer_dihedraltype(std::vector<std::string>);  // infer dihedral type from four atom type labels
+  // infer dihedral type from four numeric atom types or type labels
+  int infer_dihedraltype(int, int, int, int);
+  int infer_dihedraltype(const std::vector<std::string> &);
 
-  int infer_impropertype(int, int, int, int);        // infer improper type from four atom types
-  int infer_impropertype(std::vector<std::string>);  // infer improper type from four atom type labels
+  // infer improper type from four numeric atom types or type labels
+  int infer_impropertype(int, int, int, int);
+  int infer_impropertype(const std::vector<std::string> &);
 
-  int parse_typelabel(int, std::string, std::vector<std::string> &); // get strings within hyphen delimiters
+  // get strings within hyphen delimiters
+  int parse_typelabel(int, const std::string &, std::vector<std::string> &);
 
   // input/output for atom class label map
 
@@ -60,7 +65,7 @@ class LabelMap : protected Pointers {
   void read_restart(FILE *fp);
   void write_restart(FILE *);
 
-protected:
+ protected:
   int natomtypes, nbondtypes, nangletypes, ndihedraltypes, nimpropertypes;
   std::vector<std::string> typelabel, btypelabel, atypelabel;
   std::vector<std::string> dtypelabel, itypelabel;

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -671,7 +671,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
           error->all(FLERR, Error::NOLASTLINE,
                      "Molecule template {}: invalid atom type in \"types\" JSON section", id,
                      typestr);
-        type[iatom] = atom->lmap->find(typestr, Atom::ATOM);
+        type[iatom] = atom->lmap->find_type(typestr, Atom::ATOM);
         if (type[iatom] == -1)
           error->all(FLERR, Error::NOLASTLINE,
                      "Molecule template {}: Unknown atom type {} in \"types\" JSON section", id,
@@ -1056,7 +1056,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
               error->all(FLERR, Error::NOLASTLINE,
                          "Molecule template {}: invalid bond type in \"bonds\" JSON section", id,
                          typestr);
-            itype = atom->lmap->find(typestr, Atom::BOND);
+            itype = atom->lmap->find_type(typestr, Atom::BOND);
             if (itype == -1)
               error->all(FLERR, Error::NOLASTLINE,
                          "Molecule template {}: Unknown bond type {} in \"bonds\" JSON section", id,
@@ -1148,7 +1148,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
               error->all(FLERR, Error::NOLASTLINE,
                          "Molecule template {}: invalid angle type in \"angles\" JSON section", id,
                          typestr);
-            itype = atom->lmap->find(typestr, Atom::ANGLE);
+            itype = atom->lmap->find_type(typestr, Atom::ANGLE);
             if (itype == -1)
               error->all(FLERR, Error::NOLASTLINE,
                          "Molecule template {}: Unknown angle type {} in \"angles\" JSON section",
@@ -1259,7 +1259,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
                   FLERR, Error::NOLASTLINE,
                   "Molecule template {}: invalid dihedral type in \"dihedrals\" JSON section", id,
                   typestr);
-            itype = atom->lmap->find(typestr, Atom::DIHEDRAL);
+            itype = atom->lmap->find_type(typestr, Atom::DIHEDRAL);
             if (itype == -1)
               error->all(
                   FLERR, Error::NOLASTLINE,
@@ -1384,7 +1384,7 @@ void Molecule::from_json(const std::string &molid, const json &moldata)
                   FLERR, Error::NOLASTLINE,
                   "Molecule template {}: invalid improper type in \"impropers\" JSON section", id,
                   typestr);
-            itype = atom->lmap->find(typestr, Atom::IMPROPER);
+            itype = atom->lmap->find_type(typestr, Atom::IMPROPER);
             if (itype == -1)
               error->all(
                   FLERR, Error::NOLASTLINE,
@@ -1882,7 +1882,7 @@ json Molecule::to_json() const
     moldata["types"]["format"] = {"atom-id", "type"};
     if (atom->labelmapflag && atom->lmap->is_complete(Atom::ATOM)) {
       for (int i = 0; i < natoms; ++i) {
-        moldata["types"]["data"][i] = {i + 1, atom->lmap->find(type[i], Atom::ATOM)};
+        moldata["types"]["data"][i] = {i + 1, atom->lmap->find_label(type[i], Atom::ATOM)};
       }
     } else {
       for (int i = 0; i < natoms; ++i) moldata["types"]["data"][i] = {i + 1, type[i]};
@@ -1939,7 +1939,7 @@ json Molecule::to_json() const
       for (int j = 0; j < num_bond[i]; j++) {
         if (has_newton_bond || (i + 1 < bond_atom[i][j])) {
           if (has_typelabels) {
-            moldata["bonds"]["data"][idx] = {atom->lmap->find(bond_type[i][j], Atom::BOND), i + 1,
+            moldata["bonds"]["data"][idx] = {atom->lmap->find_label(bond_type[i][j], Atom::BOND), i + 1,
                                              bond_atom[i][j]};
           } else {
             moldata["bonds"]["data"][idx] = {bond_type[i][j], i + 1, bond_atom[i][j]};
@@ -1958,7 +1958,7 @@ json Molecule::to_json() const
       for (int j = 0; j < num_angle[i]; j++) {
         if (has_newton_bond || (i + 1 == angle_atom2[i][j])) {
           if (has_typelabels) {
-            moldata["angles"]["data"][idx] = {atom->lmap->find(angle_type[i][j], Atom::ANGLE),
+            moldata["angles"]["data"][idx] = {atom->lmap->find_label(angle_type[i][j], Atom::ANGLE),
                                               angle_atom1[i][j], angle_atom2[i][j],
                                               angle_atom3[i][j]};
           } else {
@@ -1980,7 +1980,7 @@ json Molecule::to_json() const
         if (has_newton_bond || (i + 1 == dihedral_atom2[i][j])) {
           if (has_typelabels) {
             moldata["dihedrals"]["data"][idx] = {
-                atom->lmap->find(dihedral_type[i][j], Atom::DIHEDRAL), dihedral_atom1[i][j],
+                atom->lmap->find_label(dihedral_type[i][j], Atom::DIHEDRAL), dihedral_atom1[i][j],
                 dihedral_atom2[i][j], dihedral_atom3[i][j], dihedral_atom4[i][j]};
           } else {
             moldata["dihedrals"]["data"][idx] = {dihedral_type[i][j], dihedral_atom1[i][j],
@@ -2002,7 +2002,7 @@ json Molecule::to_json() const
         if (has_newton_bond || (i + 1 == improper_atom2[i][j])) {
           if (has_typelabels) {
             moldata["impropers"]["data"][idx] = {
-                atom->lmap->find(improper_type[i][j], Atom::IMPROPER), improper_atom1[i][j],
+                atom->lmap->find_label(improper_type[i][j], Atom::IMPROPER), improper_atom1[i][j],
                 improper_atom2[i][j], improper_atom3[i][j], improper_atom4[i][j]};
           } else {
             moldata["impropers"]["data"][idx] = {improper_type[i][j], improper_atom1[i][j],
@@ -2043,9 +2043,9 @@ json Molecule::to_json() const
                                                      shake_atom[i][2]};
           if (has_typelabels) {
             moldata["shake"]["types"]["data"][i][1] = {
-                atom->lmap->find(shake_type[i][0], Atom::BOND),
-                atom->lmap->find(shake_type[i][1], Atom::BOND),
-                atom->lmap->find(shake_type[i][2], Atom::ANGLE)};
+                atom->lmap->find_label(shake_type[i][0], Atom::BOND),
+                atom->lmap->find_label(shake_type[i][1], Atom::BOND),
+                atom->lmap->find_label(shake_type[i][2], Atom::ANGLE)};
           } else {
             moldata["shake"]["types"]["data"][i][1] = {shake_type[i][0], shake_type[i][1],
                                                        shake_type[i][2]};
@@ -2055,8 +2055,8 @@ json Molecule::to_json() const
           moldata["shake"]["atoms"]["data"][i][1] = {shake_atom[i][0], shake_atom[i][1]};
           if (has_typelabels) {
             moldata["shake"]["types"]["data"][i][1] = {
-                atom->lmap->find(shake_type[i][0], Atom::BOND),
-                atom->lmap->find(shake_type[i][1], Atom::BOND)};
+                atom->lmap->find_label(shake_type[i][0], Atom::BOND),
+                atom->lmap->find_label(shake_type[i][1], Atom::BOND)};
           } else {
             moldata["shake"]["types"]["data"][i][1] = {shake_type[i][0], shake_type[i][1]};
           }
@@ -2066,9 +2066,9 @@ json Molecule::to_json() const
                                                      shake_atom[i][2]};
           if (has_typelabels) {
             moldata["shake"]["types"]["data"][i][1] = {
-                atom->lmap->find(shake_type[i][0], Atom::BOND),
-                atom->lmap->find(shake_type[i][1], Atom::BOND),
-                atom->lmap->find(shake_type[i][2], Atom::BOND)};
+                atom->lmap->find_label(shake_type[i][0], Atom::BOND),
+                atom->lmap->find_label(shake_type[i][1], Atom::BOND),
+                atom->lmap->find_label(shake_type[i][2], Atom::BOND)};
           } else {
             moldata["shake"]["types"]["data"][i][1] = {shake_type[i][0], shake_type[i][1],
                                                        shake_type[i][2]};
@@ -2079,10 +2079,10 @@ json Molecule::to_json() const
                                                      shake_atom[i][2], shake_atom[i][3]};
           if (has_typelabels) {
             moldata["shake"]["types"]["data"][i][1] = {
-                atom->lmap->find(shake_type[i][0], Atom::BOND),
-                atom->lmap->find(shake_type[i][1], Atom::BOND),
-                atom->lmap->find(shake_type[i][2], Atom::BOND),
-                atom->lmap->find(shake_type[i][3], Atom::BOND)};
+                atom->lmap->find_label(shake_type[i][0], Atom::BOND),
+                atom->lmap->find_label(shake_type[i][1], Atom::BOND),
+                atom->lmap->find_label(shake_type[i][2], Atom::BOND),
+                atom->lmap->find_label(shake_type[i][3], Atom::BOND)};
           } else {
             moldata["shake"]["types"]["data"][i][1] = {shake_type[i][0], shake_type[i][1],
                                                        shake_type[i][2], shake_type[i][3]};
@@ -2772,7 +2772,7 @@ void Molecule::types(char *line)
         if (!atom->labelmapflag)
           error->all(FLERR, fileiarg, "Invalid atom type {} in {}: {}", typestr, location,
                      utils::trim(line));
-        type[iatom] = atom->lmap->find(typestr, Atom::ATOM);
+        type[iatom] = atom->lmap->find_type(typestr, Atom::ATOM);
         if (type[iatom] == -1)
           error->all(FLERR, fileiarg, "Unknown atom type {} in {}: {}", typestr, location,
                      utils::trim(line));
@@ -3050,7 +3050,7 @@ void Molecule::bonds(int flag, char *line)
       case 1: {    // type label
         if (!atom->labelmapflag)
           error->all(FLERR, fileiarg, "Invalid bond type {} in {}: {}", typestr, location, utils::trim(line));
-        itype = atom->lmap->find(typestr, Atom::BOND);
+        itype = atom->lmap->find_type(typestr, Atom::BOND);
         if (itype == -1)
           error->all(FLERR, fileiarg, "Unknown bond type {} in {}: {}", typestr, location, utils::trim(line));
         break;
@@ -3136,7 +3136,7 @@ void Molecule::angles(int flag, char *line)
       case 1: {    // type label
         if (!atom->labelmapflag)
           error->all(FLERR, fileiarg, "Invalid angle type {} in {}: {}", typestr, location, utils::trim(line));
-        itype = atom->lmap->find(typestr, Atom::ANGLE);
+        itype = atom->lmap->find_type(typestr, Atom::ANGLE);
         if (itype == -1)
           error->all(FLERR, fileiarg, "Unknown angle type {} in {}: {}", typestr, location, utils::trim(line));
         break;
@@ -3237,7 +3237,7 @@ void Molecule::dihedrals(int flag, char *line)
       case 1: {    // type label
         if (!atom->labelmapflag)
           error->all(FLERR, fileiarg, "Invalid dihedral type {} in {}: {}", typestr, location, utils::trim(line));
-        itype = atom->lmap->find(typestr, Atom::DIHEDRAL);
+        itype = atom->lmap->find_type(typestr, Atom::DIHEDRAL);
         if (itype == -1)
           error->all(FLERR, fileiarg, "Unknown dihedral type {} in {}: {}", typestr, location, utils::trim(line));
         break;
@@ -3352,7 +3352,7 @@ void Molecule::impropers(int flag, char *line)
       case 1: {    // type label
         if (!atom->labelmapflag)
           error->all(FLERR, fileiarg, "Invalid improper type {} in {}: {}", typestr, location, utils::trim(line));
-        itype = atom->lmap->find(typestr, Atom::IMPROPER);
+        itype = atom->lmap->find_type(typestr, Atom::IMPROPER);
         if (itype == -1)
           error->all(FLERR, fileiarg, "Unknown improper type {} in {}: {}", typestr, location, utils::trim(line));
         break;
@@ -4274,7 +4274,7 @@ void Molecule::print(FILE *fp)
     fputs("\nTypes\n\n", fp);
     if (atom->labelmapflag && atom->lmap->is_complete(Atom::ATOM)) {
       for (int i = 0; i < natoms; i++)
-        utils::print(fp, " {} {}\n", i + 1, atom->lmap->find(type[i], Atom::ATOM));
+        utils::print(fp, " {} {}\n", i + 1, atom->lmap->find_label(type[i], Atom::ATOM));
     } else {
       for (int i = 0; i < natoms; i++) utils::print(fp, " {}  {}\n", i + 1, type[i]);
     }
@@ -4329,7 +4329,7 @@ void Molecule::print(FILE *fp)
         if (has_newton_bond || (i + 1 < bond_atom[i][j])) {
           ++idx;
           if (has_typelabels) {
-            utils::print(fp, " {}  {}", idx, atom->lmap->find(bond_type[i][j], Atom::BOND));
+            utils::print(fp, " {}  {}", idx, atom->lmap->find_label(bond_type[i][j], Atom::BOND));
           } else {
             utils::print(fp, " {}  {}", idx, bond_type[i][j]);
           }
@@ -4348,7 +4348,7 @@ void Molecule::print(FILE *fp)
         if (has_newton_bond || (i + 1 == angle_atom2[i][j])) {
           ++idx;
           if (has_typelabels) {
-            utils::print(fp, " {}  {}", idx, atom->lmap->find(angle_type[i][j], Atom::ANGLE));
+            utils::print(fp, " {}  {}", idx, atom->lmap->find_label(angle_type[i][j], Atom::ANGLE));
           } else {
             utils::print(fp, " {}  {}", idx, angle_type[i][j]);
           }
@@ -4367,7 +4367,7 @@ void Molecule::print(FILE *fp)
         if (has_newton_bond || (i + 1 == dihedral_atom2[i][j])) {
           ++idx;
           if (has_typelabels) {
-            utils::print(fp, " {}  {}", idx, atom->lmap->find(dihedral_type[i][j], Atom::DIHEDRAL));
+            utils::print(fp, " {}  {}", idx, atom->lmap->find_label(dihedral_type[i][j], Atom::DIHEDRAL));
           } else {
             utils::print(fp, " {}  {}", idx, dihedral_type[i][j]);
           }
@@ -4387,7 +4387,7 @@ void Molecule::print(FILE *fp)
         if (has_newton_bond || (i + 1 == improper_atom2[i][j])) {
           ++idx;
           if (has_typelabels) {
-            utils::print(fp, " {}  {}", idx, atom->lmap->find(improper_type[i][j], Atom::IMPROPER));
+            utils::print(fp, " {}  {}", idx, atom->lmap->find_label(improper_type[i][j], Atom::IMPROPER));
           } else {
             utils::print(fp, " {}  {}", idx, improper_type[i][j]);
           }
@@ -4452,9 +4452,9 @@ void Molecule::print(FILE *fp)
         case 1:
           has_typelabels = has_typelabels && atom->lmap->is_complete(Atom::ANGLE);
           if (has_typelabels) {
-            utils::print(fp, " {} {} {}\n", atom->lmap->find(shake_type[i][0], Atom::BOND),
-                         atom->lmap->find(shake_type[i][1], Atom::BOND),
-                         atom->lmap->find(shake_type[i][2], Atom::ANGLE));
+            utils::print(fp, " {} {} {}\n", atom->lmap->find_label(shake_type[i][0], Atom::BOND),
+                         atom->lmap->find_label(shake_type[i][1], Atom::BOND),
+                         atom->lmap->find_label(shake_type[i][2], Atom::ANGLE));
           } else {
             utils::print(fp, " {} {} {}\n", shake_type[i][0], shake_type[i][1], shake_type[i][2]);
           }
@@ -4462,8 +4462,8 @@ void Molecule::print(FILE *fp)
 
         case 2:
           if (has_typelabels) {
-            utils::print(fp, " {} {}\n", atom->lmap->find(shake_type[i][0], Atom::BOND),
-                         atom->lmap->find(shake_type[i][1], Atom::BOND));
+            utils::print(fp, " {} {}\n", atom->lmap->find_label(shake_type[i][0], Atom::BOND),
+                         atom->lmap->find_label(shake_type[i][1], Atom::BOND));
           } else {
             utils::print(fp, " {} {}\n", shake_type[i][0], shake_type[i][1]);
           }
@@ -4471,9 +4471,9 @@ void Molecule::print(FILE *fp)
 
         case 3:
           if (has_typelabels) {
-            utils::print(fp, " {} {} {}\n", atom->lmap->find(shake_type[i][0], Atom::BOND),
-                         atom->lmap->find(shake_type[i][1], Atom::BOND),
-                         atom->lmap->find(shake_type[i][2], Atom::BOND));
+            utils::print(fp, " {} {} {}\n", atom->lmap->find_label(shake_type[i][0], Atom::BOND),
+                         atom->lmap->find_label(shake_type[i][1], Atom::BOND),
+                         atom->lmap->find_label(shake_type[i][2], Atom::BOND));
           } else {
             utils::print(fp, " {} {} {}\n", shake_type[i][0], shake_type[i][1], shake_type[i][2]);
           }
@@ -4481,10 +4481,10 @@ void Molecule::print(FILE *fp)
 
         case 4:
           if (has_typelabels) {
-            utils::print(fp, " {} {} {} {}\n", atom->lmap->find(shake_type[i][0], Atom::BOND),
-                         atom->lmap->find(shake_type[i][1], Atom::BOND),
-                         atom->lmap->find(shake_type[i][2], Atom::BOND),
-                         atom->lmap->find(shake_type[i][3], Atom::BOND));
+            utils::print(fp, " {} {} {} {}\n", atom->lmap->find_label(shake_type[i][0], Atom::BOND),
+                         atom->lmap->find_label(shake_type[i][1], Atom::BOND),
+                         atom->lmap->find_label(shake_type[i][2], Atom::BOND),
+                         atom->lmap->find_label(shake_type[i][3], Atom::BOND));
           } else {
             utils::print(fp, " {} {} {} {}\n", shake_type[i][0], shake_type[i][1], shake_type[i][2],
                          shake_type[i][3]);

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -745,7 +745,7 @@ void Output::write_molecule_json(FILE *fp, int json_level, int printflag, int *i
         for (auto myatom : atoms_root) {
           int mytype = myatom.type;
           std::string typestr = std::to_string(mytype);
-          if (atom->labelmapflag) typestr = atom->lmap->find(mytype, Atom::ATOM);
+          if (atom->labelmapflag) typestr = atom->lmap->find_label(mytype, Atom::ATOM);
           utils::print(fp, "{}[{}, \"{}\"]", indent, myatom.tag, typestr);
           if (std::next(it) == atoms_root.end()) fprintf(fp, "\n");
           else fprintf(fp, ",\n");

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1150,7 +1150,7 @@ char *utils::expand_type(const char *file, int line, const std::string &str, int
       lmp->error->all(file, line, "{} type string {} cannot be used without a labelmap",
                       labeltypes[mode], typestr);
 
-    int type = lmp->atom->lmap->find(typestr, mode);
+    int type = lmp->atom->lmap->find_type(typestr, mode);
     if (type == -1)
       lmp->error->all(file, line, "{} type string {} not found in labelmap", labeltypes[mode],
                       typestr);

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -4543,15 +4543,15 @@ int Variable::special_function(const std::string &word, char *contents, Tree **t
 
     int value = -1;
     if (kind == "atom") {
-      value = atom->lmap->find(typestr,Atom::ATOM);
+      value = atom->lmap->find_type(typestr,Atom::ATOM);
     } else if (kind == "bond") {
-      value = atom->lmap->find(typestr,Atom::BOND);
+      value = atom->lmap->find_type(typestr,Atom::BOND);
     } else if (kind == "angle") {
-      value = atom->lmap->find(typestr,Atom::ANGLE);
+      value = atom->lmap->find_type(typestr,Atom::ANGLE);
     } else if (kind == "dihedral") {
-      value = atom->lmap->find(typestr,Atom::DIHEDRAL);
+      value = atom->lmap->find_type(typestr,Atom::DIHEDRAL);
     } else if (kind == "improper") {
-      value = atom->lmap->find(typestr,Atom::IMPROPER);
+      value = atom->lmap->find_type(typestr,Atom::IMPROPER);
     } else {
       print_var_error(FLERR, fmt::format("Invalid kind {} in {}() in variable", kind, word),ivar);
     }

--- a/unittest/commands/test_labelmap.cpp
+++ b/unittest/commands/test_labelmap.cpp
@@ -291,6 +291,57 @@ TEST_F(LabelMapTest, Topology)
                  utils::expand_type(FLERR, "XX", Atom::DIHEDRAL, lmp););
     TEST_FAILURE(".*ERROR: Improper type string XX not found in labelmap.*",
                  utils::expand_type(FLERR, "XX", Atom::IMPROPER, lmp););
+
+    // check for inference
+
+    BEGIN_HIDE_OUTPUT();
+    command(R"(labelmap atom 2 "N2")");
+    command(R"(labelmap bond 2 "C1-C1")");
+    command(R"(labelmap bond 3 "N2-N2")");
+    command(R"(labelmap angle 2 "N2-C1-N2")");
+    END_HIDE_OUTPUT();
+
+    EXPECT_EQ(atom->lmap->infer_bondtype(1, 1), 2);
+    EXPECT_EQ(atom->lmap->infer_bondtype(1, 2), 1);
+    EXPECT_EQ(atom->lmap->infer_bondtype(2, 2), 3);
+    EXPECT_EQ(atom->lmap->infer_bondtype(2, 3), -1);
+    EXPECT_EQ(atom->lmap->infer_bondtype({"N2", "N2"}), 3);
+    EXPECT_EQ(atom->lmap->infer_bondtype({"C1", "N2"}), 1);
+    EXPECT_EQ(atom->lmap->infer_bondtype({"C1", "C1"}), 2);
+    EXPECT_EQ(atom->lmap->infer_bondtype({"N2", "C1"}), 1);
+    EXPECT_EQ(atom->lmap->infer_bondtype({"N3", "C1"}), -1);
+    EXPECT_EQ(atom->lmap->infer_angletype(1, 2, 1), 1);
+    EXPECT_EQ(atom->lmap->infer_angletype(2, 1, 2), 2);
+    EXPECT_EQ(atom->lmap->infer_angletype(1, 1, 1), -1);
+    EXPECT_EQ(atom->lmap->infer_angletype(3, 1, 1), -1);
+    EXPECT_EQ(atom->lmap->infer_angletype(1, 3, 1), -1);
+    EXPECT_EQ(atom->lmap->infer_angletype(1, 1, 3), -1);
+    EXPECT_EQ(atom->lmap->infer_angletype({"C1", "N2", "C1"}), 1);
+    EXPECT_EQ(atom->lmap->infer_angletype({"N2", "C1", "N2"}), 2);
+    EXPECT_EQ(atom->lmap->infer_angletype({"C1", "N2", "N2"}), -1);
+    EXPECT_EQ(atom->lmap->infer_angletype({"C1", "N3", "C1"}), -1);
+    EXPECT_EQ(atom->lmap->infer_dihedraltype(1, 2, 1, 2), 1);
+    EXPECT_EQ(atom->lmap->infer_dihedraltype(2, 1, 2, 2), -1);
+    EXPECT_EQ(atom->lmap->infer_dihedraltype(2, 1, 2, 1), 1);
+    EXPECT_EQ(atom->lmap->infer_dihedraltype(3, 1, 2, 1), -1);
+    EXPECT_EQ(atom->lmap->infer_dihedraltype(2, 3, 2, 1), -1);
+    EXPECT_EQ(atom->lmap->infer_dihedraltype(2, 1, 3, 1), -1);
+    EXPECT_EQ(atom->lmap->infer_dihedraltype(2, 1, 2, 3), -1);
+    EXPECT_EQ(atom->lmap->infer_dihedraltype({"C1", "N2", "C1", "N2"}), 1);
+    EXPECT_EQ(atom->lmap->infer_dihedraltype({"N2", "C1", "N2", "C1"}), 1);
+    EXPECT_EQ(atom->lmap->infer_dihedraltype({"C1", "N2", "N2", "C1"}), -1);
+    EXPECT_EQ(atom->lmap->infer_dihedraltype({"N3", "C1", "N2", "C1"}), -1);
+    EXPECT_EQ(atom->lmap->infer_impropertype(1, 2, 1, 2), 1);
+    EXPECT_EQ(atom->lmap->infer_impropertype(2, 1, 2, 2), -1);
+    EXPECT_EQ(atom->lmap->infer_impropertype(2, 1, 2, 1), 1);
+    EXPECT_EQ(atom->lmap->infer_impropertype(3, 1, 2, 1), -1);
+    EXPECT_EQ(atom->lmap->infer_impropertype(2, 3, 2, 1), -1);
+    EXPECT_EQ(atom->lmap->infer_impropertype(2, 1, 3, 1), -1);
+    EXPECT_EQ(atom->lmap->infer_impropertype(2, 1, 2, 3), -1);
+    EXPECT_EQ(atom->lmap->infer_impropertype({"C1", "N2", "C1", "N2"}), 1);
+    EXPECT_EQ(atom->lmap->infer_impropertype({"N2", "C1", "N2", "C1"}), 1);
+    EXPECT_EQ(atom->lmap->infer_impropertype({"C1", "N2", "N2", "C1"}), 1);
+    EXPECT_EQ(atom->lmap->infer_impropertype({"N3", "C1", "N2", "C1"}), -1);
 }
 } // namespace LAMMPS_NS
 

--- a/unittest/commands/test_labelmap.cpp
+++ b/unittest/commands/test_labelmap.cpp
@@ -92,11 +92,11 @@ TEST_F(LabelMapTest, Atoms)
     command("mass \"O#\" 10.0");
     END_HIDE_OUTPUT();
     EXPECT_TRUE(atom->lmap->is_complete(Atom::ATOM));
-    EXPECT_EQ(atom->lmap->find("C1", Atom::ATOM), 1);
-    EXPECT_EQ(atom->lmap->find("N2", Atom::ATOM), 2);
-    EXPECT_EQ(atom->lmap->find("O#", Atom::ATOM), 3);
-    EXPECT_EQ(atom->lmap->find("H", Atom::ATOM), 4);
-    EXPECT_EQ(atom->lmap->find("X", Atom::ATOM), -1);
+    EXPECT_EQ(atom->lmap->find_type("C1", Atom::ATOM), 1);
+    EXPECT_EQ(atom->lmap->find_type("N2", Atom::ATOM), 2);
+    EXPECT_EQ(atom->lmap->find_type("O#", Atom::ATOM), 3);
+    EXPECT_EQ(atom->lmap->find_type("H", Atom::ATOM), 4);
+    EXPECT_EQ(atom->lmap->find_type("X", Atom::ATOM), -1);
     EXPECT_DOUBLE_EQ(atom->mass[3], 10.0);
 
     EXPECT_EQ(utils::expand_type(FLERR, "1", Atom::ATOM, lmp), nullptr);
@@ -161,18 +161,18 @@ TEST_F(LabelMapTest, Atoms)
     command("labelmap atom 3 C1 2 N2");
     END_HIDE_OUTPUT();
     EXPECT_FALSE(atom->lmap->is_complete(Atom::ATOM));
-    EXPECT_EQ(atom->lmap->find("C1", Atom::ATOM), 3);
-    EXPECT_EQ(atom->lmap->find("N2", Atom::ATOM), 2);
+    EXPECT_EQ(atom->lmap->find_type("C1", Atom::ATOM), 3);
+    EXPECT_EQ(atom->lmap->find_type("N2", Atom::ATOM), 2);
 
     BEGIN_HIDE_OUTPUT();
     command("labelmap clear");
     command(R"(labelmap atom 1 "C1'" 2 'C2"' 3 """C1'-C2" """ 4 """ C2"-C1'""")");
     END_HIDE_OUTPUT();
     EXPECT_TRUE(atom->lmap->is_complete(Atom::ATOM));
-    EXPECT_EQ(atom->lmap->find("C1'", Atom::ATOM), 1);
-    EXPECT_EQ(atom->lmap->find("C2\"", Atom::ATOM), 2);
-    EXPECT_EQ(atom->lmap->find("C1'-C2\"", Atom::ATOM), 3);
-    EXPECT_EQ(atom->lmap->find("C2\"-C1'", Atom::ATOM), 4);
+    EXPECT_EQ(atom->lmap->find_type("C1'", Atom::ATOM), 1);
+    EXPECT_EQ(atom->lmap->find_type("C2\"", Atom::ATOM), 2);
+    EXPECT_EQ(atom->lmap->find_type("C1'-C2\"", Atom::ATOM), 3);
+    EXPECT_EQ(atom->lmap->find_type("C2\"-C1'", Atom::ATOM), 4);
 }
 
 TEST_F(LabelMapTest, Topology)
@@ -220,17 +220,17 @@ TEST_F(LabelMapTest, Topology)
     EXPECT_TRUE(atom->lmap->is_complete(Atom::ANGLE));
     EXPECT_TRUE(atom->lmap->is_complete(Atom::DIHEDRAL));
     EXPECT_TRUE(atom->lmap->is_complete(Atom::IMPROPER));
-    EXPECT_EQ(atom->lmap->find("C1", Atom::ATOM), 1);
-    EXPECT_EQ(atom->lmap->find("N2'", Atom::ATOM), 2);
-    EXPECT_EQ(atom->lmap->find("C1-N2", Atom::BOND), 1);
-    EXPECT_EQ(atom->lmap->find("[C1][C1]", Atom::BOND), 2);
-    EXPECT_EQ(atom->lmap->find("N2=N2", Atom::BOND), 3);
-    EXPECT_EQ(atom->lmap->find("C1-N2-C1", Atom::ANGLE), 1);
-    EXPECT_EQ(atom->lmap->find("N2'-C1\"-N2'", Atom::ANGLE), 2);
-    EXPECT_EQ(atom->lmap->find("C1-N2-C1-N2", Atom::DIHEDRAL), 1);
-    EXPECT_EQ(atom->lmap->find("C1-N2-C1-N2", Atom::IMPROPER), 1);
-    EXPECT_EQ(atom->lmap->find("X", Atom::ATOM), -1);
-    EXPECT_EQ(atom->lmap->find("N2'-C1\"-N2'", Atom::BOND), -1);
+    EXPECT_EQ(atom->lmap->find_type("C1", Atom::ATOM), 1);
+    EXPECT_EQ(atom->lmap->find_type("N2'", Atom::ATOM), 2);
+    EXPECT_EQ(atom->lmap->find_type("C1-N2", Atom::BOND), 1);
+    EXPECT_EQ(atom->lmap->find_type("[C1][C1]", Atom::BOND), 2);
+    EXPECT_EQ(atom->lmap->find_type("N2=N2", Atom::BOND), 3);
+    EXPECT_EQ(atom->lmap->find_type("C1-N2-C1", Atom::ANGLE), 1);
+    EXPECT_EQ(atom->lmap->find_type("N2'-C1\"-N2'", Atom::ANGLE), 2);
+    EXPECT_EQ(atom->lmap->find_type("C1-N2-C1-N2", Atom::DIHEDRAL), 1);
+    EXPECT_EQ(atom->lmap->find_type("C1-N2-C1-N2", Atom::IMPROPER), 1);
+    EXPECT_EQ(atom->lmap->find_type("X", Atom::ATOM), -1);
+    EXPECT_EQ(atom->lmap->find_type("N2'-C1\"-N2'", Atom::BOND), -1);
     EXPECT_DOUBLE_EQ(atom->mass[1], 12.0);
     EXPECT_DOUBLE_EQ(atom->mass[2], 14.0);
 
@@ -255,17 +255,17 @@ TEST_F(LabelMapTest, Topology)
     EXPECT_TRUE(atom->lmap->is_complete(Atom::ANGLE));
     EXPECT_TRUE(atom->lmap->is_complete(Atom::DIHEDRAL));
     EXPECT_TRUE(atom->lmap->is_complete(Atom::IMPROPER));
-    EXPECT_EQ(atom->lmap->find("C1", Atom::ATOM), 1);
-    EXPECT_EQ(atom->lmap->find("N2'", Atom::ATOM), 2);
-    EXPECT_EQ(atom->lmap->find("C1-N2", Atom::BOND), 1);
-    EXPECT_EQ(atom->lmap->find("[C1][C1]", Atom::BOND), 2);
-    EXPECT_EQ(atom->lmap->find("N2=N2", Atom::BOND), 3);
-    EXPECT_EQ(atom->lmap->find("C1-N2-C1", Atom::ANGLE), 1);
-    EXPECT_EQ(atom->lmap->find("N2'-C1\"-N2'", Atom::ANGLE), 2);
-    EXPECT_EQ(atom->lmap->find("C1-N2-C1-N2", Atom::DIHEDRAL), 1);
-    EXPECT_EQ(atom->lmap->find("C1-N2-C1-N2", Atom::IMPROPER), 1);
-    EXPECT_EQ(atom->lmap->find("X", Atom::ATOM), -1);
-    EXPECT_EQ(atom->lmap->find("N2'-C1\"-N2'", Atom::BOND), -1);
+    EXPECT_EQ(atom->lmap->find_type("C1", Atom::ATOM), 1);
+    EXPECT_EQ(atom->lmap->find_type("N2'", Atom::ATOM), 2);
+    EXPECT_EQ(atom->lmap->find_type("C1-N2", Atom::BOND), 1);
+    EXPECT_EQ(atom->lmap->find_type("[C1][C1]", Atom::BOND), 2);
+    EXPECT_EQ(atom->lmap->find_type("N2=N2", Atom::BOND), 3);
+    EXPECT_EQ(atom->lmap->find_type("C1-N2-C1", Atom::ANGLE), 1);
+    EXPECT_EQ(atom->lmap->find_type("N2'-C1\"-N2'", Atom::ANGLE), 2);
+    EXPECT_EQ(atom->lmap->find_type("C1-N2-C1-N2", Atom::DIHEDRAL), 1);
+    EXPECT_EQ(atom->lmap->find_type("C1-N2-C1-N2", Atom::IMPROPER), 1);
+    EXPECT_EQ(atom->lmap->find_type("X", Atom::ATOM), -1);
+    EXPECT_EQ(atom->lmap->find_type("N2'-C1\"-N2'", Atom::BOND), -1);
     platform::unlink("labelmap_topology.inc");
 
     auto *expanded = utils::expand_type(FLERR, "N2'", Atom::ATOM, lmp);

--- a/unittest/commands/test_labelmap.cpp
+++ b/unittest/commands/test_labelmap.cpp
@@ -97,6 +97,13 @@ TEST_F(LabelMapTest, Atoms)
     EXPECT_EQ(atom->lmap->find_type("O#", Atom::ATOM), 3);
     EXPECT_EQ(atom->lmap->find_type("H", Atom::ATOM), 4);
     EXPECT_EQ(atom->lmap->find_type("X", Atom::ATOM), -1);
+    EXPECT_EQ(atom->lmap->find_type("", Atom::ATOM), -1);
+    EXPECT_THAT(atom->lmap->find_label(1, Atom::ATOM), StrEq("C1"));
+    EXPECT_THAT(atom->lmap->find_label(2, Atom::ATOM), StrEq("N2"));
+    EXPECT_THAT(atom->lmap->find_label(3, Atom::ATOM), StrEq("O#"));
+    EXPECT_THAT(atom->lmap->find_label(4, Atom::ATOM), StrEq("H"));
+    EXPECT_THAT(atom->lmap->find_label(-1, Atom::ATOM), StrEq(""));
+    EXPECT_THAT(atom->lmap->find_label(5, Atom::ATOM), StrEq(""));
     EXPECT_DOUBLE_EQ(atom->mass[3], 10.0);
 
     EXPECT_EQ(utils::expand_type(FLERR, "1", Atom::ATOM, lmp), nullptr);
@@ -170,9 +177,13 @@ TEST_F(LabelMapTest, Atoms)
     END_HIDE_OUTPUT();
     EXPECT_TRUE(atom->lmap->is_complete(Atom::ATOM));
     EXPECT_EQ(atom->lmap->find_type("C1'", Atom::ATOM), 1);
-    EXPECT_EQ(atom->lmap->find_type("C2\"", Atom::ATOM), 2);
-    EXPECT_EQ(atom->lmap->find_type("C1'-C2\"", Atom::ATOM), 3);
-    EXPECT_EQ(atom->lmap->find_type("C2\"-C1'", Atom::ATOM), 4);
+    EXPECT_EQ(atom->lmap->find_type(R"(C2")", Atom::ATOM), 2);
+    EXPECT_EQ(atom->lmap->find_type(R"(C1'-C2")", Atom::ATOM), 3);
+    EXPECT_EQ(atom->lmap->find_type(R"(C2"-C1')", Atom::ATOM), 4);
+    EXPECT_THAT(atom->lmap->find_label(1, Atom::ATOM), StrEq("C1'"));
+    EXPECT_THAT(atom->lmap->find_label(2, Atom::ATOM), StrEq(R"(C2")"));
+    EXPECT_THAT(atom->lmap->find_label(3, Atom::ATOM), StrEq(R"(C1'-C2")"));
+    EXPECT_THAT(atom->lmap->find_label(4, Atom::ATOM), StrEq(R"(C2"-C1')"));
 }
 
 TEST_F(LabelMapTest, Topology)
@@ -231,6 +242,22 @@ TEST_F(LabelMapTest, Topology)
     EXPECT_EQ(atom->lmap->find_type("C1-N2-C1-N2", Atom::IMPROPER), 1);
     EXPECT_EQ(atom->lmap->find_type("X", Atom::ATOM), -1);
     EXPECT_EQ(atom->lmap->find_type("N2'-C1\"-N2'", Atom::BOND), -1);
+
+    EXPECT_THAT(atom->lmap->find_label(1, Atom::BOND), StrEq("C1-N2"));
+    EXPECT_THAT(atom->lmap->find_label(2, Atom::BOND), StrEq("[C1][C1]"));
+    EXPECT_THAT(atom->lmap->find_label(3, Atom::BOND), StrEq("N2=N2"));
+    EXPECT_THAT(atom->lmap->find_label(1, Atom::ANGLE), StrEq("C1-N2-C1"));
+    EXPECT_THAT(atom->lmap->find_label(2, Atom::ANGLE), StrEq(R"(N2'-C1"-N2')"));
+    EXPECT_THAT(atom->lmap->find_label(1, Atom::DIHEDRAL), StrEq("C1-N2-C1-N2"));
+    EXPECT_THAT(atom->lmap->find_label(1, Atom::IMPROPER), StrEq("C1-N2-C1-N2"));
+    EXPECT_THAT(atom->lmap->find_label(0, Atom::BOND), StrEq(""));
+    EXPECT_THAT(atom->lmap->find_label(4, Atom::BOND), StrEq(""));
+    EXPECT_THAT(atom->lmap->find_label(-1, Atom::ANGLE), StrEq(""));
+    EXPECT_THAT(atom->lmap->find_label(3, Atom::ANGLE), StrEq(""));
+    EXPECT_THAT(atom->lmap->find_label(0, Atom::DIHEDRAL), StrEq(""));
+    EXPECT_THAT(atom->lmap->find_label(2, Atom::DIHEDRAL), StrEq(""));
+    EXPECT_THAT(atom->lmap->find_label(-1, Atom::IMPROPER), StrEq(""));
+    EXPECT_THAT(atom->lmap->find_label(0, Atom::IMPROPER), StrEq(""));
     EXPECT_DOUBLE_EQ(atom->mass[1], 12.0);
     EXPECT_DOUBLE_EQ(atom->mass[2], 14.0);
 


### PR DESCRIPTION
**Summary**

This pull request combines multiple small changes and fixes that do not warrant a pull request of their own.

**Related Issue(s)**

Fixes #4815
Fixes #4852

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

The Doxygen comments for the `LabelMap` class were drafted by GitHub Copilot and then revised and condensed and cross-linked to other parts of the manual where appropriate.

**Backward Compatibility**

N/A

**Implementation Notes**

The following individual changes are included:
- changes to the CMake scripting to re-enable building the SCAFACOS package on Ubuntu 22.04LTS
- modernize error messages in `fix brownian/*`, fix indexing bugs
- add example VMD workflow to visualization howto
- add unit tests for typelabel inference
- import bugfix from PR #4851 and extend it to fix neb/spin
- apply optimization to LabelMap class suggested by Coverity Scan
- add out-of-range checks for type label inference
- simplify typelabel parser by using Tokenizer class
- protect improper inference against segfault due to missing improper style instance
- add Doxygen comments to `LabelMap` class and examples and usage instructions to the Developer information

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
