### PR TITLE
Allow KOKKOS computes to pack/unpack forward comm buffers on device

### DIFF
--- a/doc/src/package.rst
+++ b/doc/src/package.rst
@@ -562,7 +562,7 @@ atom coordinates and any other atom properties that needs to be updated
 for ghost atoms owned by each processor. "Comm/pair" controls additional
 communication in pair styles, such as pair_style EAM. "Comm/fix" controls
 additional communication in fixes, such as fix SHAKE. Similarly,
-"comm/compute" controls additional communication in computes. 
+"comm/compute" controls additional communication in computes.
 
 The *comm* keyword is simply a short-cut to set the same value for all
 the comm keywords.

--- a/doc/src/package.rst
+++ b/doc/src/package.rst
@@ -79,7 +79,7 @@ Syntax
         *no_affinity* values = none
     *kokkos* args = keyword value ...
       zero or more keyword/value pairs may be appended
-      keywords = *neigh* or *neigh/qeq* or *neigh/thread* or *neigh/transpose* or *newton* or *binsize* or *comm* or *comm/exchange* or *comm/forward* or *comm/pair/forward* or *comm/fix/forward* or *comm/reverse* or *comm/pair/reverse* or *comm/fix/reverse* or *sort* or *atom/map* or *gpu/aware* or *pair/only*
+      keywords = *neigh* or *neigh/qeq* or *neigh/thread* or *neigh/transpose* or *newton* or *binsize* or *comm* or *comm/exchange* or *comm/forward* or *comm/pair/forward* or *comm/fix/forward* or *comm/compute/forward* or *comm/reverse* or *comm/pair/reverse* or *comm/fix/reverse* or *sort* or *atom/map* or *gpu/aware* or *pair/only*
         *neigh* value = *full* or *half*
           full = full neighbor list
           half = half neighbor list built in thread-safe manner
@@ -98,11 +98,12 @@ Syntax
         *binsize* value = size
           size = bin size for neighbor list construction (distance units)
         *comm* value = *no* or *host* or *device*
-          use value for comm/exchange and comm/forward and comm/pair/forward and comm/fix/forward and comm/reverse and comm/fix/reverse
+          use value for comm/exchange and comm/forward and comm/pair/forward and comm/fix/forward and comm/compute/forward and comm/reverse and comm/fix/reverse
         *comm/exchange* value = *no* or *host* or *device*
         *comm/forward* value = *no* or *host* or *device*
         *comm/pair/forward* value = *no* or *device*
         *comm/fix/forward* value = *no* or *device*
+        *comm/compute/forward* value = *no* or *device*
         *comm/reverse* value = *no* or *host* or *device*
           *no* = perform communication pack/unpack in non-KOKKOS mode
           *host* = perform pack/unpack on host (e.g. with OpenMP threading)
@@ -548,9 +549,9 @@ because the GPU is faster at performing pairwise interactions, then this
 rule of thumb may give too large a binsize and the default should be
 overridden with a smaller value.
 
-The *comm* and *comm/exchange* and *comm/forward* and *comm/pair/forward*
-and *comm/fix/forward* and *comm/reverse* and *comm/pair/reverse* and
-*comm/fix/reverse*
+The *comm* and *comm/exchange* and *comm/forward* and
+*comm/pair/forward* and *comm/fix/forward* and *comm/compute/forward*
+and *comm/reverse* and *comm/pair/reverse* and *comm/fix/reverse*
 keywords determine whether the host or device performs the packing and
 unpacking of data when communicating per-atom data between processors.
 "Exchange" communication happens only on timesteps that neighbor lists
@@ -558,14 +559,15 @@ are rebuilt. The data is only for atoms that migrate to new processors.
 "Forward" communication happens every timestep. "Reverse" communication
 happens every timestep if the *newton* option is on. The data is for
 atom coordinates and any other atom properties that needs to be updated
-for ghost atoms owned by each processor. "Pair/comm" controls additional
-communication in pair styles, such as pair_style EAM. "Fix/comm" controls
-additional communication in fixes, such as fix SHAKE.
+for ghost atoms owned by each processor. "Comm/pair" controls additional
+communication in pair styles, such as pair_style EAM. "Comm/fix" controls
+additional communication in fixes, such as fix SHAKE. Similarly,
+"comm/compute" controls additional communication in computes. 
 
 The *comm* keyword is simply a short-cut to set the same value for all
 the comm keywords.
 
