### PR TITLE
Add ENERGY_ONLY bit to eflag parameter for force computation

### DIFF
--- a/src/DIELECTRIC/fix_polarize_bem_gmres.cpp
+++ b/src/DIELECTRIC/fix_polarize_bem_gmres.cpp
@@ -350,8 +350,10 @@ void FixPolarizeBEMGMRES::compute_induced_charges()
   double *em = atom->em;
   double *epsilon = atom->epsilon;
   int nlocal = atom->nlocal;
-  int eflag = 1;
-  int vflag = 0;
+
+  // flag that we only need to compute the global energy
+  int eflag = ENERGY_GLOBAL | ENERGY_ONLY;
+  int vflag = VIRIAL_NONE;
 
   // compute the right hand side (vector b) of Eq. (40) according to Eq. (42)
   // keep the scaled real charges intact here to compute efield for the right hand side (b)

--- a/src/DIELECTRIC/fix_polarize_bem_icc.cpp
+++ b/src/DIELECTRIC/fix_polarize_bem_icc.cpp
@@ -255,9 +255,11 @@ void FixPolarizeBEMICC::compute_induced_charges()
   double *epsilon = atom->epsilon;
   int *mask = atom->mask;
   int nlocal = atom->nlocal;
-  int eflag = 1;
-  int vflag = 0;
   int itr;
+
+  // flag that we only need to compute the global energy
+  int eflag = ENERGY_GLOBAL | ENERGY_ONLY;
+  int vflag = VIRIAL_NONE;
 
   // use Eq. (64) in Barros et al. to initialize the induced charges
   // Note: area[i] is included here to ensure correct charge unit

