### PR TITLE
Bump MBX version to v1.3.5

### DIFF
--- a/cmake/Modules/Packages/MBX.cmake
+++ b/cmake/Modules/Packages/MBX.cmake
@@ -34,8 +34,8 @@ if(CONFIGURE_REQUEST_PIC)
   list(APPEND MBX_CONFIG_FLAGS ${CONFIGURE_REQUEST_PIC})
 endif()
 
-set(MBXLIB_URL "https://github.com/paesanilab/MBX/releases/download/v1.3.3/mbx-1.3.3.tar.gz" CACHE STRING "URL for MBX tarball")
-set(MBXLIB_MD5 "78abbf597e8077e5e0b18e86fc3248c1" CACHE STRING "MD5 checksum of MBX tarball")
+set(MBXLIB_URL "https://github.com/paesanilab/MBX/releases/download/v1.3.5/mbx-1.3.5.tar.gz" CACHE STRING "URL for MBX tarball")
+set(MBXLIB_MD5 "2ffdcdbebf3c10ba010c573545a33d47" CACHE STRING "MD5 checksum of MBX tarball")
 
 mark_as_advanced(MBXLIB_URL)
 mark_as_advanced(MBXLIB_MD5)


### PR DESCRIPTION
Includes updated Nlohmann JSON 3.12.0 within MBX.

**Summary**

MBX v1.3.5 includes an updated version of the Nlohmann::JSON library (3.12.0) used within MBX. This should provider better long-term compiler compatibility.

**Author(s)**

@Miniland1333, UC San Diego

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Implementation Notes**

MBX was compiled with this updated Nlohmann::JSON and the output matches the expected logfiles.

Other minor changes will be in a separate PR.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [x] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

https://github.com/paesanilab/MBX/releases/tag/v1.3.5