-The value options for the keywords are *no* or *host* or *device*\ . A
+The value options for the keywords are *no* or *host* or *device*. A
 value of *no* means to use the standard non-KOKKOS method of
 packing/unpacking data for the communication. A value of *host* means to
 use the host, typically a multicore CPU, and perform the
@@ -573,15 +575,15 @@ packing/unpacking in parallel with threads. A value of *device* means to
 use the device, typically a GPU, to perform the packing/unpacking
 operation.
 
-For the *comm/pair/forward* or *comm/fix/forward* or *comm/pair/reverse*
-keywords, if a value of *host* is used it will be automatically
-be changed to *no* since these keywords don't support *host* mode. The
-value of *no* will also always be used when running on the CPU, i.e. setting
-the value to *device* will have no effect if the pair/fix style is
-running on the CPU. For the *comm/fix/forward* or *comm/pair/reverse* or
-*comm/fix/reverse*
-keywords, not all styles support *device* mode and in that case will run
-in *no* mode instead.
+For the *comm/pair/forward* or *comm/fix/forward* or
+*comm/compute/forward* or *comm/pair/reverse* keywords, if a value of
+*host* is used it will be automatically be changed to *no* since these
+keywords don't support *host* mode. The value of *no* will also always
+be used when running on the CPU, i.e. setting the value to *device*
+will have no effect if the pair/fix style is running on the CPU. For
+the *comm/fix/forward* or *comm/compute/forward* or
+*comm/pair/reverse* or *comm/fix/reverse* keywords, not all styles
+support *device* mode and in that case will run in *no* mode instead.
 
 The optimal choice for these keywords depends on the input script and
 the hardware used. The *no* value is useful for verifying that the

--- a/src/KOKKOS/comm_kokkos.cpp
+++ b/src/KOKKOS/comm_kokkos.cpp
@@ -87,6 +87,10 @@ CommKokkos::CommKokkos(LAMMPS *lmp) : CommBrick(lmp)
   max_buf_fix = 0;
   k_buf_send_fix = DAT::tdual_double_1d("comm:k_buf_send_fix",1);
   k_buf_recv_fix = DAT::tdual_double_1d("comm:k_recv_send_fix",1);
+
+  max_buf_compute = 0;
+  k_buf_send_compute = DAT::tdual_double_1d("comm:k_buf_send_compute",1);
+  k_buf_recv_compute = DAT::tdual_double_1d("comm:k_recv_send_compute",1);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -117,6 +121,7 @@ void CommKokkos::init()
   forward_pair_comm_legacy = lmp->kokkos->forward_pair_comm_legacy;
   reverse_pair_comm_legacy = lmp->kokkos->reverse_pair_comm_legacy;
   forward_fix_comm_legacy = lmp->kokkos->forward_fix_comm_legacy;
+  forward_compute_comm_legacy = lmp->kokkos->forward_compute_comm_legacy;
   reverse_comm_legacy = lmp->kokkos->reverse_comm_legacy;
   reverse_fix_comm_legacy = lmp->kokkos->reverse_fix_comm_legacy;
   exchange_comm_on_host = lmp->kokkos->exchange_comm_on_host;
