### PR TITLE
Add KOKKOS version of dihedral style nharmonic

### DIFF
--- a/doc/src/Commands_bond.rst
+++ b/doc/src/Commands_bond.rst
@@ -129,7 +129,7 @@ OPT.
    * :doc:`helix (o) <dihedral_helix>`
    * :doc:`lepton (o) <dihedral_lepton>`
    * :doc:`multi/harmonic (ko) <dihedral_multi_harmonic>`
-   * :doc:`nharmonic (o) <dihedral_nharmonic>`
+   * :doc:`nharmonic (ko) <dihedral_nharmonic>`
    * :doc:`opls (iko) <dihedral_opls>`
    * :doc:`quadratic (o) <dihedral_quadratic>`
    * :doc:`spherical <dihedral_spherical>`

--- a/doc/src/dihedral_nharmonic.rst
+++ b/doc/src/dihedral_nharmonic.rst
@@ -1,10 +1,11 @@
 .. index:: dihedral_style nharmonic
+.. index:: dihedral_style nharmonic/kk
 .. index:: dihedral_style nharmonic/omp
 
 dihedral_style nharmonic command
 ================================
 
-Accelerator Variants: *nharmonic/omp*
+Accelerator Variants: *nharmonic/kk*, *nharmonic/omp*
 
 Syntax
 """"""

--- a/src/EXTRA-MOLECULE/dihedral_fourier.cpp
+++ b/src/EXTRA-MOLECULE/dihedral_fourier.cpp
@@ -290,6 +290,7 @@ void DihedralFourier::coeff(int narg, char **arg)
   int multiplicity_one;
   double shift_one;
   int nterms_one = utils::inumeric(FLERR,arg[1],false,lmp);
+  nterms_max = MAX(nterms_max,nterms_one);
 
   if (nterms_one < 1)
     error->all(FLERR,"Incorrect number of terms arg for dihedral coefficients");
