### PR TITLE
Fixed gif documentation

### DIFF
--- a/doc/src/fix_gjf.rst
+++ b/doc/src/fix_gjf.rst
@@ -197,7 +197,7 @@ The option defaults are vel = vhalf, method = 1.
 
 .. _Finkelstein:
 
-**(Finkelstein)** Finkelstein, Cheng, Florin, Seibold, Gronbech-Jensen, J. Chem. Phys., 155, 18 (2021)
+**(Finkelstein)** Finkelstein, Cheng, Fiorin, Seibold, Gronbech-Jensen, J. Chem. Phys., 155, 18 (2021)
 
 .. _Gronbech-Jensen-2024:
 


### PR DESCRIPTION
Fixed Giacomo's name in "fix gif". was appearing as "Florin" in the docs.