--- a/src/EXTRA-FIX/fix_numdiff.cpp
+++ b/src/EXTRA-FIX/fix_numdiff.cpp
@@ -296,18 +296,20 @@ double FixNumDiff::update_energy()
 {
   force_clear(atom->f);
 
-  int eflag = 1;
+  // flag that we only need to compute the global energy
+  int eflag = ENERGY_GLOBAL | ENERGY_ONLY;
+  int vflag = VIRIAL_NONE;
 
-  if (pair_compute_flag) force->pair->compute(eflag, 0);
+  if (pair_compute_flag) force->pair->compute(eflag, vflag);
 
   if (atom->molecular != Atom::ATOMIC) {
-    if (force->bond) force->bond->compute(eflag, 0);
-    if (force->angle) force->angle->compute(eflag, 0);
-    if (force->dihedral) force->dihedral->compute(eflag, 0);
-    if (force->improper) force->improper->compute(eflag, 0);
+    if (force->bond) force->bond->compute(eflag, vflag);
+    if (force->angle) force->angle->compute(eflag, vflag);
+    if (force->dihedral) force->dihedral->compute(eflag, vflag);
+    if (force->improper) force->improper->compute(eflag, vflag);
   }
 
-  if (kspace_compute_flag) force->kspace->compute(eflag, 0);
+  if (kspace_compute_flag) force->kspace->compute(eflag, vflag);
 
   double energy = pe->compute_scalar();
   return energy;

--- a/src/EXTRA-FIX/fix_numdiff_virial.cpp
+++ b/src/EXTRA-FIX/fix_numdiff_virial.cpp
@@ -272,18 +272,20 @@ void FixNumDiffVirial::restore_atoms(int nall, int idir)
 
 double FixNumDiffVirial::update_energy()
 {
-  int eflag = 1;
+  // flag that we only need to compute the global energy
+  int eflag = ENERGY_GLOBAL | ENERGY_ONLY;
+  int vflag = VIRIAL_NONE;
 
-  if (pair_compute_flag) force->pair->compute(eflag, 0);
+  if (pair_compute_flag) force->pair->compute(eflag, vflag);
 
   if (atom->molecular != Atom::ATOMIC) {
-    if (force->bond) force->bond->compute(eflag, 0);
-    if (force->angle) force->angle->compute(eflag, 0);
-    if (force->dihedral) force->dihedral->compute(eflag, 0);
-    if (force->improper) force->improper->compute(eflag, 0);
+    if (force->bond) force->bond->compute(eflag, vflag);
+    if (force->angle) force->angle->compute(eflag, vflag);
+    if (force->dihedral) force->dihedral->compute(eflag, vflag);
+    if (force->improper) force->improper->compute(eflag, vflag);
   }
 
-  if (kspace_compute_flag) force->kspace->compute(eflag, 0);
+  if (kspace_compute_flag) force->kspace->compute(eflag, vflag);
 
   double energy = pe->compute_scalar();
   return energy;

--- a/src/FEP/compute_fep.cpp
+++ b/src/FEP/compute_fep.cpp
@@ -268,8 +268,9 @@ void ComputeFEP::compute_vector()
 {
   double pe0, pe1;
 
-  eflag = 1;
-  vflag = 0;
+  // flag that we only need to compute the global energy
+  int eflag = ENERGY_GLOBAL | ENERGY_ONLY;
+  int vflag = VIRIAL_NONE;
 
   invoked_vector = update->ntimestep;
 

--- a/src/FEP/compute_fep.h
+++ b/src/FEP/compute_fep.h
@@ -41,7 +41,6 @@ class ComputeFEP : public Compute {
   int chgflag;
   int tailflag, volumeflag;
   int fepinitflag;
-  int eflag, vflag;
   double temp_fep;
 
   int nmax;

--- a/src/FEP/compute_fep_ta.cpp
+++ b/src/FEP/compute_fep_ta.cpp
@@ -149,8 +149,9 @@ void ComputeFEPTA::compute_vector()
 {
   double pe0, pe1;
 
-  eflag = 1;
-  vflag = 0;
+  // flag that we only need to compute the global energy
+  int eflag = ENERGY_GLOBAL | ENERGY_ONLY;
+  int vflag = VIRIAL_NONE;
 
   invoked_vector = update->ntimestep;
 

--- a/src/FEP/compute_fep_ta.h
+++ b/src/FEP/compute_fep_ta.h
@@ -38,7 +38,6 @@ class ComputeFEPTA : public Compute {
  private:
   int tailflag;
   int fepinitflag;
-  int eflag, vflag;
   double temp_fep;
   double scale_factor;
   int tan_axis1, tan_axis2, norm_axis;

--- a/src/MC/fix_atom_swap.cpp
+++ b/src/MC/fix_atom_swap.cpp
@@ -662,8 +662,9 @@ int FixAtomSwap::attempt_swap()
 
 double FixAtomSwap::energy_full()
 {
-  int eflag = 1;
-  int vflag = 0;
+  // flag that we only need to compute the global energy
+  int eflag = ENERGY_GLOBAL | ENERGY_ONLY;
+  int vflag = VIRIAL_NONE;
 
   if (modify->n_pre_force) modify->pre_force(vflag);
 

--- a/src/MC/fix_charge_regulation.cpp
+++ b/src/MC/fix_charge_regulation.cpp
@@ -1125,6 +1125,11 @@ int FixChargeRegulation::get_random_particle(int ptype, double charge, double rd
 /* ---------------------------------------------------------------------- */
 
 double FixChargeRegulation::energy_full() {
+
+  // flag that we only need to compute the global energy
+  int eflag = ENERGY_GLOBAL | ENERGY_ONLY;
+  int vflag = VIRIAL_NONE;
+
   if (triclinic) domain->x2lamda(atom->nlocal);
   domain->pbc();
   comm->exchange();
@@ -1133,8 +1138,7 @@ double FixChargeRegulation::energy_full() {
   if (triclinic) domain->lamda2x(atom->nlocal + atom->nghost);
   if (modify->n_pre_neighbor) modify->pre_neighbor();
   neighbor->build(1);
-  int eflag = 1;
-  int vflag = 0;
+
   if (overlap_flag) {
     int overlaptestall;
     int overlaptest = 0;

--- a/src/MC/fix_gcmc.cpp
+++ b/src/MC/fix_gcmc.cpp
@@ -2329,8 +2329,10 @@ double FixGCMC::energy_full()
   if (triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
   if (modify->n_pre_neighbor) modify->pre_neighbor();
   neighbor->build(1);
-  int eflag = 1;
-  int vflag = 0;
+
+  // flag that we only need to compute the global energy
+  int eflag = ENERGY_GLOBAL | ENERGY_ONLY;
+  int vflag = VIRIAL_NONE;
 
   // if overlap check requested, if overlap,
   // return signal value for energy

--- a/src/MC/fix_mol_swap.cpp
+++ b/src/MC/fix_mol_swap.cpp
@@ -429,8 +429,9 @@ int FixMolSwap::attempt_swap()
 
 double FixMolSwap::energy_full()
 {
-  int eflag = 1;
-  int vflag = 0;
+  // flag that we only need to compute the global energy
+  int eflag = ENERGY_GLOBAL | ENERGY_ONLY;
+  int vflag = VIRIAL_NONE;
 
   if (modify->n_pre_force) modify->pre_force(vflag);
 

--- a/src/MC/fix_neighbor_swap.cpp
+++ b/src/MC/fix_neighbor_swap.cpp
@@ -632,8 +632,9 @@ int FixNeighborSwap::attempt_swap()
 
 double FixNeighborSwap::energy_full()
 {
-  int eflag = 1;
-  int vflag = 0;
+  // flag that we only need to compute the global energy
+  int eflag = ENERGY_GLOBAL | ENERGY_ONLY;
+  int vflag = VIRIAL_NONE;
 
   if (modify->n_pre_force) modify->pre_force(vflag);
 

--- a/src/MC/fix_sgcmc.cpp
+++ b/src/MC/fix_sgcmc.cpp
@@ -896,8 +896,9 @@ double FixSemiGrandCanonicalMC::computeEnergyChangeGeneric(int flipAtom, int old
  *********************************************************************/
 double FixSemiGrandCanonicalMC::computeTotalEnergy()
 {
-  int eflag = 1;
-  int vflag = 0;
+  // flag that we only need to compute the global energy
+  int eflag = ENERGY_GLOBAL | ENERGY_ONLY;
+  int vflag = VIRIAL_NONE;
 
   if (force->pair) force->pair->compute(eflag,vflag);
 

--- a/src/MC/fix_widom.cpp
+++ b/src/MC/fix_widom.cpp
@@ -1055,8 +1055,10 @@ double FixWidom::energy_full()
   if (triclinic) domain->lamda2x(atom->nlocal+atom->nghost);
   if (modify->n_pre_neighbor) modify->pre_neighbor();
   neighbor->build(1);
-  int eflag = 1;
-  int vflag = 0;
+
+  // flag that we only need to compute the global energy
+  int eflag = ENERGY_GLOBAL | ENERGY_ONLY;
+  int vflag = VIRIAL_NONE;
 
   // clear forces so they don't accumulate over multiple
   // calls within fix widom timestep

--- a/src/angle.cpp
+++ b/src/angle.cpp
@@ -100,6 +100,7 @@ void Angle::settings(int narg, char **args)
      eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
      eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
      eflag_either != 0 if eflag_global or eflag_atom is set
+     eflag_only   != 0 if ENERGY_ONLY bit of eflag set
      vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
      vflag_atom   != 0 if VIRIAL_ATOM bit of vflag set
      vflag_atom   != 0 if VIRIAL_CENTROID bit of vflag set
@@ -118,6 +119,7 @@ void Angle::ev_setup(int eflag, int vflag, int alloc)
   eflag_either = eflag;
   eflag_global = eflag & ENERGY_GLOBAL;
   eflag_atom = eflag & ENERGY_ATOM;
+  eflag_only = eflag & ENERGY_ONLY;
 
   vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
   vflag_atom = vflag & VIRIAL_ATOM;

--- a/src/angle.cpp
+++ b/src/angle.cpp
@@ -97,15 +97,15 @@ void Angle::settings(int narg, char **args)
    see integrate::ev_set() for bitwise settings of eflag/vflag
    set the following flags, values are otherwise set to 0:
      evflag       != 0 if any bits of eflag or vflag are set
-     eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
-     eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
+     eflag_global != 0 if ENERGY_GLOBAL bit of eflag is set
+     eflag_atom   != 0 if ENERGY_ATOM bit of eflag is set
      eflag_either != 0 if eflag_global or eflag_atom is set
-     eflag_only   != 0 if ENERGY_ONLY bit of eflag set
-     vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
-     vflag_atom   != 0 if VIRIAL_ATOM bit of vflag set
-     vflag_atom   != 0 if VIRIAL_CENTROID bit of vflag set
+     eflag_only   != 0 if ENERGY_GLOBAL and ENERGY_ONLY bits of eflag are set
+     vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag is set
+     vflag_atom   != 0 if VIRIAL_ATOM bit of vflag is set
+     vflag_atom   != 0 if VIRIAL_CENTROID bit of vflag is set
                        and centroidstressflag != CENTROID_AVAIL
-     cvflag_atom  != 0 if VIRIAL_CENTROID bit of vflag set
+     cvflag_atom  != 0 if VIRIAL_CENTROID bit of vflag is set
                        and centroidstressflag = CENTROID_AVAIL
      vflag_either != 0 if any of vflag_global, vflag_atom, cvflag_atom is set
 ------------------------------------------------------------------------- */
@@ -116,10 +116,10 @@ void Angle::ev_setup(int eflag, int vflag, int alloc)
 
   evflag = 1;
 
-  eflag_either = eflag;
+  eflag_either = eflag & (ENERGY_GLOBAL | ENERGY_ATOM);
   eflag_global = eflag & ENERGY_GLOBAL;
   eflag_atom = eflag & ENERGY_ATOM;
-  eflag_only = eflag & ENERGY_ONLY;
+  eflag_only = eflag_global ? (eflag & ENERGY_ONLY) : 0;
 
   vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
   vflag_atom = vflag & VIRIAL_ATOM;

--- a/src/angle.h
+++ b/src/angle.h
@@ -74,7 +74,7 @@ class Angle : protected Pointers {
   int suffix_flag;    // suffix compatibility flag
 
   int evflag;
-  int eflag_either, eflag_global, eflag_atom;
+  int eflag_either, eflag_global, eflag_atom, eflag_only;
   int vflag_either, vflag_global, vflag_atom, cvflag_atom;
   int maxeatom, maxvatom, maxcvatom;
 
@@ -83,8 +83,8 @@ class Angle : protected Pointers {
     if (eflag || vflag)
       ev_setup(eflag, vflag, alloc);
     else
-      evflag = eflag_either = eflag_global = eflag_atom = vflag_either = vflag_global = vflag_atom =
-          cvflag_atom = 0;
+      evflag = eflag_either = eflag_global = eflag_atom = eflag_only = vflag_either = vflag_global =
+          vflag_atom = cvflag_atom = 0;
   }
   void ev_setup(int, int, int alloc = 1);
   void ev_tally(int, int, int, int, int, double, double *, double *, double, double, double, double,

--- a/src/bond.cpp
+++ b/src/bond.cpp
@@ -108,6 +108,7 @@ void Bond::settings(int narg, char **args)
      eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
      eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
      eflag_either != 0 if eflag_global or eflag_atom is set
+     eflag_only   != 0 if ENERGY_ONLY bit of eflag set
      vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
      vflag_atom   != 0 if VIRIAL_ATOM or VIRIAL_CENTROID bit of vflag set
                        two-body and centroid stress are identical for bonds
@@ -123,6 +124,7 @@ void Bond::ev_setup(int eflag, int vflag, int alloc)
   eflag_either = eflag;
   eflag_global = eflag & ENERGY_GLOBAL;
   eflag_atom = eflag & ENERGY_ATOM;
+  eflag_only = eflag & ENERGY_ONLY;
 
   vflag_either = vflag;
   vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);

--- a/src/bond.cpp
+++ b/src/bond.cpp
@@ -105,12 +105,12 @@ void Bond::settings(int narg, char **args)
    see integrate::ev_set() for bitwise settings of eflag/vflag
    set the following flags, values are otherwise set to 0:
      evflag       != 0 if any bits of eflag or vflag are set
-     eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
-     eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
+     eflag_global != 0 if ENERGY_GLOBAL bit of eflag is set
+     eflag_atom   != 0 if ENERGY_ATOM bit of eflag is set
      eflag_either != 0 if eflag_global or eflag_atom is set
-     eflag_only   != 0 if ENERGY_ONLY bit of eflag set
-     vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
-     vflag_atom   != 0 if VIRIAL_ATOM or VIRIAL_CENTROID bit of vflag set
+     eflag_only   != 0 if ENERGY_GLOBAL and ENERGY_ONLY bits of eflag are set
+     vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag is set
+     vflag_atom   != 0 if VIRIAL_ATOM or VIRIAL_CENTROID bit of vflag is set
                        two-body and centroid stress are identical for bonds
      vflag_either != 0 if vflag_global or vflag_atom is set
 ------------------------------------------------------------------------- */
@@ -121,10 +121,10 @@ void Bond::ev_setup(int eflag, int vflag, int alloc)
 
   evflag = 1;
 
-  eflag_either = eflag;
+  eflag_either = eflag & (ENERGY_GLOBAL | ENERGY_ATOM);
   eflag_global = eflag & ENERGY_GLOBAL;
   eflag_atom = eflag & ENERGY_ATOM;
-  eflag_only = eflag & ENERGY_ONLY;
+  eflag_only = eflag_global ? (eflag & ENERGY_ONLY) : 0;
 
   vflag_either = vflag;
   vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);

--- a/src/bond.h
+++ b/src/bond.h
@@ -88,7 +88,7 @@ class Bond : protected Pointers {
   int suffix_flag;    // suffix compatibility flag
 
   int evflag;
-  int eflag_either, eflag_global, eflag_atom;
+  int eflag_either, eflag_global, eflag_atom, eflag_only;
   int vflag_either, vflag_global, vflag_atom;
   int maxeatom, maxvatom;
 
@@ -97,8 +97,8 @@ class Bond : protected Pointers {
     if (eflag || vflag)
       ev_setup(eflag, vflag, alloc);
     else
-      evflag = eflag_either = eflag_global = eflag_atom = vflag_either = vflag_global = vflag_atom =
-          0;
+      evflag = eflag_either = eflag_global = eflag_atom = eflag_only = vflag_either = vflag_global =
+          vflag_atom = 0;
   }
   void ev_setup(int, int, int alloc = 1);
   void ev_tally(int, int, int, int, double, double, double, double, double);

--- a/src/dihedral.cpp
+++ b/src/dihedral.cpp
@@ -99,6 +99,7 @@ void Dihedral::settings(int narg, char **args)
      eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
      eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
      eflag_either != 0 if eflag_global or eflag_atom is set
+     eflag_only   != 0 if ENERGY_ONLY bit of eflag set
      vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
      vflag_atom   != 0 if VIRIAL_ATOM bit of vflag set
      vflag_atom   != 0 if VIRIAL_CENTROID bit of vflag set
@@ -117,6 +118,7 @@ void Dihedral::ev_setup(int eflag, int vflag, int alloc)
   eflag_either = eflag;
   eflag_global = eflag & ENERGY_GLOBAL;
   eflag_atom = eflag & ENERGY_ATOM;
+  eflag_only = eflag & ENERGY_ONLY;
 
   vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
   vflag_atom = vflag & VIRIAL_ATOM;

--- a/src/dihedral.cpp
+++ b/src/dihedral.cpp
@@ -96,15 +96,15 @@ void Dihedral::settings(int narg, char **args)
    see integrate::ev_set() for bitwise settings of eflag/vflag
    set the following flags, values are otherwise set to 0:
      evflag       != 0 if any bits of eflag or vflag are set
-     eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
-     eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
+     eflag_global != 0 if ENERGY_GLOBAL bit of eflag is set
+     eflag_atom   != 0 if ENERGY_ATOM bit of eflag is set
      eflag_either != 0 if eflag_global or eflag_atom is set
-     eflag_only   != 0 if ENERGY_ONLY bit of eflag set
-     vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
-     vflag_atom   != 0 if VIRIAL_ATOM bit of vflag set
-     vflag_atom   != 0 if VIRIAL_CENTROID bit of vflag set
+     eflag_only   != 0 if ENERGY_GLOBAL and ENERGY_ONLY bits of eflag are set
+     vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag is set
+     vflag_atom   != 0 if VIRIAL_ATOM bit of vflag is set
+     vflag_atom   != 0 if VIRIAL_CENTROID bit of vflag is set
                        and centroidstressflag != CENTROID_AVAIL
-     cvflag_atom  != 0 if VIRIAL_CENTROID bit of vflag set
+     cvflag_atom  != 0 if VIRIAL_CENTROID bit of vflag is set
                        and centroidstressflag = CENTROID_AVAIL
      vflag_either != 0 if any of vflag_global, vflag_atom, cvflag_atom is set
 ------------------------------------------------------------------------- */
@@ -115,10 +115,10 @@ void Dihedral::ev_setup(int eflag, int vflag, int alloc)
 
   evflag = 1;
 
-  eflag_either = eflag;
+  eflag_either = eflag & (ENERGY_GLOBAL | ENERGY_ATOM);
   eflag_global = eflag & ENERGY_GLOBAL;
   eflag_atom = eflag & ENERGY_ATOM;
-  eflag_only = eflag & ENERGY_ONLY;
+  eflag_only = eflag_global ? (eflag & ENERGY_ONLY) : 0;
 
   vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
   vflag_atom = vflag & VIRIAL_ATOM;

--- a/src/dihedral.h
+++ b/src/dihedral.h
@@ -37,8 +37,8 @@ class Dihedral : protected Pointers {
                              // CENTROID_AVAIL = different and implemented
                              // CENTROID_NOTAVAIL = different, not yet implemented
 
-  int reinitflag;            // 0 if not compatible with fix adapt
-                             // extract() method may still need to be added
+  int reinitflag;    // 0 if not compatible with fix adapt
+                     // extract() method may still need to be added
 
   // KOKKOS host/device flag and data masks
 
@@ -72,7 +72,7 @@ class Dihedral : protected Pointers {
   int suffix_flag;    // suffix compatibility flag
 
   int evflag;
-  int eflag_either, eflag_global, eflag_atom;
+  int eflag_either, eflag_global, eflag_atom, eflag_only;
   int vflag_either, vflag_global, vflag_atom, cvflag_atom;
   int maxeatom, maxvatom, maxcvatom;
 
@@ -81,8 +81,8 @@ class Dihedral : protected Pointers {
     if (eflag || vflag)
       ev_setup(eflag, vflag, alloc);
     else
-      evflag = eflag_either = eflag_global = eflag_atom = vflag_either = vflag_global = vflag_atom =
-          cvflag_atom = 0;
+      evflag = eflag_either = eflag_global = eflag_atom = eflag_only = vflag_either = vflag_global =
+          vflag_atom = cvflag_atom = 0;
   }
   void ev_setup(int, int, int alloc = 1);
   void ev_tally(int, int, int, int, int, int, double, double *, double *, double *, double, double,

--- a/src/fix.cpp
+++ b/src/fix.cpp
@@ -198,6 +198,9 @@ void::Fix::set_molecule(int, tagint, int, double *, double *, double *)
    if thermo_energy is not set, energy tallying is disabled
    if thermo_virial is not set, virial tallying is disabled
    global energy is tallied separately, output by compute_scalar() method
+   ENERGY_ONLY flag should only be set manually and may be ignored
+   it is meant to be used for cases where computation of only the
+   energy is *much* faster.
 ------------------------------------------------------------------------- */
 
 void Fix::ev_setup(int eflag, int vflag)
@@ -206,11 +209,12 @@ void Fix::ev_setup(int eflag, int vflag)
 
   evflag = 1;
 
-  if (!thermo_energy) eflag_either = eflag_global = eflag_atom = 0;
+  if (!thermo_energy) eflag_either = eflag_global = eflag_atom = eflag_only = 0;
   else {
     eflag_either = eflag;
     eflag_global = eflag & ENERGY_GLOBAL;
     eflag_atom = eflag & ENERGY_ATOM;
+    eflag_only = eflag & ENERGY_ONLY;
   }
 
   if (!thermo_virial) vflag_either = vflag_global = vflag_atom = 0;

--- a/src/fix.cpp
+++ b/src/fix.cpp
@@ -211,10 +211,10 @@ void Fix::ev_setup(int eflag, int vflag)
 
   if (!thermo_energy) eflag_either = eflag_global = eflag_atom = eflag_only = 0;
   else {
-    eflag_either = eflag;
+    eflag_either = eflag & (ENERGY_GLOBAL | ENERGY_ATOM);
     eflag_global = eflag & ENERGY_GLOBAL;
     eflag_atom = eflag & ENERGY_ATOM;
-    eflag_only = eflag & ENERGY_ONLY;
+    eflag_only = eflag_global ? (eflag & ENERGY_ONLY) : 0;
   }
 
   if (!thermo_virial) vflag_either = vflag_global = vflag_atom = 0;

--- a/src/fix.h
+++ b/src/fix.h
@@ -49,37 +49,37 @@ class Fix : protected Pointers {
   };
   // clang-format on
 
-  bigint next_reneighbor;      // next timestep to force a reneighboring
-  int nevery;                  // how often to call an end_of_step fix
-  int thermo_energy;           // 1 if fix_modify energy enabled, 0 if not
-  int thermo_virial;           // 1 if fix_modify virial enabled, 0 if not
-  int thermo_modify_colname;   // 1 if fix has custom column names for output
-  int energy_global_flag;      // 1 if contributes to global eng
-  int energy_peratom_flag;     // 1 if contributes to peratom eng
-  int virial_global_flag;      // 1 if contributes to global virial
-  int virial_peratom_flag;     // 1 if contributes to peratom virial
-  int ecouple_flag;            // 1 if thermostat fix outputs cumulative
-                               //      reservoir energy via compute_scalar()
-  int time_integrate;          // 1 if performs time integration, 0 if no
-  int rigid_flag;              // 1 if integrates rigid bodies, 0 if not
-  int no_change_box;           // 1 if cannot swap ortho <-> triclinic
-  int time_depend;             // 1 if requires continuous timestepping
-  int create_attribute;        // 1 if fix stores attributes that need
-                               //      setting when a new atom is created
-  int restart_pbc;             // 1 if fix moves atoms (except integrate)
-                               //      so write_restart must remap to PBC
-  int wd_header;               // # of header values fix writes to data file
-  int wd_section;              // # of sections fix writes to data file
-  int dynamic_group_allow;     // 1 if can be used with dynamic group, else 0
-  int dof_flag;                // 1 if has dof() method (not min_dof())
-  int special_alter_flag;      // 1 if has special_alter() meth for spec lists
-  int respa_level_support;     // 1 if fix supports fix_modify respa
-  int respa_level;             // which respa level to apply fix (1-Nrespa)
-  int maxexchange;             // max # of per-atom values for Comm::exchange()
-  int maxexchange_dynamic;     // 1 if fix sets maxexchange dynamically
-  int pre_exchange_migrate;    // 1 if fix migrates atoms in pre_exchange()
-  int stores_ids;              // 1 if fix stores atom IDs
-  int diam_flag;               // 1 if fix may change partical diameter
+  bigint next_reneighbor;       // next timestep to force a reneighboring
+  int nevery;                   // how often to call an end_of_step fix
+  int thermo_energy;            // 1 if fix_modify energy enabled, 0 if not
+  int thermo_virial;            // 1 if fix_modify virial enabled, 0 if not
+  int thermo_modify_colname;    // 1 if fix has custom column names for output
+  int energy_global_flag;       // 1 if contributes to global eng
+  int energy_peratom_flag;      // 1 if contributes to peratom eng
+  int virial_global_flag;       // 1 if contributes to global virial
+  int virial_peratom_flag;      // 1 if contributes to peratom virial
+  int ecouple_flag;             // 1 if thermostat fix outputs cumulative
+                                //      reservoir energy via compute_scalar()
+  int time_integrate;           // 1 if performs time integration, 0 if no
+  int rigid_flag;               // 1 if integrates rigid bodies, 0 if not
+  int no_change_box;            // 1 if cannot swap ortho <-> triclinic
+  int time_depend;              // 1 if requires continuous timestepping
+  int create_attribute;         // 1 if fix stores attributes that need
+                                //      setting when a new atom is created
+  int restart_pbc;              // 1 if fix moves atoms (except integrate)
+                                //      so write_restart must remap to PBC
+  int wd_header;                // # of header values fix writes to data file
+  int wd_section;               // # of sections fix writes to data file
+  int dynamic_group_allow;      // 1 if can be used with dynamic group, else 0
+  int dof_flag;                 // 1 if has dof() method (not min_dof())
+  int special_alter_flag;       // 1 if has special_alter() meth for spec lists
+  int respa_level_support;      // 1 if fix supports fix_modify respa
+  int respa_level;              // which respa level to apply fix (1-Nrespa)
+  int maxexchange;              // max # of per-atom values for Comm::exchange()
+  int maxexchange_dynamic;      // 1 if fix sets maxexchange dynamically
+  int pre_exchange_migrate;     // 1 if fix migrates atoms in pre_exchange()
+  int stores_ids;               // 1 if fix stores atom IDs
+  int diam_flag;                // 1 if fix may change partical diameter
 
   int scalar_flag;                 // 0/1 if compute_scalar() function exists
   int vector_flag;                 // 0/1 if compute_vector() function exists
@@ -238,7 +238,7 @@ class Fix : protected Pointers {
   virtual double compute_scalar() { return 0.0; }
   virtual double compute_vector(int) { return 0.0; }
   virtual double compute_array(int, int) { return 0.0; }
-  virtual std::string get_thermo_colname(int) { return {};  }
+  virtual std::string get_thermo_colname(int) { return {}; }
 
   virtual bigint dof(int) { return 0; }
   virtual void deform(int) {}
@@ -273,7 +273,7 @@ class Fix : protected Pointers {
   int instance_me;    // which Fix class instantiation I am
 
   int evflag;
-  int eflag_either, eflag_global, eflag_atom;
+  int eflag_either, eflag_global, eflag_atom, eflag_only;
   int vflag_either, vflag_global, vflag_atom, cvflag_atom;
   int maxeatom, maxvatom, maxcvatom;
 
@@ -287,8 +287,8 @@ class Fix : protected Pointers {
     if ((eflag && thermo_energy) || (vflag && thermo_virial))
       ev_setup(eflag, vflag);
     else
-      evflag = eflag_either = eflag_global = eflag_atom = vflag_either = vflag_global = vflag_atom =
-          cvflag_atom = 0;
+      evflag = eflag_either = eflag_global = eflag_atom = eflag_only = vflag_either = vflag_global =
+          vflag_atom = cvflag_atom = 0;
   }
   void ev_setup(int, int);
   void ev_tally(int, int *, double, double, double *);

--- a/src/fix.h
+++ b/src/fix.h
@@ -79,7 +79,7 @@ class Fix : protected Pointers {
   int maxexchange_dynamic;      // 1 if fix sets maxexchange dynamically
   int pre_exchange_migrate;     // 1 if fix migrates atoms in pre_exchange()
   int stores_ids;               // 1 if fix stores atom IDs
-  int diam_flag;                // 1 if fix may change partical diameter
+  int diam_flag;                // 1 if fix may change particle diameter
 
   int scalar_flag;                 // 0/1 if compute_scalar() function exists
   int vector_flag;                 // 0/1 if compute_vector() function exists

--- a/src/force.h
+++ b/src/force.h
@@ -26,9 +26,14 @@ class Improper;
 class KSpace;
 class Pair;
 
-enum { ENERGY_NONE = 0x00, ENERGY_GLOBAL = 0x01, ENERGY_ATOM = 0x02 };
-
 // clang-format off
+enum {
+  ENERGY_NONE   = 0x00,
+  ENERGY_GLOBAL = 0x01,
+  ENERGY_ATOM   = 0x02,
+  ENERGY_ONLY   = 0x04
+};
+
 enum {
   VIRIAL_NONE     = 0x00,
   VIRIAL_PAIR     = 0x01,
@@ -36,9 +41,13 @@ enum {
   VIRIAL_ATOM     = 0x04,
   VIRIAL_CENTROID = 0x08
 };
-// clang-format on
 
-enum { CENTROID_SAME = 0, CENTROID_AVAIL = 1, CENTROID_NOTAVAIL = 2 };
+enum {
+  CENTROID_SAME     = 0x00,
+  CENTROID_AVAIL    = 0x01,
+  CENTROID_NOTAVAIL = 0x02
+};
+// clang-format on
 
 class Force : protected Pointers {
  public:

--- a/src/improper.cpp
+++ b/src/improper.cpp
@@ -99,6 +99,7 @@ void Improper::settings(int narg, char **args)
      eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
      eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
      eflag_either != 0 if eflag_global or eflag_atom is set
+     eflag_only   != 0 if ENERGY_ONLY bit of eflag set
      vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
      vflag_atom   != 0 if VIRIAL_ATOM bit of vflag set
      vflag_atom   != 0 if VIRIAL_CENTROID bit of vflag set
@@ -117,6 +118,7 @@ void Improper::ev_setup(int eflag, int vflag, int alloc)
   eflag_either = eflag;
   eflag_global = eflag & ENERGY_GLOBAL;
   eflag_atom = eflag & ENERGY_ATOM;
+  eflag_only = eflag & ENERGY_ONLY;
 
   vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
   vflag_atom = vflag & VIRIAL_ATOM;

--- a/src/improper.cpp
+++ b/src/improper.cpp
@@ -96,15 +96,15 @@ void Improper::settings(int narg, char **args)
    see integrate::ev_set() for bitwise settings of eflag/vflag
    set the following flags, values are otherwise set to 0:
      evflag       != 0 if any bits of eflag or vflag are set
-     eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
-     eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
+     eflag_global != 0 if ENERGY_GLOBAL bit of eflag is set
+     eflag_atom   != 0 if ENERGY_ATOM bit of eflag is set
      eflag_either != 0 if eflag_global or eflag_atom is set
-     eflag_only   != 0 if ENERGY_ONLY bit of eflag set
-     vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
-     vflag_atom   != 0 if VIRIAL_ATOM bit of vflag set
-     vflag_atom   != 0 if VIRIAL_CENTROID bit of vflag set
+     eflag_only   != 0 if ENERGY_GLOBAL and ENERGY_ONLY bits of eflag are set
+     vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bits of vflag is set
+     vflag_atom   != 0 if VIRIAL_ATOM bit of vflag is set
+     vflag_atom   != 0 if VIRIAL_CENTROID bit of vflag is set
                        and centroidstressflag != CENTROID_AVAIL
-     cvflag_atom  != 0 if VIRIAL_CENTROID bit of vflag set
+     cvflag_atom  != 0 if VIRIAL_CENTROID bit of vflag is set
                        and centroidstressflag = CENTROID_AVAIL
      vflag_either != 0 if any of vflag_global, vflag_atom, cvflag_atom is set
 ------------------------------------------------------------------------- */
@@ -115,10 +115,10 @@ void Improper::ev_setup(int eflag, int vflag, int alloc)
 
   evflag = 1;
 
-  eflag_either = eflag;
+  eflag_either = eflag & (ENERGY_GLOBAL | ENERGY_ATOM);
   eflag_global = eflag & ENERGY_GLOBAL;
   eflag_atom = eflag & ENERGY_ATOM;
-  eflag_only = eflag & ENERGY_ONLY;
+  eflag_only = eflag_global ? (eflag & ENERGY_ONLY) : 0;
 
   vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);
   vflag_atom = vflag & VIRIAL_ATOM;

--- a/src/improper.cpp
+++ b/src/improper.cpp
@@ -100,7 +100,7 @@ void Improper::settings(int narg, char **args)
      eflag_atom   != 0 if ENERGY_ATOM bit of eflag is set
      eflag_either != 0 if eflag_global or eflag_atom is set
      eflag_only   != 0 if ENERGY_GLOBAL and ENERGY_ONLY bits of eflag are set
-     vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bits of vflag is set
+     vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag is set
      vflag_atom   != 0 if VIRIAL_ATOM bit of vflag is set
      vflag_atom   != 0 if VIRIAL_CENTROID bit of vflag is set
                        and centroidstressflag != CENTROID_AVAIL

--- a/src/improper.h
+++ b/src/improper.h
@@ -77,7 +77,7 @@ class Improper : protected Pointers {
   int suffix_flag;    // suffix compatibility flag
 
   int evflag;
-  int eflag_either, eflag_global, eflag_atom;
+  int eflag_either, eflag_global, eflag_atom, eflag_only;
   int vflag_either, vflag_global, vflag_atom, cvflag_atom;
   int maxeatom, maxvatom, maxcvatom;
 
@@ -86,8 +86,8 @@ class Improper : protected Pointers {
     if (eflag || vflag)
       ev_setup(eflag, vflag, alloc);
     else
-      evflag = eflag_either = eflag_global = eflag_atom = vflag_either = vflag_global = vflag_atom =
-          cvflag_atom = 0;
+      evflag = eflag_either = eflag_global = eflag_atom = eflag_only = vflag_either = vflag_global =
+          vflag_atom = cvflag_atom = 0;
   }
   void ev_setup(int, int, int alloc = 1);
   void ev_tally(int, int, int, int, int, int, double, double *, double *, double *, double, double,

--- a/src/kspace.cpp
+++ b/src/kspace.cpp
@@ -226,6 +226,7 @@ void KSpace::pair_check()
      eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
      eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
      eflag_either != 0 if eflag_global or eflag_atom is set
+     eflag_only   != 0 if ENERGY_ONLY bit of eflag set
      vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
      vflag_atom   != 0 if VIRIAL_ATOM bit of vflag set
                        no current support for centroid stress
@@ -242,6 +243,7 @@ void KSpace::ev_setup(int eflag, int vflag, int alloc)
   eflag_either = eflag;
   eflag_global = eflag & ENERGY_GLOBAL;
   eflag_atom = eflag & ENERGY_ATOM;
+  eflag_only = eflag & ENERGY_ONLY;
 
   vflag_either = vflag;
   vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);

--- a/src/kspace.cpp
+++ b/src/kspace.cpp
@@ -223,12 +223,12 @@ void KSpace::pair_check()
    see integrate::ev_set() for bitwise settings of eflag/vflag
    set the following flags, values are otherwise set to 0:
      evflag       != 0 if any bits of eflag or vflag are set
-     eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
-     eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
+     eflag_global != 0 if ENERGY_GLOBAL bit of eflag is set
+     eflag_atom   != 0 if ENERGY_ATOM bit of eflag is set
      eflag_either != 0 if eflag_global or eflag_atom is set
-     eflag_only   != 0 if ENERGY_ONLY bit of eflag set
-     vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag set
-     vflag_atom   != 0 if VIRIAL_ATOM bit of vflag set
+     eflag_only   != 0 if ENERGY_GLOBAL and ENERGY_ONLY bits of eflag are set
+     vflag_global != 0 if VIRIAL_PAIR or VIRIAL_FDOTR bit of vflag is set
+     vflag_atom   != 0 if VIRIAL_ATOM bit of vflag is set
                        no current support for centroid stress
      vflag_either != 0 if vflag_global or vflag_atom is set
      evflag_atom  != 0 if eflag_atom or vflag_atom is set
@@ -240,10 +240,10 @@ void KSpace::ev_setup(int eflag, int vflag, int alloc)
 
   evflag = 1;
 
-  eflag_either = eflag;
+  eflag_either = eflag & (ENERGY_GLOBAL | ENERGY_ATOM);
   eflag_global = eflag & ENERGY_GLOBAL;
   eflag_atom = eflag & ENERGY_ATOM;
-  eflag_only = eflag & ENERGY_ONLY;
+  eflag_only = eflag_global ? (eflag & ENERGY_ONLY) : 0;
 
   vflag_either = vflag;
   vflag_global = vflag & (VIRIAL_PAIR | VIRIAL_FDOTR);

--- a/src/kspace.h
+++ b/src/kspace.h
@@ -128,11 +128,11 @@ class KSpace : protected Pointers {
   uint64_t datamask_read, datamask_modify;
   int copymode;
 
-  int compute_flag;       // 0 if skip compute()
-  int fftbench;           // 0 if skip FFT timing
-  int collective_flag;    // 1 if use MPI collectives for FFT/remap
-  int nonblocking_flag;   // 1 if use MPI_Isend for FFT/remap
-  int stagger_flag;       // 1 if using staggered PPPM grids
+  int compute_flag;        // 0 if skip compute()
+  int fftbench;            // 0 if skip FFT timing
+  int collective_flag;     // 1 if use MPI collectives for FFT/remap
+  int nonblocking_flag;    // 1 if use MPI_Isend for FFT/remap
+  int stagger_flag;        // 1 if using staggered PPPM grids
 
   double splittol;    // tolerance for when to truncate splitting
 
@@ -232,7 +232,7 @@ class KSpace : protected Pointers {
   double **gcons, **dgcons;    // accumulated per-atom energy/virial
 
   int evflag, evflag_atom;
-  int eflag_either, eflag_global, eflag_atom;
+  int eflag_either, eflag_global, eflag_atom, eflag_only;
   int vflag_either, vflag_global, vflag_atom;
   int maxeatom, maxvatom;
 
@@ -245,7 +245,7 @@ class KSpace : protected Pointers {
     if (eflag || vflag)
       ev_setup(eflag, vflag, alloc);
     else
-      evflag = evflag_atom = eflag_either = eflag_global = eflag_atom = vflag_either =
+      evflag = evflag_atom = eflag_either = eflag_global = eflag_atom = eflag_only = vflag_either =
           vflag_global = vflag_atom = 0;
   }
   void ev_setup(int, int, int alloc = 1);

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -892,6 +892,7 @@ void Pair::map_element2type(int narg, char **arg, bool update_setflag)
      eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
      eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
      eflag_either != 0 if eflag_global or eflag_atom is set
+     eflag_only   != 0 if ENERGY_ONLY bit of eflag set
      vflag_global != 0 if VIRIAL_PAIR bit of vflag set, OR
                        if VIRIAL_FDOTR bit of vflag is set but no_virial_fdotr = 1
      vflag_fdotr  != 0 if VIRIAL_FDOTR bit of vflag set and no_virial_fdotr = 0
@@ -915,6 +916,7 @@ void Pair::ev_setup(int eflag, int vflag, int alloc)
   eflag_either = eflag;
   eflag_global = eflag & ENERGY_GLOBAL;
   eflag_atom = eflag & ENERGY_ATOM;
+  eflag_only = eflag & ENERGY_ONLY;
 
   vflag_global = vflag & VIRIAL_PAIR;
   if (vflag & VIRIAL_FDOTR && no_virial_fdotr_compute == 1) vflag_global = 1;
@@ -1014,6 +1016,7 @@ void Pair::ev_unset()
   eflag_either = 0;
   eflag_global = 0;
   eflag_atom = 0;
+  eflag_only = 0;
 
   vflag_either = 0;
   vflag_global = 0;

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -889,17 +889,17 @@ void Pair::map_element2type(int narg, char **arg, bool update_setflag)
    setup for energy, virial computation
    see integrate::ev_set() for bitwise settings of eflag/vflag
    set the following flags, values are otherwise set to 0:
-     eflag_global != 0 if ENERGY_GLOBAL bit of eflag set
-     eflag_atom   != 0 if ENERGY_ATOM bit of eflag set
+     eflag_global != 0 if ENERGY_GLOBAL bit of eflag is set
+     eflag_atom   != 0 if ENERGY_ATOM bit of eflag is set
      eflag_either != 0 if eflag_global or eflag_atom is set
-     eflag_only   != 0 if ENERGY_ONLY bit of eflag set
-     vflag_global != 0 if VIRIAL_PAIR bit of vflag set, OR
+     eflag_only   != 0 if ENERGY_GLOBAL and ENERGY_ONLY bits of eflag are set
+     vflag_global != 0 if VIRIAL_PAIR bit of vflag is set, OR
                        if VIRIAL_FDOTR bit of vflag is set but no_virial_fdotr = 1
-     vflag_fdotr  != 0 if VIRIAL_FDOTR bit of vflag set and no_virial_fdotr = 0
-     vflag_atom   != 0 if VIRIAL_ATOM bit of vflag set, OR
-                       if VIRIAL_CENTROID bit of vflag set
+     vflag_fdotr  != 0 if VIRIAL_FDOTR bit of vflag is set and no_virial_fdotr = 0
+     vflag_atom   != 0 if VIRIAL_ATOM bit of vflag is set, OR
+                       if VIRIAL_CENTROID bit of vflag is set
                        and centroidstressflag != CENTROID_AVAIL
-     cvflag_atom  != 0 if VIRIAL_CENTROID bit of vflag set
+     cvflag_atom  != 0 if VIRIAL_CENTROID bit of vflag is set
                        and centroidstressflag = CENTROID_AVAIL
      vflag_either != 0 if any of vflag_global, vflag_atom, cvflag_atom is set
      evflag       != 0 if eflag_either or vflag_either is set
@@ -913,10 +913,10 @@ void Pair::ev_setup(int eflag, int vflag, int alloc)
 {
   int i,n;
 
-  eflag_either = eflag;
+  eflag_either = eflag & (ENERGY_GLOBAL | ENERGY_ATOM);
   eflag_global = eflag & ENERGY_GLOBAL;
   eflag_atom = eflag & ENERGY_ATOM;
-  eflag_only = eflag & ENERGY_ONLY;
+  eflag_only = eflag_global ? (eflag & ENERGY_ONLY) : 0;
 
   vflag_global = vflag & VIRIAL_PAIR;
   if (vflag & VIRIAL_FDOTR && no_virial_fdotr_compute == 1) vflag_global = 1;

--- a/src/pair.h
+++ b/src/pair.h
@@ -88,7 +88,7 @@ class Pair : protected Pointers {
   int trim_flag;    // pair_modify flag for trimming neigh list
 
   int evflag;    // energy,virial settings
-  int eflag_either, eflag_global, eflag_atom;
+  int eflag_either, eflag_global, eflag_atom, eflag_only;
   int vflag_either, vflag_global, vflag_atom, cvflag_atom;
 
   int ncoultablebits;    // size of Coulomb table, accessed by KSpace


### PR DESCRIPTION
**Summary**

This adds a new bit, ENERGY_ONLY, to the eflag variable which indicates that only the (global) energy is required. This can be used by force styles to skip over steps only required for computing forces and may result in significant savings for computations like MC fixes when they need to do a full energy computation.

**Related Issue(s)**

This addresses the feature request and thus closes #4847 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Backward Compatibility**

Yes.

**Implementation Notes**

Rather than using "magic" numbers we now use the symbolic constants to set eflag and vflag to make the desired intent more obvious.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.

