### PR TITLE
  Fix CommTiledKokkos pair comm segfault with GPU pairs + CommTiled buffer undersize

### DIFF
--- a/src/KOKKOS/pair_mliap_kokkos.cpp
+++ b/src/KOKKOS/pair_mliap_kokkos.cpp
@@ -31,6 +31,7 @@
 #include "lammps.h"
 #include "kokkos.h"
 #include "pointers.h"
+#include <cuda_runtime.h>
 
 using namespace LAMMPS_NS;
 
@@ -355,11 +356,31 @@ int PairMLIAPKokkos<DeviceType>::forward_comm(CommType* copy_from_, CommType* co
   copy_from = copy_from_;
   comm_forward = vec_len=vl;
 
-  Kokkos::parallel_for((atom->nlocal+atom->nghost)*vl, KOKKOS_LAMBDA (int i) {
+  int total = (atom->nlocal+atom->nghost)*vl;
+
+  // Sync all CUDA streams (torch may have pending ops on its own stream)
+  cudaDeviceSynchronize();
+
+  Kokkos::parallel_for(total, KOKKOS_LAMBDA (int i) {
     copy_to_[i] = copy_from_[i];
   });
-  //call comm
+  Kokkos::fence();
+
+  // Create host mirror for non-Kokkos comm fallback (comm_style tiled)
+  size_t bytes = total * sizeof(CommType);
+  comm_host_buf_.resize((bytes + sizeof(double) - 1) / sizeof(double));
+  CommType* host_ptr = reinterpret_cast<CommType*>(comm_host_buf_.data());
+
+  // Use cudaMemcpy directly instead of Kokkos::View wrapping torch pointers
+  cudaMemcpy(host_ptr, copy_to_, bytes, cudaMemcpyDeviceToHost);
+
+  used_host_comm_ = false;
   comm->forward_comm(this);
+
+  // Sync host buffer back to device if non-Kokkos comm path was used
+  if (used_host_comm_) {
+    cudaMemcpy(copy_to_, host_ptr, bytes, cudaMemcpyHostToDevice);
+  }
 
   return 0;
 }
@@ -381,11 +402,31 @@ int PairMLIAPKokkos<DeviceType>::reverse_comm(CommType* copy_from_, CommType* co
   copy_from = copy_from_;
   comm_reverse = vec_len = vl;
 
-  Kokkos::parallel_for((atom->nlocal+atom->nghost)*vl, KOKKOS_LAMBDA (int i) {
+  int total = (atom->nlocal+atom->nghost)*vl;
+
+  // Sync all CUDA streams (torch may have pending ops on its own stream)
+  cudaDeviceSynchronize();
+
+  Kokkos::parallel_for(total, KOKKOS_LAMBDA (int i) {
     copy_to_[i] = copy_from_[i]; // Copy inputs
   });
+  Kokkos::fence();
 
+  // Create host mirror for non-Kokkos comm fallback (comm_style tiled)
+  size_t bytes = total * sizeof(CommType);
+  comm_host_buf_.resize((bytes + sizeof(double) - 1) / sizeof(double));
+  CommType* host_ptr = reinterpret_cast<CommType*>(comm_host_buf_.data());
+
+  // Use cudaMemcpy directly instead of Kokkos::View wrapping torch pointers
+  cudaMemcpy(host_ptr, copy_to_, bytes, cudaMemcpyDeviceToHost);
+
+  used_host_comm_ = false;
   comm->reverse_comm(this);
+
+  // Sync host buffer back to device if non-Kokkos comm path was used
+  if (used_host_comm_) {
+    cudaMemcpy(copy_to_, host_ptr, bytes, cudaMemcpyHostToDevice);
+  }
 
   Kokkos::parallel_for(
     Kokkos::RangePolicy<>( (atom->nlocal)*vl,(atom->nlocal + atom->nghost)*vl),
@@ -461,13 +502,16 @@ int PairMLIAPKokkos<DeviceType>::pack_forward_comm(int nv, int* idx_v, double *f
 template<class DeviceType>
 template <typename CommType>
 int PairMLIAPKokkos<DeviceType>::pack_forward_comm(int nv, int* idx_v, double *fill,
-                                                   int /*int2*/, int */*intp*/, CommType *copy_to)
+                                                   int /*int2*/, int */*intp*/, CommType * /*copy_to_dev*/)
 {
+  // Use host buffer instead of device pointer
+  used_host_comm_ = true;
+  CommType* ct = reinterpret_cast<CommType*>(comm_host_buf_.data());
   for (int i=0;i<nv;++i) {
     int gstart=idx_v[i]*vec_len;
     int start=i*vec_len;
     for (int j=0;j<vec_len;++j)
-      fill[start++] = static_cast<double>(copy_to[gstart++]);
+      fill[start++] = static_cast<double>(ct[gstart++]);
   }
   return nv*vec_len;
 }
@@ -524,12 +568,15 @@ void PairMLIAPKokkos<DeviceType>::unpack_forward_comm(int nv, int first_up, doub
 template <class DeviceType>
 template <typename CommType>
 void PairMLIAPKokkos<DeviceType>::unpack_forward_comm(
-    int nv, int first_up, double *fill, CommType *copy_to) {
+    int nv, int first_up, double *fill, CommType * /*copy_to_dev*/) {
+  // Use host buffer instead of device pointer
+  used_host_comm_ = true;
+  CommType* ct = reinterpret_cast<CommType*>(comm_host_buf_.data());
   for (int i=0; i<nv; ++i) {
     int gstart=(first_up+i)*vec_len;
     int start=i*vec_len;
     for (int j=0;j<vec_len;++j) {
-      copy_to[gstart+j] = static_cast<CommType>(fill[start+j]);
+      ct[gstart+j] = static_cast<CommType>(fill[start+j]);
     }
   }
 }
@@ -588,13 +635,16 @@ int PairMLIAPKokkos<DeviceType>::pack_reverse_comm(int nv, int first_up, double 
 /* ---------------------------------------------------------------------- */
 template<class DeviceType>
 template<typename CommType>
-int PairMLIAPKokkos<DeviceType>::pack_reverse_comm(int nv, int first_up, double *fill, CommType *copy_to)
+int PairMLIAPKokkos<DeviceType>::pack_reverse_comm(int nv, int first_up, double *fill, CommType * /*copy_to_dev*/)
 {
+  // Use host buffer instead of device pointer
+  used_host_comm_ = true;
+  CommType* ct = reinterpret_cast<CommType*>(comm_host_buf_.data());
   for (int i=0;i<nv;++i) {
     int gstart=(first_up+i)*vec_len;
     int start=i*vec_len;
     for (int j=0;j<vec_len;++j) {
-      fill[start++] = static_cast<double>(copy_to[gstart++]);
+      fill[start++] = static_cast<double>(ct[gstart++]);
     }
   }
   return nv*vec_len;
@@ -657,13 +707,16 @@ void PairMLIAPKokkos<DeviceType>::unpack_reverse_comm(int nv, int *idx, double *
 
 template<class DeviceType>
 template<typename CommType>
-void PairMLIAPKokkos<DeviceType>::unpack_reverse_comm(int nv, int *idx, double *fill, CommType *copy_to)
+void PairMLIAPKokkos<DeviceType>::unpack_reverse_comm(int nv, int *idx, double *fill, CommType * /*copy_to_dev*/)
 {
+  // Use host buffer instead of device pointer
+  used_host_comm_ = true;
+  CommType* ct = reinterpret_cast<CommType*>(comm_host_buf_.data());
   for (int i=0;i<nv;++i) {
     int gstart=idx[i]*vec_len;
     int start=i*vec_len;
     for (int j=0;j<vec_len;++j)
-      copy_to[gstart++] += static_cast<CommType>(fill[start++]);
+      ct[gstart++] += static_cast<CommType>(fill[start++]);
   }
 }
 namespace LAMMPS_NS {

--- a/src/KOKKOS/pair_mliap_kokkos.h
+++ b/src/KOKKOS/pair_mliap_kokkos.h
@@ -104,6 +104,13 @@ public:
   enum class COMM_TYPE {FLOAT=0, DOUBLE, UNSET} comm_type;
   int vec_len;
 
+  // Host mirror buffer for non-Kokkos comm fallback (e.g. comm_style tiled).
+  // CommTiledKokkos::forward_comm(Pair*) falls back to CPU pack/unpack which
+  // cannot access GPU pointers. We copy device data to this host buffer before
+  // comm and sync back after.
+  std::vector<double> comm_host_buf_;
+  bool used_host_comm_;
+
   typename AT::t_kkfloat_1d_3_lr_randomread x;
   typename AT::t_kkfloat_1d_3_randomread v;
   typename AT::t_kkacc_1d_3 f;

--- a/src/comm_tiled.cpp
+++ b/src/comm_tiled.cpp
@@ -1244,6 +1244,13 @@ void CommTiled::forward_comm(Pair *pair, int size)
   if (size) nsize = size;
   else nsize = pair->comm_forward;
 
+  // Ensure send/recv buffers are large enough for nsize values per atom
+  if (nsize > maxforward) {
+    maxforward = nsize;
+    if (maxforward*smaxone > maxsend) grow_send(maxforward*smaxone,0);
+    if (maxforward*rmaxall > maxrecv) grow_recv(maxforward*rmaxall);
+  }
+
   for (int iswap = 0; iswap < nswap; iswap++) {
     nsend = nsendproc[iswap] - sendself[iswap];
     nrecv = nrecvproc[iswap] - sendself[iswap];
@@ -1292,6 +1299,13 @@ void CommTiled::reverse_comm(Pair *pair, int size)
 
   if (size) nsize = MAX(pair->comm_reverse, pair->comm_reverse_off);
   else nsize = pair->comm_reverse;
+
+  // Ensure send/recv buffers are large enough for nsize values per atom
+  if (nsize > maxforward) {
+    maxforward = nsize;
+    if (maxforward*smaxone > maxsend) grow_send(maxforward*smaxone,0);
+    if (maxforward*rmaxall > maxrecv) grow_recv(maxforward*rmaxall);
+  }
 
   for (int iswap = nswap-1; iswap >= 0; iswap--) {
     nsend = nsendproc[iswap] - sendself[iswap];


### PR DESCRIPTION
  ## Summary

  Fixes two bugs when using `comm_style tiled` with Kokkos GPU pair styles (`pair_style mliap unified` on multi-GPU):

  1. **`CommTiledKokkos::forward_comm(Pair*)`** falls through to the CPU base class (`CommTiled`), which calls `pack_forward_comm()` — the CPU virtual. For GPU pairs like `PairMLIAPKokkos`, `copy_to`/`copy_from` are
  CUDA device pointers. The CPU routine dereferences them on the host → SIGSEGV at MD step 1 of NVT dynamics. The crash is latent at step 0 because `sendother[iswap]==0` for balanced initial positions; at step 1,
  velocity integration moves atoms, `sendother > 0`, and the CPU dereference segfaults. `CommKokkos` (brick comm) handles this correctly via `forward_comm_device<DeviceType>(Pair*)` → `pack_forward_comm_kokkos`;
  `CommTiledKokkos` has no equivalent.

  2. **`CommTiled::forward_comm(Pair*)`** and `reverse_comm(Pair*)` do not check that `buf_send`/`buf_recv` are large enough for the pair's per-atom comm size. Buffers are sized during `borders()` based on
  `size_border`, but pairs like MLIAP communicate `vec_len` doubles per atom (potentially much larger). `CommBrick::forward_comm(Pair*)` has the analogous buffer-grow check; `CommTiled` was missing it.

  ## Changes

  - `src/KOKKOS/pair_mliap_kokkos.h` — added `comm_host_buf_` (`std::vector<double>`) and `used_host_comm_` (`bool`) members
  - `src/KOKKOS/pair_mliap_kokkos.cpp` — host-mirror buffer workaround: `cudaMemcpy` device data to host before `comm->forward_comm(this)`; CPU `pack_forward_comm`/`unpack_forward_comm` fallback reads/writes the host
  buffer; `cudaMemcpy` back to device after comm if CPU path was used
  - `src/comm_tiled.cpp` — added `nsize`-aware buffer grow check at entry of `forward_comm(Pair*)` and `reverse_comm(Pair*)`, matching the existing pattern in `CommBrick`

  ## Note on workaround vs. proper fix

  The host-buffer approach in `PairMLIAPKokkos` is a workaround — it avoids the segfault but incurs a device→host→device round-trip per comm step. The proper long-term fix is to add a GPU-aware pair comm path to
  `CommTiledKokkos` (analogous to `CommKokkos::forward_comm_device(Pair*, int)`), which would call `pack_forward_comm_kokkos`/`unpack_forward_comm_kokkos` directly on device memory. That is left as a follow-up; the
  workaround is removed once that path exists.

  ## Test plan

  - [x] NVT dynamics with `comm_style tiled` + `pair_style mliap unified` on 8 GPUs — no segfault
  - [x] Geometry optimization with `comm_style tiled` — still works
  - [x] `comm_style brick` path — no regression
  - [ ] LAMMPS test suite: `ctest -R mliap`

Fixes #4942

**Author(s)**

Joseph Gauthier, Department of Chemical Engineering, Texas Tech University
joe.gauthier@ttu.edu
<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request. If this pull request adds new files to the distribution, please also provide a suitable "long-lived" e-mail address (ideally something that can outlive your institution's e-mail, in case you change jobs) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this contributed code.-->

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

<!--Please update the following sentence as needed in case you were using AI tools to
generate code.  Please mention which specific AI tool or tools you were using and which
parts of the code were AI generated versus the parts written by a human.  The use of AI
tools for checking spelling and syntax does not need to be reported.-->

In submitting this pull request, I acknowledge that Claude Code was utilized to diagnose and implement the fix.

**Backward Compatibility**

I am not certain that this fix will satisfy backwards compatibility. 

**Implementation Notes**

No other features should be affected by this.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines ; Not verified — clang-format was not run over the changed files. Happy to apply formatting if reviewers flag issues
- [ ] Suitable new documentation files and/or updates to the existing docs are included; This is a bug fix, not a new feature. No new user-facing behavior is introduced. No documentation changes are needed.
- [ ] The feature has been verified to work with the conventional build system; Only the CMake build was tested
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.; No unit tests added. The fix was validated by running NVT dynamics on an 8-GPU system with pair_style mliap unified + comm_style tiled, which previously segfaulted at step 1 and now completes successfully. A formal regression test would require a MACE model file and GPU resources; we are open to guidance from maintainers on how to add one.
- [ ] One or more example input decks are included; No new example added to the examples tree. The reproduction case is described in the linked issue.


