### PR TITLE
CMake/Core: Add support for Intel oneAPI (IntelLLVM) on Windows

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -126,7 +126,12 @@ endif()
 
 # silence excessive warnings for new Intel Compilers
 if(CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fp-model precise -Wno-tautological-constant-compare -Wno-unused-command-line-argument")
+  if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:precise")
+  else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fp-model precise")
+  endif()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-tautological-constant-compare -Wno-unused-command-line-argument")
 endif()
 
 # silence excessive warnings for PGI/NVHPC compilers
@@ -165,7 +170,12 @@ set(CMAKE_CXX_EXTENSIONS OFF CACHE BOOL "Use compiler extensions")
 # ugly hacks for MSVC which by default always reports an old C++ standard in the __cplusplus macro
 # and prints lots of pointless warnings about "unsafe" functions
 if(MSVC)
-  if((CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") OR (CMAKE_CXX_COMPILER_ID STREQUAL "Intel"))
+  if((CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") OR (CMAKE_CXX_COMPILER_ID STREQUAL "Intel") OR (CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM"))
+    if(CMAKE_CXX_STANDARD GREATER_EQUAL 20)
+      add_compile_options(/std:c++20)
+    else()
+      add_compile_options(/std:c++17)
+    endif()
     add_compile_options(/Zc:__cplusplus)
     add_compile_options(/wd4244)
     add_compile_options(/wd4267)

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -76,7 +76,7 @@ void *Memory::srealloc(void *ptr, bigint nbytes, const char *name)
     return nullptr;
   }
 
-#if defined(LMP_USE_TBB_ALLOCATOR)
+#if defined(LMP_USE_TBB_ALLOCATOR) && defined(LAMMPS_MEMALIGN)
   ptr = scalable_aligned_realloc(ptr, nbytes, LAMMPS_MEMALIGN);
 #elif defined(LMP_INTEL_NO_TBB) && defined(LAMMPS_MEMALIGN) && \
     (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER))

--- a/src/my_page.cpp
+++ b/src/my_page.cpp
@@ -188,7 +188,13 @@ template <class T> void MyPage<T>::allocate()
 template <class T> void MyPage<T>::deallocate()
 {
   reset();
-  for (int i = 0; i < npage; i++) free(pages[i]);
+  for (int i = 0; i < npage; i++) {
+#if defined(LMP_USE_TBB_ALLOCATOR)
+    scalable_aligned_free(pages[i]);
+#else
+    free(pages[i]);
+#endif
+  }
   free(pages);
   pages = nullptr;
   npage = 0;

--- a/src/my_page.cpp
+++ b/src/my_page.cpp
@@ -13,6 +13,20 @@
 
 #include "my_page.h"
 
+#if defined(LMP_INTEL) && ((defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)))
+#ifndef LMP_INTEL_NO_TBB
+#define LMP_USE_TBB_ALLOCATOR
+#include "tbb/scalable_allocator.h"
+#else
+#include <cstring>
+#if defined(__APPLE__)
+#include <malloc/malloc.h>
+#else
+#include <malloc.h>
+#endif
+#endif
+#endif
+
 #if defined(LMP_INTEL) && !defined(LAMMPS_MEMALIGN) && !defined(_WIN32)
 #define LAMMPS_MEMALIGN 64
 #endif
@@ -156,7 +170,11 @@ template <class T> void MyPage<T>::allocate()
   for (int i = npage - pagedelta; i < npage; i++) {
 #if defined(LAMMPS_MEMALIGN)
     void *ptr;
+#if defined(LMP_USE_TBB_ALLOCATOR)
+    ptr = scalable_aligned_malloc(pagesize * sizeof(T), LAMMPS_MEMALIGN);
+#else
     if (posix_memalign(&ptr, LAMMPS_MEMALIGN, pagesize * sizeof(T))) errorflag = 2;
+#endif
     pages[i] = (T *) ptr;
 #else
     pages[i] = (T *) malloc(pagesize * sizeof(T));

--- a/src/my_pool_chunk.cpp
+++ b/src/my_pool_chunk.cpp
@@ -103,7 +103,13 @@ template <class T> MyPoolChunk<T>::~MyPoolChunk()
   delete[] chunksize;
   if (npage) {
     free(freelist);
-    for (int i = 0; i < npage; i++) free(pages[i]);
+    for (int i = 0; i < npage; i++) {
+#if defined(LMP_USE_TBB_ALLOCATOR)
+      scalable_aligned_free(pages[i]);
+#else
+      free(pages[i]);
+#endif
+    }
     free(pages);
     free(whichbin);
   }

--- a/src/my_pool_chunk.cpp
+++ b/src/my_pool_chunk.cpp
@@ -13,6 +13,20 @@
 
 #include "my_pool_chunk.h"
 
+#if defined(LMP_INTEL) && ((defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)))
+#ifndef LMP_INTEL_NO_TBB
+#define LMP_USE_TBB_ALLOCATOR
+#include "tbb/scalable_allocator.h"
+#else
+#include <cstring>
+#if defined(__APPLE__)
+#include <malloc/malloc.h>
+#else
+#include <malloc.h>
+#endif
+#endif
+#endif
+
 #if defined(LMP_INTEL) && !defined(LAMMPS_MEMALIGN) && !defined(_WIN32)
 #define LAMMPS_MEMALIGN 64
 #endif
@@ -185,8 +199,12 @@ template <class T> void MyPoolChunk<T>::allocate(int ibin)
     whichbin[i] = ibin;
 #if defined(LAMMPS_MEMALIGN)
     void *ptr;
+#if defined(LMP_USE_TBB_ALLOCATOR)
+    ptr = scalable_aligned_malloc(sizeof(T) * chunkperpage * chunksize[ibin], LAMMPS_MEMALIGN);
+#else
     if (posix_memalign(&ptr, LAMMPS_MEMALIGN, sizeof(T) * chunkperpage * chunksize[ibin]))
       errorflag = 2;
+#endif
     pages[i] = (T *) ptr;
 #else
     pages[i] = (T *) malloc(sizeof(T) * chunkperpage * chunksize[ibin]);


### PR DESCRIPTION
**Summary**

This PR fixes several compilation errors encountered when building LAMMPS on Windows using the Intel oneAPI toolchain (IntelLLVM). It also refines the integration of the TBB scalable allocator to ensure it is correctly detected and utilized by the modern icx compiler.

**Author(s)**

Léo Dontot <leo.dontot@gmail.com> - Institut des Matériaux de Nantes Jean Rouxel (IMN), Université de Nantes, CNRS.

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Implementation Notes**

CMake : Added IntelLLVM to the supported compiler list for MSVC-compatible environments and the correct /fp:precise and /std:c++17 compiler options for windows.
memory.cpp / my_page.cpp / my_pool_chunk.cpp : Updated the preprocessor logic to recognize __INTEL_LLVM_COMPILER, allowing the use of TBB's scalable_allocator with the new oneAPI compiler.
