### PR TITLE
Fix mliap/pytorch.py and move model to the GPU device

### DIFF
--- a/python/lammps/mliap/pytorch.py
+++ b/python/lammps/mliap/pytorch.py
@@ -135,6 +135,7 @@ class TorchWrapper(torch.nn.Module):
         device = self.device
         if (use_gpu_data and (device is None) and (str(beta.device).find('CUDA') == 1)):
             device = 'cuda' #Override device as it wasn't defined in the model
+            self.model = self.model.to(device)
         with torch.autograd.enable_grad():
 
             if (use_gpu_data):


### PR DESCRIPTION
**Summary**

Fixes error of model living on the CPU side rather than GPU side, which triggered error:

RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cpu and cuda:0! (when checking argument for argument mat1 in method wrapper_CUDA_addmm)

reproducible using:

mpirun -np 1 lmp -k on g 1 -sf kk -pk kokkos newton on neigh half -in in.mliap.pytorch.Ta06A

**Author(s)**

Alberto Cano, Virginia Tech Advanced Research Computing

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Backward Compatibility**

No known issues.

**Implementation Notes**

Added an explicit instruction to move the model to the device when the GPU is in use.

**Post Submission Checklist**

- [X] The feature or features in this pull request is complete
- [X] Licensing information is complete
- [X] Corresponding author information is complete
- [X] The source code follows the LAMMPS formatting guidelines
- [X] Suitable new documentation files and/or updates to the existing docs are included
- [X] The added/updated documentation is integrated and tested with the documentation build system
- [X] The feature has been verified to work with the conventional build system
- [X] The feature has been verified to work with the CMake based build system
