### PR TITLE
Update pair granular doc: tangential models

### DIFF
--- a/doc/src/pair_granular.rst
+++ b/doc/src/pair_granular.rst
@@ -507,14 +507,14 @@ The general form of the tangential contact force for all models is:
 
 .. math::
 
-   \mathbf{F}_t =  \min(\mu_t F_{n0}, \|\mathbf{F}_{te} + mathbf{F}_\mathrm{t,damp}\|) \mathbf{t}
+   \mathbf{F}_t =  \min(\mu_t F_{n0}, \|\mathbf{F}_{te} + \mathbf{F}_\mathrm{t,damp}\|) \mathbf{t}
 
 where :math:`\mathbf{F}_{te}` and :math:`\mathbf{F}_\mathrm{t,damp}`
 are the elastic and damping components of the tangential force, respectively,
 and :math:`\mathbf{t}` is the direction of the tangential force given by:
 
 .. math::
-   \mathbf{t} = \frac{\mathbf{F}_{te} + mathbf{F}_\mathrm{t,damp})}{\|\mathbf{F}_{te} + mathbf{F}_\mathrm{t,damp}\|)}
+   \mathbf{t} = \frac{\mathbf{F}_{te} + \mathbf{F}_\mathrm{t,damp}}{\|\mathbf{F}_{te} + \mathbf{F}_\mathrm{t,damp}\|}
 
 The normal force value :math:`F_{n0}` used to compute the critical force
 depends on the form of the contact model.  For non-cohesive models (\
@@ -563,19 +563,18 @@ contact is given by :math:`\mathbf{v}_{t, rel} = \mathbf{v}_{t} -
 (R_i\boldsymbol{\Omega}_i + R_j\boldsymbol{\Omega}_j) \times
 \mathbf{n}`, where :math:`\mathbf{v}_{t} = \mathbf{v}_r -
 \mathbf{v}_r\cdot\mathbf{n}\ \mathbf{n}`, :math:`\mathbf{v}_r =
-\mathbf{v}_j - \mathbf{v}_i` . 
+\mathbf{v}_j - \mathbf{v}_i` .
 
 The elastic tangential force :math:`\mathbf{F}_{te}` depends on the tangential
 model and is detailed hereafter for each tangential model.
 
-For *tangential linear_nohistory*, no elastic force is considered,
-:math:`\mathbf{F}_{te} = \mathbf{0}`. This is used to mimic the behavior
-of the *pair gran/hooke* style.  The tangential force :math:`\mathbf{F}_t` is given
-by:
+For *tangential linear_nohistory*, no elastic force is considered:
 
 .. math::
 
-   \mathbf{F}_t =  -\min(\mu_t F_{n0}, \|\mathbf{F}_\mathrm{t,damp}\|) \mathbf{v_{t,rel}}/\|\mathbf{v_{t,rel}}\|
+   \mathbf{F}_{te} = \mathbf{0}
+
+This is used to mimic the behavior of the *pair gran/hooke* style.
 
 The remaining tangential options all use accumulated tangential
 displacement (i.e. contact history), except for the options
@@ -690,7 +689,7 @@ the normal overlap as noted above.  The elastic tangential force is given by:
 
 .. math::
 
-   mathbf{F}_{te} = \int_{t_0}^{t} -k_t a \mathbf{v}_{t,rel} \mathrm{d}\tau
+   \mathbf{F}_{te} = \int_{t_0}^{t} -k_t a \mathbf{v}_{t,rel} \mathrm{d}\tau
 
 The changes in frame of reference of the contacting pair of particles
 during contact are accounted for by the same formula as above, replacing

--- a/doc/src/pair_granular.rst
+++ b/doc/src/pair_granular.rst
@@ -503,42 +503,18 @@ damping :math:`\eta_n` that determines the magnitude of the tangential
 damping, :math:`\mu_t` is the tangential (or sliding) friction
 coefficient, and :math:`k_t` is the tangential stiffness coefficient.
 
-For *tangential linear_nohistory*, a simple velocity-dependent Coulomb
-friction criterion is used, which mimics the behavior of the *pair
-gran/hooke* style.  The tangential force :math:`\mathbf{F}_t` is given
-by:
+The general form of the tangential contact force for all models is:
 
 .. math::
 
-   \mathbf{F}_t =  -\min(\mu_t F_{n0}, \|\mathbf{F}_\mathrm{t,damp}\|) \mathbf{t}
+   \mathbf{F}_t =  \min(\mu_t F_{n0}, \|\mathbf{F}_{te} + mathbf{F}_\mathrm{t,damp}\|) \mathbf{t}
 
-The tangential damping force :math:`\mathbf{F}_\mathrm{t,damp}` is given
-by:
-
-.. math::
-
-   \mathbf{F}_\mathrm{t,damp} = -\eta_t \mathbf{v}_{t,rel}
-
-The tangential damping prefactor :math:`\eta_t` is calculated by scaling
-the normal damping :math:`\eta_n` (see above):
+where :math:`\mathbf{F}_{te}` and :math:`\mathbf{F}_\mathrm{t,damp}`
+are the elastic and damping components of the tangential force, respectively,
+and :math:`\mathbf{t}` is the direction of the tangential force given by:
 
 .. math::
-
-   \eta_t = -x_{\gamma,t} \eta_n
-
-The normal damping prefactor :math:`\eta_n` is determined by the choice
-of the *damping* keyword, as discussed above.  Thus, the *damping*
-keyword also affects the tangential damping.  The parameter
-:math:`x_{\gamma,t}` is a scaling coefficient.  Several works in the
-literature use :math:`x_{\gamma,t} = 1` (:ref:`Marshall
-<Marshall2009_1>`, :ref:`Tsuji et al <Tsuji1992_1>`, :ref:`Silbert et al
-<Silbert2001_1>`).  The relative tangential velocity at the point of
-contact is given by :math:`\mathbf{v}_{t, rel} = \mathbf{v}_{t} -
-(R_i\boldsymbol{\Omega}_i + R_j\boldsymbol{\Omega}_j) \times
-\mathbf{n}`, where :math:`\mathbf{v}_{t} = \mathbf{v}_r -
-\mathbf{v}_r\cdot\mathbf{n}\ \mathbf{n}`, :math:`\mathbf{v}_r =
-\mathbf{v}_j - \mathbf{v}_i` .  The direction of the applied force is
-:math:`\mathbf{t} = \mathbf{v_{t,rel}}/\|\mathbf{v_{t,rel}}\|` .
+   \mathbf{t} = \frac{\mathbf{F}_{te} + mathbf{F}_\mathrm{t,damp})}{\|\mathbf{F}_{te} + mathbf{F}_\mathrm{t,damp}\|)}
 
 The normal force value :math:`F_{n0}` used to compute the critical force
 depends on the form of the contact model.  For non-cohesive models (\
@@ -562,6 +538,45 @@ the form:
 Where :math:`F_{pulloff} = 3\pi \gamma R` for *jkr*, and
 :math:`F_{pulloff} = 4\pi \gamma R` for *dmt*\ .
 
+
+The tangential damping force is the same for all models and is given by:
+
+.. math::
+
+   \mathbf{F}_\mathrm{t,damp} = -\eta_t \mathbf{v}_{t,rel}
+
+The tangential damping prefactor :math:`\eta_t` is calculated by scaling
+the normal damping :math:`\eta_n` (see above):
+
+.. math::
+
+   \eta_t = -x_{\gamma,t} \eta_n
+
+The normal damping prefactor :math:`\eta_n` is determined by the choice
+of the *damping* keyword, as discussed above.  Thus, the *damping*
+keyword also affects the tangential damping.  The parameter
+:math:`x_{\gamma,t}` is a scaling coefficient.  Several works in the
+literature use :math:`x_{\gamma,t} = 1` (:ref:`Marshall
+<Marshall2009_1>`, :ref:`Tsuji et al <Tsuji1992_1>`, :ref:`Silbert et al
+<Silbert2001_1>`).  The relative tangential velocity at the point of
+contact is given by :math:`\mathbf{v}_{t, rel} = \mathbf{v}_{t} -
+(R_i\boldsymbol{\Omega}_i + R_j\boldsymbol{\Omega}_j) \times
+\mathbf{n}`, where :math:`\mathbf{v}_{t} = \mathbf{v}_r -
+\mathbf{v}_r\cdot\mathbf{n}\ \mathbf{n}`, :math:`\mathbf{v}_r =
+\mathbf{v}_j - \mathbf{v}_i` . 
+
+The elastic tangential force :math:`\mathbf{F}_{te}` depends on the tangential
+model and is detailed hereafter for each tangential model.
+
+For *tangential linear_nohistory*, no elastic force is considered,
+:math:`\mathbf{F}_{te} = \mathbf{0}`. This is used to mimic the behavior
+of the *pair gran/hooke* style.  The tangential force :math:`\mathbf{F}_t` is given
+by:
+
+.. math::
+
+   \mathbf{F}_t =  -\min(\mu_t F_{n0}, \|\mathbf{F}_\mathrm{t,damp}\|) \mathbf{v_{t,rel}}/\|\mathbf{v_{t,rel}}\|
+
 The remaining tangential options all use accumulated tangential
 displacement (i.e. contact history), except for the options
 *mindlin/force* and *mindlin_rescale/force*, that use accumulated
@@ -570,18 +585,18 @@ accumulated tangential displacement is discussed in details below in the
 context of the *linear_history* option.  The same treatment of the
 accumulated displacement applies to the other options as well.
 
-For *tangential linear_history*, the tangential force is given by:
+For *tangential linear_history*, the elastic tangential force is given by:
 
 .. math::
 
-   \mathbf{F}_t =  -\min(\mu_t F_{n0}, \|-k_t\mathbf{\xi} + \mathbf{F}_\mathrm{t,damp}\|) \mathbf{t}
+   \mathbf{F}_{te} = -k_t\mathbf{\xi}
 
 Here, :math:`\mathbf{\xi}` is the tangential displacement accumulated
 during the entire duration of the contact:
 
 .. math::
 
-   \mathbf{\xi} = \int_{t0}^t \mathbf{v}_{t,rel}(\tau) \mathrm{d}\tau
+   \mathbf{\xi} = \int_{t_0}^t \mathbf{v}_{t,rel}(\tau) \mathrm{d}\tau
 
 This accumulated tangential displacement must be adjusted to account for
 changes in the frame of reference of the contacting pair of particles
@@ -635,11 +650,11 @@ overlap region) to induce a torque on each particle according to:
 For *tangential mindlin*, the :ref:`Mindlin <Mindlin1949>` no-slip
 solution is used which differs from the *linear_history* option by an
 additional factor of :math:`a`, the radius of the contact region.  The
-tangential force is given by:
+elastic tangential force is given by:
 
 .. math::
 
-   \mathbf{F}_t =  -\min(\mu_t F_{n0}, \|-k_t a \mathbf{\xi} + \mathbf{F}_\mathrm{t,damp}\|) \mathbf{t}
+   \mathbf{F}_{te} =  -k_t a \mathbf{\xi}
 
 Here, :math:`a` is the radius of the contact region, given by :math:`a
 =\sqrt{R\delta}` for all normal contact models, except for *jkr*, where
@@ -671,18 +686,11 @@ done according to the formula above.
 For *tangential mindlin/force*, the accumulated elastic tangential force
 characterizes the contact history, instead of the accumulated tangential
 displacement.  This prevents the dependence of the tangential force on
-the normal overlap as noted above.  The tangential force is given by:
+the normal overlap as noted above.  The elastic tangential force is given by:
 
 .. math::
 
-   \mathbf{F}_t =  -\min(\mu_t F_{n0}, \|\mathbf{F}_{te} + \mathbf{F}_\mathrm{t,damp}\|) \mathbf{t}
-
-The increment of the elastic component of the tangential force
-:math:`\mathbf{F}_{te}` is given by:
-
-.. math::
-
-   \mathrm{d}\mathbf{F}_{te} = -k_t a \mathbf{v}_{t,rel} \mathrm{d}\tau
+   mathbf{F}_{te} = \int_{t_0}^{t} -k_t a \mathbf{v}_{t,rel} \mathrm{d}\tau
 
 The changes in frame of reference of the contacting pair of particles
 during contact are accounted for by the same formula as above, replacing
@@ -693,7 +701,7 @@ to match the value for the critical force:
 
 .. math::
 
-   \mathbf{F}_{te} = - \mu_t F_{n0}\mathbf{t} + \mathbf{F}_{t,damp}
+   \mathbf{F}_{te} = \mu_t F_{n0}\mathbf{t} - \mathbf{F}_{t,damp}
 
 The same rules as those described for *mindlin* apply regarding the
 tangential stiffness and mixing of the shear modulus for different

--- a/doc/src/pair_granular_superellipsoid.rst
+++ b/doc/src/pair_granular_superellipsoid.rst
@@ -343,9 +343,7 @@ The relative tangential velocity at the point of contact is given by
 (R_i\boldsymbol{\Omega}_i + R_j\boldsymbol{\Omega}_j) \times
 \mathbf{n}`, where :math:`\mathbf{v}_{t} = \mathbf{v}_r -
 \mathbf{v}_r\cdot\mathbf{n}\ \mathbf{n}`, :math:`\mathbf{v}_r =
-\mathbf{v}_j - \mathbf{v}_i` .  The direction of the applied force is
-:math:`\mathbf{t} = \mathbf{v_{t,rel}}/\|\mathbf{v_{t,rel}}\|` .
-
+\mathbf{v}_j - \mathbf{v}_i` .
 The normal force value :math:`F_{n0}` used to compute the critical force
 depends on the form of the contact model.  It is given by the magnitude
 of the normal force:
@@ -364,9 +362,15 @@ For *tangential linear_history*, the tangential force is given by:
 
 .. math::
 
-   \mathbf{F}_t =  -\min(\mu_t F_{n0}, \|-k_t\mathbf{\xi} + \mathbf{F}_\mathrm{t,damp}\|) \mathbf{t}
+   \mathbf{F}_t =  \min(\mu_t F_{n0}, \|-k_t\mathbf{\xi} + \mathbf{F}_\mathrm{t,damp}\|) \mathbf{t}
 
-Here, :math:`\mathbf{\xi}` is the tangential displacement accumulated
+Here, :math:`\mathbf{t}` is the direction of the tangential force given by:
+
+.. math::
+
+   \mathbf{t} = \frac{-k_t\mathbf{\xi} + \mathbf{F}_\mathrm{t,damp}}{\|-k_t\mathbf{\xi} + \mathbf{F}_\mathrm{t,damp}\|}
+
+and, :math:`\mathbf{\xi}` is the tangential displacement accumulated
 during the entire duration of the contact:
 
 .. math::


### PR DESCRIPTION
**Summary**

When describing the "tangential linear_nohistory" keyword, the current doc for pair granular states that "The direction of the applied force is $\mathbf{t} = \mathbf{v_{t,rel}}/\|\mathbf{v_{t,rel}}\|$ ".

This is only true for "tangential linear_nohistory" where the damping force is colinear to the relative velocity.
However, for every other model, $\mathbf{t}$ is not redefined, which leads to confusing expressions.

For example in the "tangential linear_history", expression

$$
\mathbf{F}_t =  -\min(\mu_t F_{n0}, \|-k_t\mathbf{\xi} + \mathbf{F}_\mathrm{t,damp}\|) \mathbf{t}
$$

is not correct since the tangential displacement $\mathbf{\xi} = \int_{t0}^t \mathbf{v}_{t,rel}(\tau) \mathrm{d}\tau$ is not necessarily colinear to the relative velocity.

What is actually done in the code is what is proposed by [Luding 2008](https://link.springer.com/article/10.1007/s10035-008-0099-x) (Equation 21), i.e., compute the tangential force

$$
-k_t \mathbf{\xi} + \mathbf{F}_\mathrm{t,damp}
$$

and rescale the magnitude of this force if it is larger than the Coulomb friction limit. Therefore, the direction of the applied force is always

$$ 
\mathbf{t} = \frac{-k_t\mathbf{\xi} + \mathbf{F}_\mathrm{t,damp} }{ \| -k_t\mathbf{\xi} + \mathbf{F}_\mathrm{t,damp} \|}
$$

(or the equivalent expression for the different models).

---

The PR corrects the expression of $\mathbf{t}$, and consequently modifies the expressions for the tangential forces.

The general expression of the tangential force is generalized to:

$$
\mathbf{F}_\mathrm{t} = +\min(\mu_t F_{n0}, \| \mathbf{F}_\mathrm{te} + \mathbf{F}_\mathrm{t,damp} \|) \mathbf{t}
$$

and introduced once at the beginning of the tangential force section. Note the `+`min instead of `-`min due to the change in definition of $\mathbf{t}$:

$$ 
\mathbf{t} = \frac{\mathbf{F}_\mathrm{te} + \mathbf{F}_\mathrm{t,damp} }{ \| \mathbf{F}_\mathrm{te} + \mathbf{F}_\mathrm{t,damp} \|}
$$

and where

$$
\mathbf{F}_\mathrm{t,damp} = -\eta_t \mathbf{v}_{t,rel}
$$

is the same for all models and is also only introduced once, and $\mathbf{F}_{te}$ is the elastic tangential force, which is different for each model.

For "tangential linear_history":

$$
\mathbf{F}_{te} = -k_t \xi
$$

For "tangential mindlin":

$$
\mathbf{F}_{te} = -k_t a \xi
$$

and for "tangential mindlin/force"

$$
\mathbf{F}_{te} = \int_{t_0}^{t} -k_t a \mathbf{v}_{t,rel} \mathrm{d}\tau
$$

**Related Issue(s)**

None

**Author(s)**

Jibril B. Coulibaly

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

<!--Please update the following sentence as needed in case you were using AI tools to
generate code.  Please mention which specific AI tool or tools you were using and which
parts of the code were AI generated versus the parts written by a human.  The use of AI
tools for checking spelling and syntax does not need to be reported.-->

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Backward Compatibility**

Yes, doc changes only

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->