@@ -555,8 +560,86 @@ void CommKokkos::reverse_comm_variable(Fix *fix)
 
 void CommKokkos::forward_comm(Compute *compute, int size)
 {
-  k_sendlist.sync_host();
-  CommBrick::forward_comm(compute, size);
+  if (compute->execution_space == Host || compute->execution_space == HostKK ||
+      !compute->forward_comm_device || forward_compute_comm_legacy) {
+    k_sendlist.sync_host();
+    CommBrick::forward_comm(compute, size);
+  } else {
+    k_sendlist.sync_device();
+    forward_comm_device<LMPDeviceType>(compute, size);
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void CommKokkos::forward_comm_device(Compute *compute, int size)
+{
+  int iswap,n,nsize;
+  MPI_Request request;
+  DAT::tdual_double_1d k_buf_tmp;
+
+  if (size) nsize = size;
+  else nsize = compute->comm_forward;
+  KokkosBase* computeKKBase = dynamic_cast<KokkosBase*>(compute);
+
+  for (iswap = 0; iswap < nswap; iswap++) {
+    int n = MAX(max_buf_compute,nsize*sendnum[iswap]);
+    n = MAX(n,nsize*recvnum[iswap]);
+    if (n > max_buf_compute)
+      grow_buf_compute(n);
+  }
+
+  for (iswap = 0; iswap < nswap; iswap++) {
+
+    // pack buffer
+
+    auto k_sendlist_iswap = Kokkos::subview(k_sendlist,iswap,Kokkos::ALL);
+    n = computeKKBase->pack_forward_comm_kokkos(sendnum[iswap],k_sendlist_iswap,
+                                      k_buf_send_compute,pbc_flag[iswap],pbc[iswap]);
+
+    // exchange with another proc
+    // if self, set recv buffer to send buffer
+
+    if (sendproc[iswap] != me) {
+      double* buf_send_compute;
+      double* buf_recv_compute;
+      if (lmp->kokkos->gpu_aware_flag) {
+        buf_send_compute = k_buf_send_compute.view<DeviceType>().data();
+        buf_recv_compute = k_buf_recv_compute.view<DeviceType>().data();
+      } else {
+        k_buf_send_compute.modify<DeviceType>();
+        k_buf_send_compute.sync_host();
+        buf_send_compute = k_buf_send_compute.view_host().data();
+        buf_recv_compute = k_buf_recv_compute.view_host().data();
+      }
+
+      if (recvnum[iswap]) {
+        DeviceType().fence();
+        MPI_Irecv(buf_recv_compute,nsize*recvnum[iswap],MPI_DOUBLE,
+                  recvproc[iswap],0,world,&request);
+      }
+      if (sendnum[iswap]) {
+        DeviceType().fence();
+        MPI_Send(buf_send_compute,n,MPI_DOUBLE,sendproc[iswap],0,world);
+      }
+
+      if (recvnum[iswap]) {
+        MPI_Wait(&request,MPI_STATUS_IGNORE);
+        DeviceType().fence();
+      }
+
+      if (!lmp->kokkos->gpu_aware_flag) {
+        k_buf_recv_compute.modify_host();
+        k_buf_recv_compute.sync<DeviceType>();
+      }
+      k_buf_tmp = k_buf_recv_compute;
+    } else k_buf_tmp = k_buf_send_compute;
+
+    // unpack buffer
+
+    computeKKBase->unpack_forward_comm_kokkos(recvnum[iswap],firstrecv[iswap],k_buf_tmp);
+  }
 }
 
 /* ----------------------------------------------------------------------
@@ -713,6 +796,15 @@ void CommKokkos::grow_buf_fix(int n) {
   k_buf_send_fix.resize(max_buf_fix);
   k_buf_recv_fix.resize(max_buf_fix);
 }
+
+/* ---------------------------------------------------------------------- */
+
+void CommKokkos::grow_buf_compute(int n) {
+  max_buf_compute = n * BUFFACTOR;
+  k_buf_send_compute.resize(max_buf_compute);
+  k_buf_recv_compute.resize(max_buf_compute);
+}
+
 
 /* ---------------------------------------------------------------------- */
 

--- a/src/KOKKOS/comm_kokkos.h
+++ b/src/KOKKOS/comm_kokkos.h
@@ -29,6 +29,7 @@ class CommKokkos : public CommBrick {
   bool forward_pair_comm_legacy;
   bool reverse_pair_comm_legacy;
   bool forward_fix_comm_legacy;
+  bool forward_compute_comm_legacy;
   bool reverse_comm_legacy;
   bool reverse_fix_comm_legacy;
   bool exchange_comm_on_host;
@@ -66,6 +67,7 @@ class CommKokkos : public CommBrick {
   template<class DeviceType> void reverse_comm_device(Pair *pair, int size=0);
   template<class DeviceType> void forward_comm_device(Fix *fix, int size=0);
   template<class DeviceType> void reverse_comm_device(Fix *fix, int size=0);
+  template<class DeviceType> void forward_comm_device(Compute *compute, int size=0);
   template<class DeviceType> void exchange_device();
   template<class DeviceType> void borders_device();
 
@@ -86,11 +88,12 @@ class CommKokkos : public CommBrick {
   DAT::tdual_int_1d k_sendnum_scan;
   int totalsend;
 
-  int max_buf_pair,max_buf_fix;
-  DAT::tdual_double_1d k_buf_send_pair, k_buf_send_fix;
-  DAT::tdual_double_1d k_buf_recv_pair, k_buf_recv_fix;
+  int max_buf_pair,max_buf_fix,max_buf_compute;
+  DAT::tdual_double_1d k_buf_send_pair, k_buf_send_fix, k_buf_send_compute;
+  DAT::tdual_double_1d k_buf_recv_pair, k_buf_recv_fix, k_buf_recv_compute;
   void grow_buf_pair(int);
   void grow_buf_fix(int);
+  void grow_buf_compute(int);
 
   void grow_send(int, int) override;
   void grow_recv(int) override;

--- a/src/KOKKOS/comm_tiled_kokkos.cpp
+++ b/src/KOKKOS/comm_tiled_kokkos.cpp
@@ -618,7 +618,6 @@ void CommTiledKokkos::grow_send_kokkos(int n, int flag, ExecutionSpace space)
                         atomKK->avecKK->size_border + atomKK->avecKK->size_velocity);
     else
       k_buf_send.resize(maxsend_border,atomKK->avecKK->size_border);
-    buf_send = k_buf_send.view_host().data();
   } else {
     if (ghost_velocity)
       MemoryKokkos::realloc_kokkos(k_buf_send,"comm:k_buf_send",maxsend_border,
@@ -626,8 +625,8 @@ void CommTiledKokkos::grow_send_kokkos(int n, int flag, ExecutionSpace space)
     else
       MemoryKokkos::realloc_kokkos(k_buf_send,"comm:k_buf_send",maxsend_border,
                         atomKK->avecKK->size_border);
-    buf_send = k_buf_send.view_host().data();
   }
+  buf_send = k_buf_send.view_host().data();
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/compute_ave_sphere_atom_kokkos.cpp
+++ b/src/KOKKOS/compute_ave_sphere_atom_kokkos.cpp
@@ -209,6 +209,86 @@ void ComputeAveSphereAtomKokkos<DeviceType>::operator()(TagComputeAveSphereAtom,
   }
 }
 
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+int ComputeAveSphereAtomKokkos<DeviceType>::pack_forward_comm_kokkos(int n, DAT::tdual_int_1d k_sendlist,
+                                                         DAT::tdual_double_1d &k_buf,
+                                                         int pbc_flag, int* pbc)
+{
+  d_sendlist = k_sendlist.view<DeviceType>();
+  d_buf = k_buf.view<DeviceType>();
+
+  atomKK->sync(execution_space,V_MASK);
+  v = atomKK->k_v.view<DeviceType>();
+
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeAveSphereAtomPackForwardComm>(0,n),*this);
+  return n*3;
+}
+
+template<class DeviceType>
+// NOLINTNEXTLINE
+KOKKOS_INLINE_FUNCTION
+void ComputeAveSphereAtomKokkos<DeviceType>::operator()(TagComputeAveSphereAtomPackForwardComm, const int &i) const {
+  const int j = d_sendlist(i);
+
+  d_buf[3*i] = static_cast<double>(v(j,0));
+  d_buf[3*i+1] = static_cast<double>(v(j,1));
+  d_buf[3*i+2] = static_cast<double>(v(j,2));
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void ComputeAveSphereAtomKokkos<DeviceType>::unpack_forward_comm_kokkos(int n, int first_in, DAT::tdual_double_1d &buf)
+{
+  first = first_in;
+  d_buf = buf.view<DeviceType>();
+
+  atomKK->sync(execution_space,V_MASK);
+  v = atomKK->k_v.view<DeviceType>();
+
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeAveSphereAtomUnpackForwardComm>(0,n),*this);
+
+  atomKK->modified(execution_space,V_MASK);
+}
+
+template<class DeviceType>
+// NOLINTNEXTLINE
+KOKKOS_INLINE_FUNCTION
+void ComputeAveSphereAtomKokkos<DeviceType>::operator()(TagComputeAveSphereAtomUnpackForwardComm, const int &i) const {
+  v(i + first,0) = static_cast<KK_FLOAT>(d_buf[3*i]);
+  v(i + first,1) = static_cast<KK_FLOAT>(d_buf[3*i+1]);
+  v(i + first,2) = static_cast<KK_FLOAT>(d_buf[3*i+2]);
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+int ComputeAveSphereAtomKokkos<DeviceType>::pack_forward_comm(int n, int *list, double *buf,
+                                int pbc_flag, int *pbc)
+{
+  atomKK->sync(Host,V_MASK);
+
+  int m = ComputeAveSphereAtom::pack_forward_comm(n,list,buf,pbc_flag,pbc);
+
+  return m;
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void ComputeAveSphereAtomKokkos<DeviceType>::unpack_forward_comm(int n, int first, double *buf)
+{
+  atomKK->sync(Host,V_MASK);
+
+  ComputeAveSphereAtom::unpack_forward_comm(n,first,buf);
+
+  atomKK->modified(Host,V_MASK);
+}
+
+/* ---------------------------------------------------------------------- */
+
 namespace LAMMPS_NS {
 template class ComputeAveSphereAtomKokkos<LMPDeviceType>;
 #ifdef LMP_KOKKOS_GPU

--- a/src/KOKKOS/compute_ave_sphere_atom_kokkos.cpp
+++ b/src/KOKKOS/compute_ave_sphere_atom_kokkos.cpp
@@ -22,6 +22,7 @@
 #include "comm.h"
 #include "domain.h"
 #include "force.h"
+#include "kokkos.h"
 #include "memory_kokkos.h"
 #include "neigh_request.h"
 #include "neighbor_kokkos.h"
@@ -36,6 +37,8 @@ ComputeAveSphereAtomKokkos<DeviceType>::ComputeAveSphereAtomKokkos(LAMMPS *lmp, 
   ComputeAveSphereAtom(lmp, narg, arg)
 {
   kokkosable = 1;
+  forward_comm_device = 1;
+
   atomKK = (AtomKokkos *) atom;
   execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
   datamask_read = EMPTY_MASK;
@@ -72,6 +75,9 @@ void ComputeAveSphereAtomKokkos<DeviceType>::init()
 template<class DeviceType>
 void ComputeAveSphereAtomKokkos<DeviceType>::compute_peratom()
 {
+  int prev_auto_sync = lmp->kokkos->auto_sync;
+  lmp->kokkos->auto_sync = 0;
+
   invoked_peratom = update->ntimestep;
 
   // grow result array if necessary
@@ -86,9 +92,7 @@ void ComputeAveSphereAtomKokkos<DeviceType>::compute_peratom()
 
   // need velocities of ghost atoms
 
-  atomKK->sync(Host,V_MASK);
   comm->forward_comm(this);
-  atomKK->modified(Host,V_MASK);
 
   // invoke full neighbor list (will copy or build if necessary)
 
@@ -125,7 +129,12 @@ void ComputeAveSphereAtomKokkos<DeviceType>::compute_peratom()
 
   k_result.modify<DeviceType>();
   k_result.sync_host();
+  atomKK->k_v.clear_sync_state();
+
+  lmp->kokkos->auto_sync = prev_auto_sync;
 }
+
+/* ---------------------------------------------------------------------- */
 
 template<class DeviceType>
 // NOLINTNEXTLINE
@@ -222,7 +231,10 @@ int ComputeAveSphereAtomKokkos<DeviceType>::pack_forward_comm_kokkos(int n, DAT:
   atomKK->sync(execution_space,V_MASK);
   v = atomKK->k_v.view<DeviceType>();
 
+  copymode = 1;
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeAveSphereAtomPackForwardComm>(0,n),*this);
+  copymode = 0;
+
   return n*3;
 }
 
@@ -248,7 +260,9 @@ void ComputeAveSphereAtomKokkos<DeviceType>::unpack_forward_comm_kokkos(int n, i
   atomKK->sync(execution_space,V_MASK);
   v = atomKK->k_v.view<DeviceType>();
 
+  copymode = 1;
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeAveSphereAtomUnpackForwardComm>(0,n),*this);
+  copymode = 0;
 
   atomKK->modified(execution_space,V_MASK);
 }

--- a/src/KOKKOS/compute_ave_sphere_atom_kokkos.h
+++ b/src/KOKKOS/compute_ave_sphere_atom_kokkos.h
@@ -25,14 +25,17 @@ ComputeStyle(ave/sphere/atom/kk/host,ComputeAveSphereAtomKokkos<LMPHostType>);
 
 #include "compute_ave_sphere_atom.h"
 #include "kokkos_type.h"
+#include "kokkos_base.h"
 
 namespace LAMMPS_NS {
 
 // clang-format off
 struct TagComputeAveSphereAtom {};
+struct TagComputeAveSphereAtomPackForwardComm{};
+struct TagComputeAveSphereAtomUnpackForwardComm{};
 // clang-format on
 
-template <class DeviceType> class ComputeAveSphereAtomKokkos : public ComputeAveSphereAtom {
+template <class DeviceType> class ComputeAveSphereAtomKokkos : public ComputeAveSphereAtom, public KokkosBase {
  public:
   typedef DeviceType device_type;
   typedef ArrayTypes<DeviceType> AT;
@@ -42,9 +45,23 @@ template <class DeviceType> class ComputeAveSphereAtomKokkos : public ComputeAve
   void init() override;
   void compute_peratom() override;
 
+  int pack_forward_comm_kokkos(int, DAT::tdual_int_1d, DAT::tdual_double_1d&,
+                       int, int *) override;
+  void unpack_forward_comm_kokkos(int, int, DAT::tdual_double_1d&) override;
+  int pack_forward_comm(int, int *, double *, int, int *) override;
+  void unpack_forward_comm(int, int, double *) override;
+
 // NOLINTNEXTLINE
   KOKKOS_INLINE_FUNCTION
   void operator()(TagComputeAveSphereAtom, const int &) const;
+
+// NOLINTNEXTLINE
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagComputeAveSphereAtomPackForwardComm, const int&) const;
+
+// NOLINTNEXTLINE
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagComputeAveSphereAtomUnpackForwardComm, const int&) const;
 
  private:
   KK_FLOAT adof, mvv2e, mv2d, boltz;
@@ -62,6 +79,11 @@ template <class DeviceType> class ComputeAveSphereAtomKokkos : public ComputeAve
 
   DAT::ttransform_kkfloat_2d k_result;
   typename AT::t_kkfloat_2d d_result;
+
+  int first,nsend;
+
+  typename AT::t_int_1d d_sendlist;
+  typename AT::t_double_1d_um d_buf;
 };
 
 }    // namespace LAMMPS_NS

--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -65,11 +65,12 @@ KokkosLMP::KokkosLMP(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
 
   exchange_comm_changed = 0;
   forward_comm_changed = 0;
+  reverse_comm_changed = 0;
   forward_pair_comm_changed = 0;
   reverse_pair_comm_changed = 0;
   forward_fix_comm_changed = 0;
   reverse_fix_comm_changed = 0;
-  reverse_comm_changed = 0;
+  forward_compute_comm_changed = 0;
   sort_changed = atom_map_changed = 0;
 
   delete memory;
@@ -289,7 +290,8 @@ KokkosLMP::KokkosLMP(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
 
     exchange_comm_legacy = forward_comm_legacy = reverse_comm_legacy = 0;
     forward_pair_comm_legacy = reverse_pair_comm_legacy =
-      forward_fix_comm_legacy = reverse_fix_comm_legacy = 0;
+      forward_fix_comm_legacy = reverse_fix_comm_legacy =
+      forward_compute_comm_legacy = 0;
     sort_legacy = 0;
     atom_map_legacy = 0;
 
@@ -306,7 +308,8 @@ KokkosLMP::KokkosLMP(LAMMPS *lmp, int narg, char **arg) : Pointers(lmp)
 
     exchange_comm_legacy = forward_comm_legacy = reverse_comm_legacy = 1;
     forward_pair_comm_legacy = reverse_pair_comm_legacy =
-      forward_fix_comm_legacy = reverse_fix_comm_legacy = 1;
+      forward_fix_comm_legacy = reverse_fix_comm_legacy =
+      forward_compute_comm_legacy = 0;
     sort_legacy = 1;
     atom_map_legacy = 1;
 
@@ -492,19 +495,22 @@ void KokkosLMP::accelerator(int narg, char **arg)
       if (strcmp(arg[iarg+1],"no") == 0) {
         exchange_comm_legacy = forward_comm_legacy = reverse_comm_legacy = 1;
         forward_pair_comm_legacy = reverse_pair_comm_legacy =
-          forward_fix_comm_legacy = reverse_fix_comm_legacy = 1;
+          forward_fix_comm_legacy = reverse_fix_comm_legacy =
+          forward_compute_comm_legacy = 0;
 
         exchange_comm_on_host = forward_comm_on_host = reverse_comm_on_host = 0;
       } else if (strcmp(arg[iarg+1],"host") == 0) {
         exchange_comm_legacy = forward_comm_legacy = reverse_comm_legacy = 0;
         forward_pair_comm_legacy = reverse_pair_comm_legacy =
-          forward_fix_comm_legacy = reverse_fix_comm_legacy = 1;
+          forward_fix_comm_legacy = reverse_fix_comm_legacy =
+          forward_compute_comm_legacy = 0;
 
         exchange_comm_on_host = forward_comm_on_host = reverse_comm_on_host = 1;
       } else if (strcmp(arg[iarg+1],"device") == 0) {
         exchange_comm_legacy = forward_comm_legacy = reverse_comm_legacy = 0;
         forward_pair_comm_legacy = reverse_pair_comm_legacy =
-          forward_fix_comm_legacy = reverse_fix_comm_legacy = 0;
+          forward_fix_comm_legacy = reverse_fix_comm_legacy =
+          forward_compute_comm_legacy = 0;
 
         exchange_comm_on_host = forward_comm_on_host = reverse_comm_on_host = 0;
       } else error->all(FLERR,"Illegal package kokkos command");
@@ -564,6 +570,14 @@ void KokkosLMP::accelerator(int narg, char **arg)
       else if (strcmp(arg[iarg+1],"device") == 0) reverse_fix_comm_legacy = 0;
       else error->all(FLERR,"Illegal package kokkos command");
       reverse_fix_comm_changed = 0;
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"comm/compute/forward") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal package kokkos command");
+      if (strcmp(arg[iarg+1],"no") == 0) forward_compute_comm_legacy = 1;
+      else if (strcmp(arg[iarg+1],"host") == 0) forward_compute_comm_legacy = 1;
+      else if (strcmp(arg[iarg+1],"device") == 0) forward_compute_comm_legacy = 0;
+      else error->all(FLERR,"Illegal package kokkos command");
+      forward_compute_comm_changed = 0;
       iarg += 2;
     } else if (strcmp(arg[iarg],"comm/reverse") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal package kokkos command");
@@ -671,6 +685,10 @@ void KokkosLMP::accelerator(int narg, char **arg)
       reverse_fix_comm_legacy = 1;
       reverse_fix_comm_changed = 1;
     }
+    if (forward_compute_comm_legacy == 0) {
+      forward_compute_comm_legacy = 1;
+      forward_compute_comm_changed = 1;
+    }
     if (reverse_comm_legacy == 0 && reverse_comm_on_host == 0) {
       reverse_comm_legacy = 1;
       reverse_comm_changed = 1;
@@ -714,6 +732,10 @@ void KokkosLMP::accelerator(int narg, char **arg)
     if (reverse_fix_comm_changed) {
       reverse_fix_comm_legacy = 0;
       reverse_fix_comm_changed = 0;
+    }
+    if (forward_compute_comm_changed) {
+      forward_compute_comm_legacy = 0;
+      forward_compute_comm_changed = 0;
     }
     if (reverse_comm_changed) {
       reverse_comm_legacy = 0;

--- a/src/KOKKOS/kokkos.h
+++ b/src/KOKKOS/kokkos.h
@@ -29,11 +29,12 @@ class KokkosLMP : protected Pointers {
   int neighflag_qeq_set;
   int exchange_comm_legacy;
   int forward_comm_legacy;
+  int reverse_comm_legacy;
   int forward_pair_comm_legacy;
   int reverse_pair_comm_legacy;
   int forward_fix_comm_legacy;
   int reverse_fix_comm_legacy;
-  int reverse_comm_legacy;
+  int forward_compute_comm_legacy;
   int sort_legacy;
   int atom_map_legacy;
   int exchange_comm_on_host;
@@ -41,11 +42,12 @@ class KokkosLMP : protected Pointers {
   int reverse_comm_on_host;
   int exchange_comm_changed;
   int forward_comm_changed;
+  int reverse_comm_changed;
   int forward_pair_comm_changed;
   int reverse_pair_comm_changed;
   int forward_fix_comm_changed;
   int reverse_fix_comm_changed;
-  int reverse_comm_changed;
+  int forward_compute_comm_changed;
   int sort_changed;
   int atom_map_changed;
   int nthreads,ngpus;

--- a/src/KOKKOS/kokkos_base.h
+++ b/src/KOKKOS/kokkos_base.h
@@ -45,8 +45,18 @@ class KokkosBase {
   virtual int pack_reverse_comm_fix_kokkos(int, int, DAT::tdual_double_1d &) {return 0;};
   virtual void unpack_reverse_comm_fix_kokkos(int, DAT::tdual_int_1d,
                                           int, DAT::tdual_double_1d &) {}
+  // Compute
+  virtual int pack_forward_comm_compute_kokkos(int, DAT::tdual_int_1d,
+                                           DAT::tdual_double_1d &,
+                                           int, int *) {return 0;};
+  virtual void unpack_forward_comm_compute_kokkos(int, int, DAT::tdual_double_1d &) {}
 
 
+  virtual int pack_reverse_comm_compute_kokkos(int, int, DAT::tdual_double_1d &) {return 0;};
+  virtual void unpack_reverse_comm_compute_kokkos(int, DAT::tdual_int_1d,
+                                          int, DAT::tdual_double_1d &) {}
+
+  // Exchange
   virtual int pack_exchange_kokkos(const int & /*nsend*/, DAT::tdual_double_2d_lr & /*k_buf*/,
                                    DAT::tdual_int_1d /*k_sendlist*/,
                                    DAT::tdual_int_1d /*k_copylist*/,

--- a/src/KOKKOS/kokkos_base.h
+++ b/src/KOKKOS/kokkos_base.h
@@ -25,7 +25,7 @@ class KokkosBase {
  public:
   KokkosBase() {}
 
-  // Pair
+  // Forward for Pair, Fix, Compute
   virtual int pack_forward_comm_kokkos(int, DAT::tdual_int_1d,
                                        DAT::tdual_double_1d &,
                                        int, int *) {return 0;};
@@ -34,27 +34,6 @@ class KokkosBase {
   virtual int pack_reverse_comm_kokkos(int, int, DAT::tdual_double_1d &) {return 0;};
   virtual void unpack_reverse_comm_kokkos(int, DAT::tdual_int_1d,
                                           DAT::tdual_double_1d &) {}
-
-  // Fix
-  virtual int pack_forward_comm_fix_kokkos(int, DAT::tdual_int_1d,
-                                           DAT::tdual_double_1d &,
-                                           int, int *) {return 0;};
-  virtual void unpack_forward_comm_fix_kokkos(int, int, DAT::tdual_double_1d &) {}
-
-
-  virtual int pack_reverse_comm_fix_kokkos(int, int, DAT::tdual_double_1d &) {return 0;};
-  virtual void unpack_reverse_comm_fix_kokkos(int, DAT::tdual_int_1d,
-                                          int, DAT::tdual_double_1d &) {}
-  // Compute
-  virtual int pack_forward_comm_compute_kokkos(int, DAT::tdual_int_1d,
-                                           DAT::tdual_double_1d &,
-                                           int, int *) {return 0;};
-  virtual void unpack_forward_comm_compute_kokkos(int, int, DAT::tdual_double_1d &) {}
-
-
-  virtual int pack_reverse_comm_compute_kokkos(int, int, DAT::tdual_double_1d &) {return 0;};
-  virtual void unpack_reverse_comm_compute_kokkos(int, DAT::tdual_int_1d,
-                                          int, DAT::tdual_double_1d &) {}
 
   // Exchange
   virtual int pack_exchange_kokkos(const int & /*nsend*/, DAT::tdual_double_2d_lr & /*k_buf*/,

--- a/src/compute.cpp
+++ b/src/compute.cpp
@@ -99,6 +99,7 @@ Compute::Compute(LAMMPS *lmp, int narg, char **arg) :
 
   copymode = 0;
   kokkosable = 0;
+  forward_comm_device = 0;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute.h
+++ b/src/compute.h
@@ -111,6 +111,7 @@ class Compute : protected Pointers {
   uint64_t datamask_read, datamask_modify;
 
   int copymode, kokkosable;
+  int forward_comm_device;    // 1 if forward comm on Device
 
   Compute(class LAMMPS *, int, char **);
   ~Compute() override;


### PR DESCRIPTION
**Summary**

- Allow KOKKOS computes to pack/unpack forward comm buffers on device
- Enable this new functionality for `compute ave/sphere/atom/kk`

**Related Issue(s)**

None

**Author(s)**

Stan Moore (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

<!--Please update the following sentence as needed in case you were using AI tools to
generate code.  Please mention which specific AI tool or tools you were using and which
parts of the code were AI generated versus the parts written by a human.  The use of AI
tools for checking spelling and syntax does not need to be reported.-->

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Backward Compatibility**

Yes

