### PR TITLE
Fix bug in KOKKOS Comm

### DIFF
--- a/src/KOKKOS/atom_vec_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_kokkos.cpp
@@ -33,7 +33,7 @@ AtomVecKokkos::AtomVecKokkos(LAMMPS *lmp) : AtomVec(lmp)
   kokkosable = 1;
   buffer = nullptr;
   buffer_size = 0;
-  size_exchange = 0;
+  size_exchange = size_exchange_default = size_exchange_bonus = 0;
 
   datamask_grow = datamask_comm = datamask_comm_vel = datamask_reverse =
     datamask_border = datamask_border_vel = datamask_exchange =

--- a/src/KOKKOS/comm_kokkos.cpp
+++ b/src/KOKKOS/comm_kokkos.cpp
@@ -1120,6 +1120,11 @@ void CommKokkos::exchange_device()
                                    k_exchange_sendlist,k_exchange_copylist,
                                    k_exchange_copylist_bonus,
                                    ExecutionSpaceFromDevice<DeviceType>::space);
+
+      // pack_exchange_kokkos may resize k_buf_send
+
+      buf_send = k_buf_send.view_host().data();
+
       atom->nlocal = nlocal;
       if (bonus_flag) atomKK->avecKK->set_status_nlocal_bonus(nlocal_bonus);
 
@@ -1695,7 +1700,6 @@ void CommKokkos::grow_send_kokkos(int n, int flag, ExecutionSpace space)
                         atomKK->avecKK->size_border + atomKK->avecKK->size_velocity);
     else
       k_buf_send.resize(maxsend_border,atomKK->avecKK->size_border);
-    buf_send = k_buf_send.view_host().data();
   } else {
     if (ghost_velocity)
       MemoryKokkos::realloc_kokkos(k_buf_send,"comm:k_buf_send",maxsend_border,
@@ -1703,8 +1707,8 @@ void CommKokkos::grow_send_kokkos(int n, int flag, ExecutionSpace space)
     else
       MemoryKokkos::realloc_kokkos(k_buf_send,"comm:k_buf_send",maxsend_border,
                         atomKK->avecKK->size_border);
-    buf_send = k_buf_send.view_host().data();
   }
+  buf_send = k_buf_send.view_host().data();
 }
 
 /* ----------------------------------------------------------------------


### PR DESCRIPTION
**Summary**

- Fixes dangling pointer to host comm buffer which could lead to crashes when mixing KOKKOS and non-KOKKOS comm routines
- Also fixes uninitialized variables which gave Valgrind warning

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

<!--Please update the following sentence as needed in case you were using AI tools to
generate code.  Please mention which specific AI tool or tools you were using and which
parts of the code were AI generated versus the parts written by a human.  The use of AI
tools for checking spelling and syntax does not need to be reported.-->

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Backward Compatibility**

Yes