@@ -300,7 +301,6 @@ void DihedralFourier::coeff(int narg, char **arg)
   int count = 0;
   for (int i = ilo; i <= ihi; i++) {
     nterms[i] = nterms_one;
-    nterms_max = MAX(nterms_max,nterms_one);
     delete[] k[i];
     delete[] multiplicity[i];
     delete[] shift[i];

--- a/src/EXTRA-MOLECULE/dihedral_nharmonic.cpp
+++ b/src/EXTRA-MOLECULE/dihedral_nharmonic.cpp
@@ -291,7 +291,11 @@ void DihedralNHarmonic::coeff(int narg, char **arg)
 
 void DihedralNHarmonic::write_restart(FILE *fp)
 {
+  // must store nterms_max in restart file in addition to the nterms array
+  // the KOKKOS version requires it to store the coefficients in a 2d view
+  fwrite(&nterms_max,sizeof(int),1,fp);
   fwrite(&nterms[1],sizeof(int),atom->ndihedraltypes,fp);
+
   for (int i = 1; i <= atom->ndihedraltypes; i++)
     fwrite(a[i],sizeof(double),nterms[i],fp);
 }
@@ -304,9 +308,11 @@ void DihedralNHarmonic::read_restart(FILE *fp)
 {
   allocate();
 
-  if (comm->me == 0)
+  if (comm->me == 0) {
+    utils::sfread(FLERR,&nterms_max,sizeof(int),1,fp,nullptr,error);
     utils::sfread(FLERR,&nterms[1],sizeof(int),atom->ndihedraltypes,fp,nullptr,error);
-
+  }
+  MPI_Bcast(&nterms_max,1,MPI_INT,0,world);
   MPI_Bcast(&nterms[1],atom->ndihedraltypes,MPI_INT,0,world);
 
   // allocate

--- a/src/EXTRA-MOLECULE/dihedral_nharmonic.cpp
+++ b/src/EXTRA-MOLECULE/dihedral_nharmonic.cpp
@@ -50,9 +50,9 @@ DihedralNHarmonic::~DihedralNHarmonic()
   if (allocated) {
     memory->destroy(setflag);
     for (int i = 1; i <= atom->ndihedraltypes; i++)
-      delete [] a[i];
-    delete [] a;
-    delete [] nterms;
+      delete[] a[i];
+    delete[] a;
+    delete[] nterms;
   }
 }
 

--- a/src/EXTRA-MOLECULE/dihedral_nharmonic.cpp
+++ b/src/EXTRA-MOLECULE/dihedral_nharmonic.cpp
@@ -40,6 +40,7 @@ DihedralNHarmonic::DihedralNHarmonic(LAMMPS *lmp) : Dihedral(lmp)
   writedata = 1;
   a = nullptr;
   born_matrix_enable = 1;
+  nterms_max = 0;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -259,8 +260,9 @@ void DihedralNHarmonic::coeff(int narg, char **arg)
 {
   if (narg < 3) error->all(FLERR,"Incorrect args for dihedral coefficients" + utils::errorurl(21));
 
-  int n = utils::inumeric(FLERR,arg[1],false,lmp);
-  if (narg != n + 2)
+  int nterms_one = utils::inumeric(FLERR,arg[1],false,lmp);
+  nterms_max = MAX(nterms_max,nterms_one);
+  if (narg != nterms_one + 2)
     error->all(FLERR,"Incorrect args for dihedral coefficients" + utils::errorurl(21));
 
   if (!allocated) allocate();
@@ -271,9 +273,9 @@ void DihedralNHarmonic::coeff(int narg, char **arg)
   int count = 0;
   for (int i = ilo; i <= ihi; i++) {
     delete[] a[i];
-    a[i] = new double [n];
-    nterms[i] = n;
-    for (int j = 0; j < n; j++) {
+    a[i] = new double [nterms_one];
+    nterms[i] = nterms_one;
+    for (int j = 0; j < nterms_one; j++) {
       a[i][j] = utils::numeric(FLERR,arg[2+j],false,lmp);
       setflag[i] = 1;
     }

--- a/src/EXTRA-MOLECULE/dihedral_nharmonic.cpp
+++ b/src/EXTRA-MOLECULE/dihedral_nharmonic.cpp
@@ -47,6 +47,8 @@ DihedralNHarmonic::DihedralNHarmonic(LAMMPS *lmp) : Dihedral(lmp)
 
 DihedralNHarmonic::~DihedralNHarmonic()
 {
+  if (copymode) return;
+
   if (allocated) {
     memory->destroy(setflag);
     for (int i = 1; i <= atom->ndihedraltypes; i++)

--- a/src/EXTRA-MOLECULE/dihedral_nharmonic.h
+++ b/src/EXTRA-MOLECULE/dihedral_nharmonic.h
@@ -38,6 +38,7 @@ class DihedralNHarmonic : public Dihedral {
  protected:
   int *nterms;
   double **a;
+  int nterms_max;
 
   void allocate();
 };

--- a/src/KOKKOS/dihedral_nharmonic_kokkos.cpp
+++ b/src/KOKKOS/dihedral_nharmonic_kokkos.cpp
@@ -13,8 +13,8 @@
 ------------------------------------------------------------------------- */
 
 /* ----------------------------------------------------------------------
-   Contributing author: Richard Berger (LANL)
-   [ based on dihedral_multi_harmonic_kokkos.cpp ]
+   Contributing author: Axel Kohlmeyer using Claude Opus 4.6
+   [ based on dihedral_multi_harmonic_kokkos.cpp and dihedral_fourier_kokkos.cpp]
 ------------------------------------------------------------------------- */
 
 #include "dihedral_nharmonic_kokkos.h"
@@ -340,20 +340,14 @@ void DihedralNHarmonicKokkos<DeviceType>::operator()(TagDihedralNHarmonicCompute
 template<class DeviceType>
 void DihedralNHarmonicKokkos<DeviceType>::allocate_kokkos()
 {
-  int nd = atom->ndihedraltypes;
-
-  // find maximum number of terms across all dihedral types
-
-  int max_nterms = 0;
-  for (int i = 1; i <= nd; i++)
-    if (nterms[i] > max_nterms) max_nterms = nterms[i];
+  int n = atom->ndihedraltypes;
 
   if (!allocated_kokkos) {
-    k_a = DAT::tdual_kkfloat_2d("DihedralNHarmonic::a",nd+1,max_nterms);
-    k_nterms = DAT::tdual_int_1d("DihedralNHarmonic::nterms",nd+1);
+    k_a = DAT::tdual_kkfloat_2d("DihedralNHarmonic::a",n+1,nterms_max);
+    k_nterms = DAT::tdual_int_1d("DihedralNHarmonic::nterms",n+1);
   } else {
-    k_a.resize(nd+1,max_nterms);
-    k_nterms.resize(nd+1);
+    k_a.resize(n+1,nterms_max);
+    k_nterms.resize(n+1);
   }
 
   d_a = k_a.template view<DeviceType>();
@@ -395,8 +389,8 @@ void DihedralNHarmonicKokkos<DeviceType>::read_restart(FILE *fp)
   DihedralNHarmonic::read_restart(fp);
   allocate_kokkos();
 
-  int nd = atom->ndihedraltypes;
-  for (int i = 1; i <= nd; i++) {
+  int n = atom->ndihedraltypes;
+  for (int i = 1; i <= n; i++) {
     k_nterms.view_host()[i] = nterms[i];
     for (int j = 0; j < nterms[i]; j++)
       k_a.view_host()(i,j) = a[i][j];

--- a/src/KOKKOS/dihedral_nharmonic_kokkos.cpp
+++ b/src/KOKKOS/dihedral_nharmonic_kokkos.cpp
@@ -1,0 +1,549 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Richard Berger (LANL)
+   [ based on dihedral_multi_harmonic_kokkos.cpp ]
+------------------------------------------------------------------------- */
+
+#include "dihedral_nharmonic_kokkos.h"
+
+#include "atom_kokkos.h"
+#include "atom_masks.h"
+#include "comm.h"
+#include "error.h"
+#include "force.h"
+#include "memory_kokkos.h"
+#include "neighbor_kokkos.h"
+
+#include <cmath>
+
+using namespace LAMMPS_NS;
+
+static constexpr double TOLERANCE = 0.05;
+static constexpr double SMALL = 0.001;
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+DihedralNHarmonicKokkos<DeviceType>::DihedralNHarmonicKokkos(LAMMPS *lmp) : DihedralNHarmonic(lmp)
+{
+  kokkosable = 1;
+  atomKK = (AtomKokkos *) atom;
+  neighborKK = (NeighborKokkos *) neighbor;
+  execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
+  datamask_read = X_MASK | F_MASK | Q_MASK | ENERGY_MASK | VIRIAL_MASK;
+  datamask_modify = F_MASK | ENERGY_MASK | VIRIAL_MASK;
+
+  k_warning_flag = DAT::tdual_int_scalar("Dihedral:warning_flag");
+  d_warning_flag = k_warning_flag.view<DeviceType>();
+  h_warning_flag = k_warning_flag.view_host();
+
+  centroidstressflag = CENTROID_NOTAVAIL;
+
+  allocated_kokkos = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+DihedralNHarmonicKokkos<DeviceType>::~DihedralNHarmonicKokkos()
+{
+  if (!copymode) {
+    memoryKK->destroy_kokkos(k_eatom,eatom);
+    memoryKK->destroy_kokkos(k_vatom,vatom);
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void DihedralNHarmonicKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
+{
+  eflag = eflag_in;
+  vflag = vflag_in;
+
+  ev_init(eflag,vflag,0);
+
+  // reallocate per-atom arrays if necessary
+
+  if (eflag_atom) {
+    if ((int)k_eatom.extent(0) < maxeatom) {
+    memoryKK->destroy_kokkos(k_eatom,eatom);
+    memoryKK->create_kokkos(k_eatom,eatom,maxeatom,"dihedral:eatom");
+    d_eatom = k_eatom.view<DeviceType>();
+    } else Kokkos::deep_copy(d_eatom,0.0);
+  }
+  if (vflag_atom) {
+    if ((int)k_vatom.extent(0) < maxvatom) {
+    memoryKK->destroy_kokkos(k_vatom,vatom);
+    memoryKK->create_kokkos(k_vatom,vatom,maxvatom,"dihedral:vatom");
+    d_vatom = k_vatom.view<DeviceType>();
+    } else Kokkos::deep_copy(d_vatom,0.0);
+  }
+
+  k_a.template sync<DeviceType>();
+  k_nterms.template sync<DeviceType>();
+
+  x = atomKK->k_x.view<DeviceType>();
+  f = atomKK->k_f.view<DeviceType>();
+  neighborKK->k_dihedrallist.template sync<DeviceType>();
+  dihedrallist = neighborKK->k_dihedrallist.view<DeviceType>();
+  int ndihedrallist = neighborKK->ndihedrallist;
+  nlocal = atom->nlocal;
+  newton_bond = force->newton_bond;
+
+  h_warning_flag() = 0;
+  k_warning_flag.modify_host();
+  k_warning_flag.template sync<DeviceType>();
+
+  copymode = 1;
+
+  // loop over neighbors of my atoms
+
+  EV_FLOAT ev;
+
+  if (evflag) {
+    if (newton_bond) {
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagDihedralNHarmonicCompute<1,1> >(0,ndihedrallist),*this,ev);
+    } else {
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagDihedralNHarmonicCompute<0,1> >(0,ndihedrallist),*this,ev);
+    }
+  } else {
+    if (newton_bond) {
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagDihedralNHarmonicCompute<1,0> >(0,ndihedrallist),*this);
+    } else {
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagDihedralNHarmonicCompute<0,0> >(0,ndihedrallist),*this);
+    }
+  }
+
+  // error check
+
+  k_warning_flag.template modify<DeviceType>();
+  k_warning_flag.sync_host();
+  if (h_warning_flag())
+    error->warning(FLERR,"Dihedral problem");
+
+  if (eflag_global) energy += ev.evdwl;
+  if (vflag_global) {
+    virial[0] += ev.v[0];
+    virial[1] += ev.v[1];
+    virial[2] += ev.v[2];
+    virial[3] += ev.v[3];
+    virial[4] += ev.v[4];
+    virial[5] += ev.v[5];
+  }
+
+  if (eflag_atom) {
+    k_eatom.template modify<DeviceType>();
+    k_eatom.sync_host();
+  }
+
+  if (vflag_atom) {
+    k_vatom.template modify<DeviceType>();
+    k_vatom.sync_host();
+  }
+
+  copymode = 0;
+}
+
+template<class DeviceType>
+template<int NEWTON_BOND, int EVFLAG>
+// NOLINTNEXTLINE
+KOKKOS_INLINE_FUNCTION
+void DihedralNHarmonicKokkos<DeviceType>::operator()(TagDihedralNHarmonicCompute<NEWTON_BOND,EVFLAG>, const int &n, EV_FLOAT& ev) const {
+
+  // The f array is atomic
+  Kokkos::View<KK_ACC_FLOAT*[3], typename DAT::t_kkacc_1d_3::array_layout,typename KKDevice<DeviceType>::value,Kokkos::MemoryTraits<Kokkos::Atomic|Kokkos::Unmanaged> > a_f = f;
+
+  const int i1 = dihedrallist(n,0);
+  const int i2 = dihedrallist(n,1);
+  const int i3 = dihedrallist(n,2);
+  const int i4 = dihedrallist(n,3);
+  const int type = dihedrallist(n,4);
+
+  // 1st bond
+
+  const KK_FLOAT vb1x = x(i1,0) - x(i2,0);
+  const KK_FLOAT vb1y = x(i1,1) - x(i2,1);
+  const KK_FLOAT vb1z = x(i1,2) - x(i2,2);
+
+  // 2nd bond
+
+  const KK_FLOAT vb2x = x(i3,0) - x(i2,0);
+  const KK_FLOAT vb2y = x(i3,1) - x(i2,1);
+  const KK_FLOAT vb2z = x(i3,2) - x(i2,2);
+
+  const KK_FLOAT vb2xm = -vb2x;
+  const KK_FLOAT vb2ym = -vb2y;
+  const KK_FLOAT vb2zm = -vb2z;
+
+  // 3rd bond
+
+  const KK_FLOAT vb3x = x(i4,0) - x(i3,0);
+  const KK_FLOAT vb3y = x(i4,1) - x(i3,1);
+  const KK_FLOAT vb3z = x(i4,2) - x(i3,2);
+
+  // c0 calculation
+
+  const KK_FLOAT sb1 = 1.0 / (vb1x * vb1x + vb1y * vb1y + vb1z * vb1z);
+  const KK_FLOAT sb2 = 1.0 / (vb2x * vb2x + vb2y * vb2y + vb2z * vb2z);
+  const KK_FLOAT sb3 = 1.0 / (vb3x * vb3x + vb3y * vb3y + vb3z * vb3z);
+
+  const KK_FLOAT rb1 = sqrt(sb1);
+  const KK_FLOAT rb3 = sqrt(sb3);
+
+  KK_FLOAT c0 = (vb1x * vb3x + vb1y * vb3y + vb1z * vb3z) * rb1 * rb3;
+
+  // 1st and 2nd angle
+
+  KK_FLOAT b1mag2 = vb1x * vb1x + vb1y * vb1y + vb1z * vb1z;
+  KK_FLOAT b1mag = sqrt(b1mag2);
+  KK_FLOAT b2mag2 = vb2x * vb2x + vb2y * vb2y + vb2z * vb2z;
+  KK_FLOAT b2mag = sqrt(b2mag2);
+  KK_FLOAT b3mag2 = vb3x * vb3x + vb3y * vb3y + vb3z * vb3z;
+  KK_FLOAT b3mag = sqrt(b3mag2);
+
+  KK_FLOAT ctmp = vb1x * vb2x + vb1y * vb2y + vb1z * vb2z;
+  KK_FLOAT r12c1 = 1.0 / (b1mag * b2mag);
+  KK_FLOAT c1mag = ctmp * r12c1;
+
+  ctmp = vb2xm * vb3x + vb2ym * vb3y + vb2zm * vb3z;
+  KK_FLOAT r12c2 = 1.0 / (b2mag * b3mag);
+  KK_FLOAT c2mag = ctmp * r12c2;
+
+  // cos and sin of 2 angles and final c
+
+  KK_FLOAT sin2 = MAX(1.0 - c1mag * c1mag, 0.0);
+  KK_FLOAT sc1 = sqrt(sin2);
+  if (sc1 < SMALL) sc1 = SMALL;
+  sc1 = 1.0 / sc1;
+
+  sin2 = MAX(1.0 - c2mag * c2mag, 0.0);
+  KK_FLOAT sc2 = sqrt(sin2);
+  if (sc2 < SMALL) sc2 = SMALL;
+  sc2 = 1.0 / sc2;
+
+  KK_FLOAT s1 = sc1 * sc1;
+  KK_FLOAT s2 = sc2 * sc2;
+  KK_FLOAT s12 = sc1 * sc2;
+  KK_FLOAT c = (c0 + c1mag * c2mag) * s12;
+
+  // error check
+
+  if ((c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE)) && !d_warning_flag())
+    d_warning_flag() = 1;
+
+  if (c > 1.0) c = 1.0;
+  if (c < -1.0) c = -1.0;
+
+  // force & energy
+  // p = sum (i=1,n) a_i * c**(i-1)
+  // pd = dp/dc
+
+  const int nt = d_nterms[type];
+  KK_FLOAT c_ = 1.0;
+  KK_FLOAT p = d_a(type, 0);
+  KK_FLOAT pd = 0.0;
+  for (int i = 1; i < nt; i++) {
+    pd += c_ * i * d_a(type, i);
+    c_ *= c;
+    p += c_ * d_a(type, i);
+  }
+
+  KK_FLOAT edihedral = 0.0;
+  if (eflag) edihedral = p;
+
+  c = c * pd;
+  s12 = s12 * pd;
+  const KK_FLOAT a11 = c * sb1 * s1;
+  const KK_FLOAT a22 = -sb2 * (2.0 * c0 * s12 - c * (s1 + s2));
+  const KK_FLOAT a33 = c * sb3 * s2;
+  const KK_FLOAT a12 = -r12c1 * (c1mag * c * s1 + c2mag * s12);
+  const KK_FLOAT a13 = -rb1 * rb3 * s12;
+  const KK_FLOAT a23 = r12c2 * (c2mag * c * s2 + c1mag * s12);
+
+  const KK_FLOAT sx2 = a12 * vb1x + a22 * vb2x + a23 * vb3x;
+  const KK_FLOAT sy2 = a12 * vb1y + a22 * vb2y + a23 * vb3y;
+  const KK_FLOAT sz2 = a12 * vb1z + a22 * vb2z + a23 * vb3z;
+
+  KK_FLOAT f1[3],f2[3],f3[3],f4[3];
+  f1[0] = a11 * vb1x + a12 * vb2x + a13 * vb3x;
+  f1[1] = a11 * vb1y + a12 * vb2y + a13 * vb3y;
+  f1[2] = a11 * vb1z + a12 * vb2z + a13 * vb3z;
+
+  f2[0] = -sx2 - f1[0];
+  f2[1] = -sy2 - f1[1];
+  f2[2] = -sz2 - f1[2];
+
+  f4[0] = a13 * vb1x + a23 * vb2x + a33 * vb3x;
+  f4[1] = a13 * vb1y + a23 * vb2y + a33 * vb3y;
+  f4[2] = a13 * vb1z + a23 * vb2z + a33 * vb3z;
+
+  f3[0] = sx2 - f4[0];
+  f3[1] = sy2 - f4[1];
+  f3[2] = sz2 - f4[2];
+
+  // apply force to each of 4 atoms
+
+  if (NEWTON_BOND || i1 < nlocal) {
+    a_f(i1,0) += f1[0];
+    a_f(i1,1) += f1[1];
+    a_f(i1,2) += f1[2];
+  }
+
+  if (NEWTON_BOND || i2 < nlocal) {
+    a_f(i2,0) += f2[0];
+    a_f(i2,1) += f2[1];
+    a_f(i2,2) += f2[2];
+  }
+
+  if (NEWTON_BOND || i3 < nlocal) {
+    a_f(i3,0) += f3[0];
+    a_f(i3,1) += f3[1];
+    a_f(i3,2) += f3[2];
+  }
+
+  if (NEWTON_BOND || i4 < nlocal) {
+    a_f(i4,0) += f4[0];
+    a_f(i4,1) += f4[1];
+    a_f(i4,2) += f4[2];
+  }
+
+  if (EVFLAG)
+    ev_tally(ev,i1,i2,i3,i4,edihedral,f1,f3,f4,
+             vb1x,vb1y,vb1z,vb2x,vb2y,vb2z,vb3x,vb3y,vb3z);
+}
+
+template<class DeviceType>
+template<int NEWTON_BOND, int EVFLAG>
+// NOLINTNEXTLINE
+KOKKOS_INLINE_FUNCTION
+void DihedralNHarmonicKokkos<DeviceType>::operator()(TagDihedralNHarmonicCompute<NEWTON_BOND,EVFLAG>, const int &n) const {
+  EV_FLOAT ev;
+  this->template operator()<NEWTON_BOND,EVFLAG>(TagDihedralNHarmonicCompute<NEWTON_BOND,EVFLAG>(), n, ev);
+}
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+void DihedralNHarmonicKokkos<DeviceType>::allocate_kokkos()
+{
+  int nd = atom->ndihedraltypes;
+
+  // find maximum number of terms across all dihedral types
+
+  int max_nterms = 0;
+  for (int i = 1; i <= nd; i++)
+    if (nterms[i] > max_nterms) max_nterms = nterms[i];
+
+  if (!allocated_kokkos) {
+    k_a = DAT::tdual_kkfloat_2d("DihedralNHarmonic::a",nd+1,max_nterms);
+    k_nterms = DAT::tdual_int_1d("DihedralNHarmonic::nterms",nd+1);
+  } else {
+    k_a.resize(nd+1,max_nterms);
+    k_nterms.resize(nd+1);
+  }
+
+  d_a = k_a.template view<DeviceType>();
+  d_nterms = k_nterms.template view<DeviceType>();
+
+  allocated_kokkos = 1;
+}
+
+/* ----------------------------------------------------------------------
+   set coeffs for one type
+------------------------------------------------------------------------- */
+
+template<class DeviceType>
+void DihedralNHarmonicKokkos<DeviceType>::coeff(int narg, char **arg)
+{
+  DihedralNHarmonic::coeff(narg, arg);
+  allocate_kokkos();
+
+  int ilo,ihi;
+  utils::bounds(FLERR,arg[0],1,atom->ndihedraltypes,ilo,ihi,error);
+
+  for (int i = ilo; i <= ihi; i++) {
+    k_nterms.view_host()[i] = nterms[i];
+    for (int j = 0; j < nterms[i]; j++)
+      k_a.view_host()(i,j) = a[i][j];
+  }
+
+  k_a.modify_host();
+  k_nterms.modify_host();
+}
+
+/* ----------------------------------------------------------------------
+   proc 0 reads coeffs from restart file, bcasts them
+------------------------------------------------------------------------- */
+
+template<class DeviceType>
+void DihedralNHarmonicKokkos<DeviceType>::read_restart(FILE *fp)
+{
+  DihedralNHarmonic::read_restart(fp);
+  allocate_kokkos();
+
+  int nd = atom->ndihedraltypes;
+  for (int i = 1; i <= nd; i++) {
+    k_nterms.view_host()[i] = nterms[i];
+    for (int j = 0; j < nterms[i]; j++)
+      k_a.view_host()(i,j) = a[i][j];
+  }
+
+  k_a.modify_host();
+  k_nterms.modify_host();
+}
+
+/* ----------------------------------------------------------------------
+   tally energy and virial into global and per-atom accumulators
+   virial = r1F1 + r2F2 + r3F3 + r4F4 = (r1-r2) F1 + (r3-r2) F3 + (r4-r2) F4
+          = (r1-r2) F1 + (r3-r2) F3 + (r4-r3 + r3-r2) F4
+          = vb1*f1 + vb2*f3 + (vb3+vb2)*f4
+------------------------------------------------------------------------- */
+
+template<class DeviceType>
+//template<int NEWTON_BOND>
+// NOLINTNEXTLINE
+KOKKOS_INLINE_FUNCTION
+void DihedralNHarmonicKokkos<DeviceType>::ev_tally(EV_FLOAT &ev, const int i1, const int i2, const int i3, const int i4,
+                        KK_FLOAT &edihedral, KK_FLOAT *f1, KK_FLOAT *f3, KK_FLOAT *f4,
+                        const KK_FLOAT &vb1x, const KK_FLOAT &vb1y, const KK_FLOAT &vb1z,
+                        const KK_FLOAT &vb2x, const KK_FLOAT &vb2y, const KK_FLOAT &vb2z,
+                        const KK_FLOAT &vb3x, const KK_FLOAT &vb3y, const KK_FLOAT &vb3z) const
+{
+  KK_FLOAT edihedralquarter;
+  KK_FLOAT v[6];
+
+  // The eatom and vatom arrays are atomic
+  Kokkos::View<KK_ACC_FLOAT*, typename DAT::t_kkacc_1d::array_layout,typename KKDevice<DeviceType>::value,Kokkos::MemoryTraits<Kokkos::Atomic|Kokkos::Unmanaged> > v_eatom = d_eatom;
+  Kokkos::View<KK_ACC_FLOAT*[6], typename DAT::t_kkacc_1d_6::array_layout,typename KKDevice<DeviceType>::value,Kokkos::MemoryTraits<Kokkos::Atomic|Kokkos::Unmanaged> > v_vatom = d_vatom;
+
+  if (eflag_either) {
+    if (eflag_global) {
+      if (newton_bond) ev.evdwl += edihedral;
+      else {
+        edihedralquarter = 0.25*edihedral;
+        if (i1 < nlocal) ev.evdwl += edihedralquarter;
+        if (i2 < nlocal) ev.evdwl += edihedralquarter;
+        if (i3 < nlocal) ev.evdwl += edihedralquarter;
+        if (i4 < nlocal) ev.evdwl += edihedralquarter;
+      }
+    }
+    if (eflag_atom) {
+      edihedralquarter = 0.25*edihedral;
+      if (newton_bond || i1 < nlocal) v_eatom[i1] += edihedralquarter;
+      if (newton_bond || i2 < nlocal) v_eatom[i2] += edihedralquarter;
+      if (newton_bond || i3 < nlocal) v_eatom[i3] += edihedralquarter;
+      if (newton_bond || i4 < nlocal) v_eatom[i4] += edihedralquarter;
+    }
+  }
+
+  if (vflag_either) {
+    v[0] = vb1x*f1[0] + vb2x*f3[0] + (vb3x+vb2x)*f4[0];
+    v[1] = vb1y*f1[1] + vb2y*f3[1] + (vb3y+vb2y)*f4[1];
+    v[2] = vb1z*f1[2] + vb2z*f3[2] + (vb3z+vb2z)*f4[2];
+    v[3] = vb1x*f1[1] + vb2x*f3[1] + (vb3x+vb2x)*f4[1];
+    v[4] = vb1x*f1[2] + vb2x*f3[2] + (vb3x+vb2x)*f4[2];
+    v[5] = vb1y*f1[2] + vb2y*f3[2] + (vb3y+vb2y)*f4[2];
+
+    if (vflag_global) {
+      if (newton_bond) {
+        ev.v[0] += v[0];
+        ev.v[1] += v[1];
+        ev.v[2] += v[2];
+        ev.v[3] += v[3];
+        ev.v[4] += v[4];
+        ev.v[5] += v[5];
+      } else {
+        if (i1 < nlocal) {
+          ev.v[0] += 0.25*v[0];
+          ev.v[1] += 0.25*v[1];
+          ev.v[2] += 0.25*v[2];
+          ev.v[3] += 0.25*v[3];
+          ev.v[4] += 0.25*v[4];
+          ev.v[5] += 0.25*v[5];
+        }
+        if (i2 < nlocal) {
+          ev.v[0] += 0.25*v[0];
+          ev.v[1] += 0.25*v[1];
+          ev.v[2] += 0.25*v[2];
+          ev.v[3] += 0.25*v[3];
+          ev.v[4] += 0.25*v[4];
+          ev.v[5] += 0.25*v[5];
+        }
+        if (i3 < nlocal) {
+          ev.v[0] += 0.25*v[0];
+          ev.v[1] += 0.25*v[1];
+          ev.v[2] += 0.25*v[2];
+          ev.v[3] += 0.25*v[3];
+          ev.v[4] += 0.25*v[4];
+          ev.v[5] += 0.25*v[5];
+        }
+        if (i4 < nlocal) {
+          ev.v[0] += 0.25*v[0];
+          ev.v[1] += 0.25*v[1];
+          ev.v[2] += 0.25*v[2];
+          ev.v[3] += 0.25*v[3];
+          ev.v[4] += 0.25*v[4];
+          ev.v[5] += 0.25*v[5];
+        }
+      }
+    }
+
+    if (vflag_atom) {
+      if (newton_bond || i1 < nlocal) {
+        v_vatom(i1,0) += 0.25*v[0];
+        v_vatom(i1,1) += 0.25*v[1];
+        v_vatom(i1,2) += 0.25*v[2];
+        v_vatom(i1,3) += 0.25*v[3];
+        v_vatom(i1,4) += 0.25*v[4];
+        v_vatom(i1,5) += 0.25*v[5];
+      }
+      if (newton_bond || i2 < nlocal) {
+        v_vatom(i2,0) += 0.25*v[0];
+        v_vatom(i2,1) += 0.25*v[1];
+        v_vatom(i2,2) += 0.25*v[2];
+        v_vatom(i2,3) += 0.25*v[3];
+        v_vatom(i2,4) += 0.25*v[4];
+        v_vatom(i2,5) += 0.25*v[5];
+      }
+      if (newton_bond || i3 < nlocal) {
+        v_vatom(i3,0) += 0.25*v[0];
+        v_vatom(i3,1) += 0.25*v[1];
+        v_vatom(i3,2) += 0.25*v[2];
+        v_vatom(i3,3) += 0.25*v[3];
+        v_vatom(i3,4) += 0.25*v[4];
+        v_vatom(i3,5) += 0.25*v[5];
+      }
+      if (newton_bond || i4 < nlocal) {
+        v_vatom(i4,0) += 0.25*v[0];
+        v_vatom(i4,1) += 0.25*v[1];
+        v_vatom(i4,2) += 0.25*v[2];
+        v_vatom(i4,3) += 0.25*v[3];
+        v_vatom(i4,4) += 0.25*v[4];
+        v_vatom(i4,5) += 0.25*v[5];
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+namespace LAMMPS_NS {
+template class DihedralNHarmonicKokkos<LMPDeviceType>;
+#ifdef LMP_KOKKOS_GPU
+template class DihedralNHarmonicKokkos<LMPHostType>;
+#endif
+}

--- a/src/KOKKOS/dihedral_nharmonic_kokkos.h
+++ b/src/KOKKOS/dihedral_nharmonic_kokkos.h
@@ -1,0 +1,99 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef DIHEDRAL_CLASS
+// clang-format off
+DihedralStyle(nharmonic/kk,DihedralNHarmonicKokkos<LMPDeviceType>);
+DihedralStyle(nharmonic/kk/device,DihedralNHarmonicKokkos<LMPDeviceType>);
+DihedralStyle(nharmonic/kk/host,DihedralNHarmonicKokkos<LMPHostType>);
+// clang-format on
+#else
+
+// clang-format off
+#ifndef LMP_DIHEDRAL_NHARMONIC_KOKKOS_H
+#define LMP_DIHEDRAL_NHARMONIC_KOKKOS_H
+
+#include "dihedral_nharmonic.h"
+#include "kokkos_type.h"
+
+namespace LAMMPS_NS {
+
+template<int NEWTON_BOND, int EVFLAG>
+struct TagDihedralNHarmonicCompute{};
+
+template<class DeviceType>
+class DihedralNHarmonicKokkos : public DihedralNHarmonic {
+ public:
+  typedef DeviceType device_type;
+  typedef ArrayTypes<DeviceType> AT;
+  typedef EV_FLOAT value_type;
+
+  DihedralNHarmonicKokkos(class LAMMPS *);
+  ~DihedralNHarmonicKokkos() override;
+  void compute(int, int) override;
+  void coeff(int, char **) override;
+  void read_restart(FILE *) override;
+
+  template<int NEWTON_BOND, int EVFLAG>
+// NOLINTNEXTLINE
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagDihedralNHarmonicCompute<NEWTON_BOND,EVFLAG>, const int&, EV_FLOAT&) const;
+
+  template<int NEWTON_BOND, int EVFLAG>
+// NOLINTNEXTLINE
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagDihedralNHarmonicCompute<NEWTON_BOND,EVFLAG>, const int&) const;
+
+  //template<int NEWTON_BOND>
+// NOLINTNEXTLINE
+  KOKKOS_INLINE_FUNCTION
+  void ev_tally(EV_FLOAT &ev, const int i1, const int i2, const int i3, const int i4,
+                          KK_FLOAT &edihedral, KK_FLOAT *f1, KK_FLOAT *f3, KK_FLOAT *f4,
+                          const KK_FLOAT &vb1x, const KK_FLOAT &vb1y, const KK_FLOAT &vb1z,
+                          const KK_FLOAT &vb2x, const KK_FLOAT &vb2y, const KK_FLOAT &vb2z,
+                          const KK_FLOAT &vb3x, const KK_FLOAT &vb3y, const KK_FLOAT &vb3z) const;
+
+  DAT::ttransform_kkacc_1d k_eatom;
+  DAT::ttransform_kkacc_1d_6 k_vatom;
+
+ protected:
+  int allocated_kokkos;
+
+  class NeighborKokkos *neighborKK;
+
+  typename AT::t_kkfloat_1d_3_lr_randomread x;
+  typename AT::t_kkacc_1d_3 f;
+  typename AT::t_int_2d_lr dihedrallist;
+  typename AT::t_kkacc_1d d_eatom;
+  typename AT::t_kkacc_1d_6 d_vatom;
+
+  int nlocal,newton_bond;
+  int eflag,vflag;
+
+  DAT::tdual_int_scalar k_warning_flag;
+  typename AT::t_int_scalar d_warning_flag;
+  HAT::t_int_scalar h_warning_flag;
+
+  DAT::tdual_kkfloat_2d k_a;
+  DAT::tdual_int_1d k_nterms;
+
+  typename AT::t_kkfloat_2d d_a;
+  typename AT::t_int_1d d_nterms;
+
+  void allocate_kokkos();
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif


### PR DESCRIPTION
**Summary**

This ports the dihedral style nharmonic to the KOKKOS package.

**Related Issue(s)**

Implements and thus closes #4931 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

The porting was done almost completely by GitHub Copilot using Claude Opus 4.6.
Axel Kohlmeyer only fixed a couple of bugs including the restart bug that was
just today discovered and corrected in dihedral style fourier in PR #4929.

**Backward Compatibility**

Binary restarts for dihedral nharmonic are not compatible with older versions.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the CMake based build system
