### PR TITLE
Skip NeighborClass test if MANYBODY not installed

### DIFF
--- a/unittest/cplusplus/test_neighbor_class.cpp
+++ b/unittest/cplusplus/test_neighbor_class.cpp
@@ -1340,6 +1340,7 @@ TEST_F(NeighborListsNsq, one_atomic_half_list_nonewton_exclude)
 
 TEST_F(NeighborListsNsq, one_atomic_full)
 {
+    if (!lammps_config_has_package("MANYBODY")) GTEST_SKIP() << "Missing MANYBODY package for test";
     create_system("atomic", "metal", "on");
     BEGIN_CAPTURE_OUTPUT();
     command("pair_style sw");


### PR DESCRIPTION
**Summary**

This is a bugfix for the unit tests.
The NeighborClass test fails if the MANYBODY package is not installed, because "TEST_F(NeighborListsNsq, one_atomic_full)" is using "pair_sytle sw". This test is now skipped in the same way as "TEST_F(NeighborListsBin, one_atomic_full)"

**Related Issue(s)**

N/A

**Author(s)**

Ludwig Ahrens (ludwig.ahiw@gmail.com)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included


