### PR TITLE
Port bond, angle, dihedral, and improper styles to the OPENMP package

### DIFF
--- a/doc/src/Commands_bond.rst
+++ b/doc/src/Commands_bond.rst
@@ -31,7 +31,7 @@ OPT.
    * :doc:`gaussian <bond_gaussian>`
    * :doc:`gromos (o) <bond_gromos>`
    * :doc:`harmonic (iko) <bond_harmonic>`
-   * :doc:`harmonic/restrain <bond_harmonic_restrain>`
+   * :doc:`harmonic/restrain (o) <bond_harmonic_restrain>`
    * :doc:`harmonic/shift (o) <bond_harmonic_shift>`
    * :doc:`harmonic/shift/cut (o) <bond_harmonic_shift_cut>`
    * :doc:`lepton (o) <bond_lepton>`
@@ -87,12 +87,12 @@ OPT.
    * :doc:`dipole (o) <angle_dipole>`
    * :doc:`fourier (o) <angle_fourier>`
    * :doc:`fourier/simple (o) <angle_fourier_simple>`
-   * :doc:`gaussian <angle_gaussian>`
+   * :doc:`gaussian (o) <angle_gaussian>`
    * :doc:`harmonic (iko) <angle_harmonic>`
    * :doc:`lepton (o) <angle_lepton>`
    * :doc:`mesocnt <angle_mesocnt>`
    * :doc:`mm3 <angle_mm3>`
-   * :doc:`mwlc <angle_mwlc>`
+   * :doc:`mwlc (o) <angle_mwlc>`
    * :doc:`quartic (o) <angle_quartic>`
    * :doc:`spica (ko) <angle_spica>`
    * :doc:`table (o) <angle_table>`
@@ -121,11 +121,11 @@ OPT.
    *
    *
    * :doc:`charmm (iko) <dihedral_charmm>`
-   * :doc:`charmmfsw (k) <dihedral_charmm>`
+   * :doc:`charmmfsw (ko) <dihedral_charmm>`
    * :doc:`class2 (ko) <dihedral_class2>`
    * :doc:`class2xe <dihedral_class2>`
    * :doc:`cosine/shift/exp (o) <dihedral_cosine_shift_exp>`
-   * :doc:`cosine/squared/restricted <dihedral_cosine_squared_restricted>`
+   * :doc:`cosine/squared/restricted (o) <dihedral_cosine_squared_restricted>`
    * :doc:`fourier (iko) <dihedral_fourier>`
    * :doc:`harmonic (iko) <dihedral_harmonic>`
    * :doc:`helix (o) <dihedral_helix>`
@@ -134,9 +134,9 @@ OPT.
    * :doc:`nharmonic (ko) <dihedral_nharmonic>`
    * :doc:`opls (iko) <dihedral_opls>`
    * :doc:`quadratic (o) <dihedral_quadratic>`
-   * :doc:`spherical <dihedral_spherical>`
+   * :doc:`spherical (o) <dihedral_spherical>`
    * :doc:`table (o) <dihedral_table>`
-   * :doc:`table/cut <dihedral_table>`
+   * :doc:`table/cut (o) <dihedral_table>`
 
 .. _improper:
 
@@ -165,7 +165,7 @@ OPT.
    * :doc:`class2 (ko) <improper_class2>`
    * :doc:`cossq (o) <improper_cossq>`
    * :doc:`cvff (iko) <improper_cvff>`
-   * :doc:`distance <improper_distance>`
+   * :doc:`distance (o) <improper_distance>`
    * :doc:`distharm <improper_distharm>`
    * :doc:`fourier (o) <improper_fourier>`
    * :doc:`harmonic (iko) <improper_harmonic>`

--- a/doc/src/Commands_bond.rst
+++ b/doc/src/Commands_bond.rst
@@ -74,7 +74,7 @@ OPT.
    * :doc:`charmm (iko) <angle_charmm>`
    * :doc:`class2 (ko) <angle_class2>`
    * :doc:`class2/p6 <angle_class2>`
-   * :doc:`class2xe <angle_class2>`
+   * :doc:`class2xe (o) <angle_class2>`
    * :doc:`cosine (ko) <angle_cosine>`
    * :doc:`cosine/buck6d <angle_cosine_buck6d>`
    * :doc:`cosine/delta (o) <angle_cosine_delta>`
@@ -123,7 +123,7 @@ OPT.
    * :doc:`charmm (iko) <dihedral_charmm>`
    * :doc:`charmmfsw (k) <dihedral_charmm>`
    * :doc:`class2 (ko) <dihedral_class2>`
-   * :doc:`class2xe <dihedral_class2>`
+   * :doc:`class2xe (o) <dihedral_class2>`
    * :doc:`cosine/shift/exp (o) <dihedral_cosine_shift_exp>`
    * :doc:`cosine/squared/restricted <dihedral_cosine_squared_restricted>`
    * :doc:`fourier (iko) <dihedral_fourier>`

--- a/doc/src/angle_class2.rst
+++ b/doc/src/angle_class2.rst
@@ -2,6 +2,7 @@
 .. index:: angle_style class2/kk
 .. index:: angle_style class2/omp
 .. index:: angle_style class2xe
+.. index:: angle_style class2xe/omp
 .. index:: angle_style class2/p6
 
 angle_style class2 command
@@ -11,6 +12,8 @@ Accelerator Variants: *class2/kk*, *class2/omp*
 
 angle_style class2xe command
 ============================
+
+Accelerator Variants: *class2xe/omp*
 
 angle_style class2/p6 command
 =============================

--- a/doc/src/angle_gaussian.rst
+++ b/doc/src/angle_gaussian.rst
@@ -1,7 +1,10 @@
 .. index:: angle_style gaussian
+.. index:: angle_style gaussian/omp
 
 angle_style gaussian command
-================================
+============================
+
+Accelerator Variant: *gaussian/omp*
 
 Syntax
 """"""
@@ -46,6 +49,11 @@ or :doc:`read_restart <read_restart>` commands:
 * :math:`w_n` (> 0, radians)
 * :math:`\theta_n` (degrees)
 
+----------
+
+.. include:: accel_styles.rst
+
+----------
 
 Restrictions
 """"""""""""

--- a/doc/src/angle_mwlc.rst
+++ b/doc/src/angle_mwlc.rst
@@ -1,7 +1,10 @@
 .. index:: angle_style mwlc
+.. index:: angle_style mwlc/omp
 
 angle_style mwlc command
-==========================
+========================
+
+Accelerator Variant: *mwlc/omp*
 
 Syntax
 """"""
@@ -65,6 +68,9 @@ or :doc:`read_restart <read_restart>` commands:
 
 ----------
 
+.. include:: accel_styles.rst
+
+----------
 
 Restrictions
 """"""""""""

--- a/doc/src/bond_harmonic_restrain.rst
+++ b/doc/src/bond_harmonic_restrain.rst
@@ -1,7 +1,10 @@
 .. index:: bond_style harmonic/restrain
+.. index:: bond_style harmonic/restrain/omp
 
 bond_style harmonic/restrain command
 ====================================
+
+Accelerator Variant: *harmonic/restrain/omp*
 
 Syntax
 """"""
@@ -57,6 +60,12 @@ Restart info
 This bond style supports the :doc:`write_restart <write_restart>` and
 :doc:`read_restart <read_restart>` commands. The state of the initial
 bond lengths is stored with restart files and read back.
+
+----------
+
+.. include:: accel_styles.rst
+
+----------
 
 Restrictions
 """"""""""""

--- a/doc/src/dihedral_charmm.rst
+++ b/doc/src/dihedral_charmm.rst
@@ -4,6 +4,7 @@
 .. index:: dihedral_style charmm/omp
 .. index:: dihedral_style charmmfsw
 .. index:: dihedral_style charmmfsw/kk
+.. index:: dihedral_style charmmfsw/omp
 
 dihedral_style charmm command
 =============================
@@ -13,7 +14,7 @@ Accelerator Variants: *charmm/intel*, *charmm/kk*, *charmm/omp*
 dihedral_style charmmfsw command
 ================================
 
-Accelerator Variants: *charmmfsw/kk*
+Accelerator Variants: *charmmfsw/kk*, *charmmfsw/omp*
 
 Syntax
 """"""

--- a/doc/src/dihedral_class2.rst
+++ b/doc/src/dihedral_class2.rst
@@ -2,6 +2,7 @@
 .. index:: dihedral_style class2/omp
 .. index:: dihedral_style class2/kk
 .. index:: dihedral_style class2xe
+.. index:: dihedral_style class2xe/omp
 
 dihedral_style class2 command
 =============================
@@ -10,6 +11,8 @@ Accelerator Variants: *class2/omp*, *class2/kk*
 
 dihedral_style class2xe command
 ===============================
+
+Accelerator Variants: *class2xe/omp*
 
 Syntax
 """"""

--- a/doc/src/dihedral_cosine_squared_restricted.rst
+++ b/doc/src/dihedral_cosine_squared_restricted.rst
@@ -1,8 +1,10 @@
 .. index:: dihedral_style cosine/squared/restricted
+.. index:: dihedral_style cosine/squared/restricted/omp
 
 dihedral_style cosine/squared/restricted command
 ================================================
 
+Accelerator Variant: *cosine/squared/restricted/omp*
 
 Syntax
 """"""
@@ -43,6 +45,10 @@ or :doc:`read_restart <read_restart>` commands:
 * :math:`\phi_0` (degrees)
 
 :math:`\phi_0` is specified in degrees, but LAMMPS converts it to radians internally.
+
+----------
+
+.. include:: accel_styles.rst
 
 ----------
 

--- a/doc/src/dihedral_spherical.rst
+++ b/doc/src/dihedral_spherical.rst
@@ -4,7 +4,7 @@
 dihedral_style spherical command
 ================================
 
-Accelertor Variant: *spherical/omp*
+Accelerator Variant: *spherical/omp*
 
 Syntax
 """"""

--- a/doc/src/dihedral_spherical.rst
+++ b/doc/src/dihedral_spherical.rst
@@ -1,7 +1,10 @@
 .. index:: dihedral_style spherical
+.. index:: dihedral_style spherical/omp
 
 dihedral_style spherical command
 ================================
+
+Accelertor Variant: *spherical/omp*
 
 Syntax
 """"""
@@ -82,6 +85,10 @@ the Dihedral Coeffs section of a data file read by the
 * :math:`M_n` (typically an integer)
 * :math:`c_n` (degrees, typically 0.0 or 90.0)
 * :math:`w_n` (typically 0.0 or 1.0)
+
+----------
+
+.. include:: accel_styles.rst
 
 ----------
 

--- a/doc/src/dihedral_table.rst
+++ b/doc/src/dihedral_table.rst
@@ -1,14 +1,17 @@
 .. index:: dihedral_style table
 .. index:: dihedral_style table/omp
 .. index:: dihedral_style table/cut
+.. index:: dihedral_style table/cut/omp
 
 dihedral_style table command
 ============================
 
-Accelerator Variants: *table/omp*
+Accelerator Variant: *table/omp*
 
 dihedral_style table/cut command
 ================================
+
+Accelerator Variant: *table/cut/omp*
 
 Syntax
 """"""
@@ -232,6 +235,8 @@ that matches the specified keyword.
 ----------
 
 .. include:: accel_styles.rst
+
+----------
 
 Restart, fix_modify, output, run start/stop, minimize info
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/doc/src/improper_distance.rst
+++ b/doc/src/improper_distance.rst
@@ -1,7 +1,10 @@
 .. index:: improper_style distance
+.. index:: improper_style distance/omp
 
 improper_style distance command
 ===============================
+
+Accelerator Variant: *distance/omp*
 
 Syntax
 """"""
@@ -58,6 +61,12 @@ atom of symmetry; all other atoms are considered interchangeable.  This
 convention is relevant for operations that require knowledge of how atoms
 are ordered, such as automatic assignment of new improper types by
 :doc:`fix bond/react <fix_bond_react>`.
+
+----------
+
+.. include:: accel_styles.rst
+
+----------
 
 Restrictions
 """"""""""""

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -542,6 +542,8 @@
 /angle_class2.h
 /angle_class2_p6.cpp
 /angle_class2_p6.h
+/angle_class2xe.cpp
+/angle_class2xe.h
 /angle_cosine_buck6d.cpp
 /angle_cosine_buck6d.h
 /angle_cosine.cpp
@@ -778,6 +780,8 @@
 /dihedral_charmm.h
 /dihedral_class2.cpp
 /dihedral_class2.h
+/dihedral_class2xe.cpp
+/dihedral_class2xe.h
 /dihedral_cosine_shift_exp.cpp
 /dihedral_cosine_shift_exp.h
 /dihedral_cosine_squared_restricted.cpp

--- a/src/OPENMP/angle_class2xe_omp.cpp
+++ b/src/OPENMP/angle_class2xe_omp.cpp
@@ -1,0 +1,246 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#include "omp_compat.h"
+#include "angle_class2xe_omp.h"
+#include <cmath>
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "neighbor.h"
+
+#include "suffix.h"
+using namespace LAMMPS_NS;
+
+static constexpr double SMALL = 0.001;
+
+/* ---------------------------------------------------------------------- */
+
+AngleClass2xeOMP::AngleClass2xeOMP(class LAMMPS *lmp)
+  : AngleClass2xe(lmp), ThrOMP(lmp,THR_ANGLE)
+{
+  suffix_flag |= Suffix::OMP;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void AngleClass2xeOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = neighbor->nanglelist;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, cvatom, thr);
+
+    if (inum > 0) {
+      if (evflag) {
+        if (eflag) {
+          if (force->newton_bond) eval<1,1,1>(ifrom, ito, thr);
+          else eval<1,1,0>(ifrom, ito, thr);
+        } else {
+          if (force->newton_bond) eval<1,0,1>(ifrom, ito, thr);
+          else eval<1,0,0>(ifrom, ito, thr);
+        }
+      } else {
+        if (force->newton_bond) eval<0,0,1>(ifrom, ito, thr);
+        else eval<0,0,0>(ifrom, ito, thr);
+      }
+    }
+    thr->timer(Timer::BOND);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+void AngleClass2xeOMP::eval(int nfrom, int nto, ThrData * const thr)
+{
+  int i1,i2,i3,n,type;
+  double delx1,dely1,delz1,delx2,dely2,delz2;
+  double eangle,f1[3],f3[3];
+  double dtheta,dtheta2,dtheta3,dtheta4,de_angle;
+  double dr1,dr2,tk1,tk2,aa1,aa2,aa11,aa12,aa21,aa22;
+  double rsq1,rsq2,r1,r2,c,s,a,a11,a12,a22,b1,b2;
+  double vx11,vx12,vy11,vy12,vz11,vz12,vx21,vx22,vy21,vy22,vz21,vz22;
+  double bb_ralpha1,bb_ralpha2;
+  double ba_ralpha1,ba_ralpha2;
+
+  const auto * _noalias const x = (dbl3_t *) atom->x[0];
+  auto * _noalias const f = (dbl3_t *) thr->get_f()[0];
+  const int4_t * _noalias const anglelist = (int4_t *) neighbor->anglelist[0];
+  const int nlocal = atom->nlocal;
+  eangle = 0.0;
+
+  for (n = nfrom; n < nto; n++) {
+    i1 = anglelist[n].a;
+    i2 = anglelist[n].b;
+    i3 = anglelist[n].c;
+    type = anglelist[n].t;
+
+    // 1st bond
+
+    delx1 = x[i1].x - x[i2].x;
+    dely1 = x[i1].y - x[i2].y;
+    delz1 = x[i1].z - x[i2].z;
+
+    rsq1 = delx1*delx1 + dely1*dely1 + delz1*delz1;
+    r1 = sqrt(rsq1);
+
+    // 2nd bond
+
+    delx2 = x[i3].x - x[i2].x;
+    dely2 = x[i3].y - x[i2].y;
+    delz2 = x[i3].z - x[i2].z;
+
+    rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
+    r2 = sqrt(rsq2);
+
+    // angle (cos and sin)
+
+    c = delx1*delx2 + dely1*dely2 + delz1*delz2;
+    c /= r1*r2;
+
+    if (c > 1.0) c = 1.0;
+    if (c < -1.0) c = -1.0;
+
+    s = sqrt(1.0 - c*c);
+    if (s < SMALL) s = SMALL;
+    s = 1.0/s;
+
+    // force & energy for angle term
+
+    dtheta = acos(c) - theta0[type];
+    dtheta2 = dtheta*dtheta;
+    dtheta3 = dtheta2*dtheta;
+    dtheta4 = dtheta3*dtheta;
+
+    de_angle = 2.0*k2[type]*dtheta + 3.0*k3[type]*dtheta2 +
+      4.0*k4[type]*dtheta3;
+
+    a = -de_angle*s;
+    a11 = a*c / rsq1;
+    a12 = -a / (r1*r2);
+    a22 = a*c / rsq2;
+
+    f1[0] = a11*delx1 + a12*delx2;
+    f1[1] = a11*dely1 + a12*dely2;
+    f1[2] = a11*delz1 + a12*delz2;
+
+    f3[0] = a22*delx2 + a12*delx1;
+    f3[1] = a22*dely2 + a12*dely1;
+    f3[2] = a22*delz2 + a12*delz1;
+
+    if (EFLAG) eangle = k2[type]*dtheta2 + k3[type]*dtheta3 + k4[type]*dtheta4;
+
+    // force & energy for bond-bond term
+
+    dr1 = r1 - bb_r1[type];
+    dr2 = r2 - bb_r2[type];
+    bb_ralpha1 = exp(-bb_alpha[type]*dr1);
+    bb_ralpha2 = exp(-bb_alpha[type]*dr2);
+    tk1 = bb_d0[type]*bb_alpha[type]*bb_ralpha1*(1 - bb_ralpha2);
+    tk2 = bb_d0[type]*bb_alpha[type]*bb_ralpha2*(1 - bb_ralpha1);
+
+    f1[0] -= delx1*tk2/r1;
+    f1[1] -= dely1*tk2/r1;
+    f1[2] -= delz1*tk2/r1;
+
+    f3[0] -= delx2*tk1/r2;
+    f3[1] -= dely2*tk1/r2;
+    f3[2] -= delz2*tk1/r2;
+
+    if (EFLAG) eangle += bb_d0[type]*(1 - bb_ralpha1)*(1 - bb_ralpha2);
+
+    // force & energy for bond-angle term
+
+    dr1 = r1 - ba_r1[type];
+    dr2 = r2 - ba_r2[type];
+    ba_ralpha1 = exp(-ba_alpha1[type]*dr1);
+    ba_ralpha2 = exp(-ba_alpha2[type]*dr2);
+    aa1 = ba_d1[type]*(1 - ba_ralpha1)*s;
+    aa2 = ba_d2[type]*(1 - ba_ralpha2)*s;
+
+    aa11 = aa1 * c / rsq1;
+    aa12 = -aa1 / (r1 * r2);
+    aa21 = aa2 * c / rsq1;
+    aa22 = -aa2 / (r1 * r2);
+
+    vx11 = (aa11 * delx1) + (aa12 * delx2);
+    vx12 = (aa21 * delx1) + (aa22 * delx2);
+    vy11 = (aa11 * dely1) + (aa12 * dely2);
+    vy12 = (aa21 * dely1) + (aa22 * dely2);
+    vz11 = (aa11 * delz1) + (aa12 * delz2);
+    vz12 = (aa21 * delz1) + (aa22 * delz2);
+
+    aa11 = aa1 * c / rsq2;
+    aa21 = aa2 * c / rsq2;
+
+    vx21 = (aa11 * delx2) + (aa12 * delx1);
+    vx22 = (aa21 * delx2) + (aa22 * delx1);
+    vy21 = (aa11 * dely2) + (aa12 * dely1);
+    vy22 = (aa21 * dely2) + (aa22 * dely1);
+    vz21 = (aa11 * delz2) + (aa12 * delz1);
+    vz22 = (aa21 * delz2) + (aa22 * delz1);
+
+    b1 = ba_d1[type]*ba_alpha1[type]*ba_ralpha1*dtheta/r1;
+    b2 = ba_d2[type]*ba_alpha2[type]*ba_ralpha2*dtheta/r2;
+
+    f1[0] -= vx11 + b1*delx1 + vx12;
+    f1[1] -= vy11 + b1*dely1 + vy12;
+    f1[2] -= vz11 + b1*delz1 + vz12;
+
+    f3[0] -= vx21 + b2*delx2 + vx22;
+    f3[1] -= vy21 + b2*dely2 + vy22;
+    f3[2] -= vz21 + b2*delz2 + vz22;
+
+    if (EFLAG) eangle += ba_d1[type]*(1 - ba_ralpha1)*dtheta + ba_d2[type]*(1 - ba_ralpha2)*dtheta;
+
+    // apply force to each of 3 atoms
+
+    if (NEWTON_BOND || i1 < nlocal) {
+      f[i1].x += f1[0];
+      f[i1].y += f1[1];
+      f[i1].z += f1[2];
+    }
+
+    if (NEWTON_BOND || i2 < nlocal) {
+      f[i2].x -= f1[0] + f3[0];
+      f[i2].y -= f1[1] + f3[1];
+      f[i2].z -= f1[2] + f3[2];
+    }
+
+    if (NEWTON_BOND || i3 < nlocal) {
+      f[i3].x += f3[0];
+      f[i3].y += f3[1];
+      f[i3].z += f3[2];
+    }
+
+    if (EVFLAG) ev_tally_thr(this,i1,i2,i3,nlocal,NEWTON_BOND,eangle,f1,f3,
+                             delx1,dely1,delz1,delx2,dely2,delz2,thr);
+  }
+}

--- a/src/OPENMP/angle_class2xe_omp.h
+++ b/src/OPENMP/angle_class2xe_omp.h
@@ -1,0 +1,46 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#ifdef ANGLE_CLASS
+// clang-format off
+AngleStyle(class2xe/omp,AngleClass2xeOMP);
+// clang-format on
+#else
+
+#ifndef LMP_ANGLE_CLASS2XE_OMP_H
+#define LMP_ANGLE_CLASS2XE_OMP_H
+
+#include "angle_class2xe.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class AngleClass2xeOMP : public AngleClass2xe, public ThrOMP {
+
+ public:
+  AngleClass2xeOMP(class LAMMPS *lmp);
+  void compute(int, int) override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/angle_gaussian_omp.cpp
+++ b/src/OPENMP/angle_gaussian_omp.cpp
@@ -1,0 +1,193 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#include "angle_gaussian_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "math_const.h"
+#include "neighbor.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+#include "suffix.h"
+using namespace LAMMPS_NS;
+using namespace MathConst;
+
+static constexpr double SMALL = 0.001;
+static constexpr double SMALLG = 2.3e-308;
+
+/* ---------------------------------------------------------------------- */
+
+AngleGaussianOMP::AngleGaussianOMP(class LAMMPS *lmp)
+  : AngleGaussian(lmp), ThrOMP(lmp,THR_ANGLE)
+{
+  suffix_flag |= Suffix::OMP;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void AngleGaussianOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = neighbor->nanglelist;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, cvatom, thr);
+
+    if (inum > 0) {
+      if (evflag) {
+        if (eflag) {
+          if (force->newton_bond) eval<1,1,1>(ifrom, ito, thr);
+          else eval<1,1,0>(ifrom, ito, thr);
+        } else {
+          if (force->newton_bond) eval<1,0,1>(ifrom, ito, thr);
+          else eval<1,0,0>(ifrom, ito, thr);
+        }
+      } else {
+        if (force->newton_bond) eval<0,0,1>(ifrom, ito, thr);
+        else eval<0,0,0>(ifrom, ito, thr);
+      }
+    }
+    thr->timer(Timer::BOND);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+void AngleGaussianOMP::eval(int nfrom, int nto, ThrData * const thr)
+{
+  int i1,i2,i3,n,type;
+  double delx1,dely1,delz1,delx2,dely2,delz2;
+  double eangle,f1[3],f3[3];
+  double dtheta;
+  double rsq1,rsq2,r1,r2,c,s,a,a11,a12,a22;
+  double prefactor,exponent,g_i,sum_g_i,sum_numerator;
+
+  eangle = 0.0;
+
+  const auto * _noalias const x = (dbl3_t *) atom->x[0];
+  auto * _noalias const f = (dbl3_t *) thr->get_f()[0];
+  const int4_t * _noalias const anglelist = (int4_t *) neighbor->anglelist[0];
+  const int nlocal = atom->nlocal;
+
+  for (n = nfrom; n < nto; n++) {
+    i1 = anglelist[n].a;
+    i2 = anglelist[n].b;
+    i3 = anglelist[n].c;
+    type = anglelist[n].t;
+
+    // 1st bond
+
+    delx1 = x[i1].x - x[i2].x;
+    dely1 = x[i1].y - x[i2].y;
+    delz1 = x[i1].z - x[i2].z;
+
+    rsq1 = delx1*delx1 + dely1*dely1 + delz1*delz1;
+    r1 = sqrt(rsq1);
+
+    // 2nd bond
+
+    delx2 = x[i3].x - x[i2].x;
+    dely2 = x[i3].y - x[i2].y;
+    delz2 = x[i3].z - x[i2].z;
+
+    rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
+    r2 = sqrt(rsq2);
+
+    // angle (cos and sin)
+
+    c = delx1*delx2 + dely1*dely2 + delz1*delz2;
+    c /= r1*r2;
+
+    if (c > 1.0) c = 1.0;
+    if (c < -1.0) c = -1.0;
+
+    s = sqrt(1.0 - c*c);
+    if (s < SMALL) s = SMALL;
+    s = 1.0/s;
+
+    // force & energy
+
+    double theta = acos(c);
+
+    sum_g_i = 0.0;
+    sum_numerator = 0.0;
+    for (int i = 0; i < nterms[type]; i++) {
+      dtheta = theta - theta0[type][i];
+      prefactor = (alpha[type][i] / (width[type][i] * sqrt(MY_PI2)));
+      exponent = -2.0 * dtheta * dtheta / (width[type][i] * width[type][i]);
+      g_i = prefactor * exp(exponent);
+      sum_g_i += g_i;
+      sum_numerator += g_i * dtheta / (width[type][i] * width[type][i]);
+    }
+
+    // avoid overflow
+    if (sum_g_i < sum_numerator * SMALLG) sum_g_i = sum_numerator * SMALLG;
+
+    if (EFLAG) eangle = -(force->boltz * angle_temperature[type]) * log(sum_g_i);
+
+    a = -4.0 * (force->boltz * angle_temperature[type]) * (sum_numerator / sum_g_i) * s;
+    a11 = a*c / rsq1;
+    a12 = -a / (r1*r2);
+    a22 = a*c / rsq2;
+
+    f1[0] = a11*delx1 + a12*delx2;
+    f1[1] = a11*dely1 + a12*dely2;
+    f1[2] = a11*delz1 + a12*delz2;
+    f3[0] = a22*delx2 + a12*delx1;
+    f3[1] = a22*dely2 + a12*dely1;
+    f3[2] = a22*delz2 + a12*delz1;
+
+    // apply force to each of 3 atoms
+
+    if (NEWTON_BOND || i1 < nlocal) {
+      f[i1].x += f1[0];
+      f[i1].y += f1[1];
+      f[i1].z += f1[2];
+    }
+
+    if (NEWTON_BOND || i2 < nlocal) {
+      f[i2].x -= f1[0] + f3[0];
+      f[i2].y -= f1[1] + f3[1];
+      f[i2].z -= f1[2] + f3[2];
+    }
+
+    if (NEWTON_BOND || i3 < nlocal) {
+      f[i3].x += f3[0];
+      f[i3].y += f3[1];
+      f[i3].z += f3[2];
+    }
+
+    if (EVFLAG) ev_tally_thr(this,i1,i2,i3,nlocal,NEWTON_BOND,eangle,f1,f3,
+                             delx1,dely1,delz1,delx2,dely2,delz2,thr);
+  }
+}

--- a/src/OPENMP/angle_gaussian_omp.h
+++ b/src/OPENMP/angle_gaussian_omp.h
@@ -11,34 +11,33 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
-#ifdef IMPROPER_CLASS
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#ifdef ANGLE_CLASS
 // clang-format off
-ImproperStyle(distance,ImproperDistance);
+AngleStyle(gaussian/omp,AngleGaussianOMP);
 // clang-format on
 #else
 
-#ifndef LMP_IMPROPER_DISTANCE_H
-#define LMP_IMPROPER_DISTANCE_H
+#ifndef LMP_ANGLE_GAUSSIAN_OMP_H
+#define LMP_ANGLE_GAUSSIAN_OMP_H
 
-#include "improper.h"
+#include "angle_gaussian.h"
+#include "thr_omp.h"
 
 namespace LAMMPS_NS {
 
-class ImproperDistance : public Improper {
+class AngleGaussianOMP : public AngleGaussian, public ThrOMP {
+
  public:
-  ImproperDistance(class LAMMPS *);
-  ~ImproperDistance() override;
+  AngleGaussianOMP(class LAMMPS *lmp);
   void compute(int, int) override;
-  void coeff(int, char **) override;
-  void write_restart(FILE *) override;
-  void read_restart(FILE *) override;
-  void write_data(FILE *) override;
-  void *extract(const char *, int &) override;
 
- protected:
-  double *k, *chi;
-
-  void allocate();
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+  void eval(int ifrom, int ito, ThrData *const thr);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/OPENMP/angle_mwlc_omp.cpp
+++ b/src/OPENMP/angle_mwlc_omp.cpp
@@ -1,0 +1,172 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#include "angle_mwlc_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "neighbor.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+#include "suffix.h"
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+AngleMWLCOMP::AngleMWLCOMP(class LAMMPS *lmp)
+  : AngleMWLC(lmp), ThrOMP(lmp,THR_ANGLE)
+{
+  suffix_flag |= Suffix::OMP;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void AngleMWLCOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = neighbor->nanglelist;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, cvatom, thr);
+
+    if (inum > 0) {
+      if (evflag) {
+        if (eflag) {
+          if (force->newton_bond) eval<1,1,1>(ifrom, ito, thr);
+          else eval<1,1,0>(ifrom, ito, thr);
+        } else {
+          if (force->newton_bond) eval<1,0,1>(ifrom, ito, thr);
+          else eval<1,0,0>(ifrom, ito, thr);
+        }
+      } else {
+        if (force->newton_bond) eval<0,0,1>(ifrom, ito, thr);
+        else eval<0,0,0>(ifrom, ito, thr);
+      }
+    }
+    thr->timer(Timer::BOND);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+void AngleMWLCOMP::eval(int nfrom, int nto, ThrData * const thr)
+{
+  int i1,i2,i3,n,type;
+  double delx1,dely1,delz1,delx2,dely2,delz2;
+  double eangle,f1[3],f3[3];
+  double rsq1,rsq2,r1,r2,c,a,a11,a12,a22;
+  double q,qm,Q,kbt,v_min;
+
+  eangle = 0.0;
+
+  const auto * _noalias const x = (dbl3_t *) atom->x[0];
+  auto * _noalias const f = (dbl3_t *) thr->get_f()[0];
+  const int4_t * _noalias const anglelist = (int4_t *) neighbor->anglelist[0];
+  const int nlocal = atom->nlocal;
+
+  for (n = nfrom; n < nto; n++) {
+    i1 = anglelist[n].a;
+    i2 = anglelist[n].b;
+    i3 = anglelist[n].c;
+    type = anglelist[n].t;
+    kbt = temp[type] * force->boltz;
+    v_min = -kbt * log(1 + exp(-mu[type] / kbt));
+
+    // 1st bond
+
+    delx1 = x[i1].x - x[i2].x;
+    dely1 = x[i1].y - x[i2].y;
+    delz1 = x[i1].z - x[i2].z;
+
+    rsq1 = delx1*delx1 + dely1*dely1 + delz1*delz1;
+    r1 = sqrt(rsq1);
+
+    // 2nd bond
+
+    delx2 = x[i3].x - x[i2].x;
+    dely2 = x[i3].y - x[i2].y;
+    delz2 = x[i3].z - x[i2].z;
+
+    rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
+    r2 = sqrt(rsq2);
+
+    // c = cosine of angle
+
+    c = delx1*delx2 + dely1*dely2 + delz1*delz2;
+    c /= r1*r2;
+    if (c > 1.0) c = 1.0;
+    if (c < -1.0) c = -1.0;
+
+    // force & energy
+
+    q = exp(-k1[type] * (1.0 + c) / kbt);
+    qm = exp((-k2[type] * (1.0 + c) - mu[type]) / kbt);
+    Q = q + qm;
+
+    if (EFLAG) eangle = -kbt * log(Q) - v_min;
+
+    a = (k1[type]*q + k2[type]*qm) / Q;
+    a11 = a*c / rsq1;
+    a12 = -a / (r1*r2);
+    a22 = a*c / rsq2;
+
+    f1[0] = a11*delx1 + a12*delx2;
+    f1[1] = a11*dely1 + a12*dely2;
+    f1[2] = a11*delz1 + a12*delz2;
+    f3[0] = a22*delx2 + a12*delx1;
+    f3[1] = a22*dely2 + a12*dely1;
+    f3[2] = a22*delz2 + a12*delz1;
+
+    // apply force to each of 3 atoms
+
+    if (NEWTON_BOND || i1 < nlocal) {
+      f[i1].x += f1[0];
+      f[i1].y += f1[1];
+      f[i1].z += f1[2];
+    }
+
+    if (NEWTON_BOND || i2 < nlocal) {
+      f[i2].x -= f1[0] + f3[0];
+      f[i2].y -= f1[1] + f3[1];
+      f[i2].z -= f1[2] + f3[2];
+    }
+
+    if (NEWTON_BOND || i3 < nlocal) {
+      f[i3].x += f3[0];
+      f[i3].y += f3[1];
+      f[i3].z += f3[2];
+    }
+
+    if (EVFLAG) ev_tally_thr(this,i1,i2,i3,nlocal,NEWTON_BOND,eangle,f1,f3,
+                             delx1,dely1,delz1,delx2,dely2,delz2,thr);
+  }
+}

--- a/src/OPENMP/angle_mwlc_omp.h
+++ b/src/OPENMP/angle_mwlc_omp.h
@@ -11,34 +11,33 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
-#ifdef IMPROPER_CLASS
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#ifdef ANGLE_CLASS
 // clang-format off
-ImproperStyle(distance,ImproperDistance);
+AngleStyle(mwlc/omp,AngleMWLCOMP);
 // clang-format on
 #else
 
-#ifndef LMP_IMPROPER_DISTANCE_H
-#define LMP_IMPROPER_DISTANCE_H
+#ifndef LMP_ANGLE_MWLC_OMP_H
+#define LMP_ANGLE_MWLC_OMP_H
 
-#include "improper.h"
+#include "angle_mwlc.h"
+#include "thr_omp.h"
 
 namespace LAMMPS_NS {
 
-class ImproperDistance : public Improper {
+class AngleMWLCOMP : public AngleMWLC, public ThrOMP {
+
  public:
-  ImproperDistance(class LAMMPS *);
-  ~ImproperDistance() override;
+  AngleMWLCOMP(class LAMMPS *lmp);
   void compute(int, int) override;
-  void coeff(int, char **) override;
-  void write_restart(FILE *) override;
-  void read_restart(FILE *) override;
-  void write_data(FILE *) override;
-  void *extract(const char *, int &) override;
 
- protected:
-  double *k, *chi;
-
-  void allocate();
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+  void eval(int ifrom, int ito, ThrData *const thr);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/OPENMP/bond_harmonic_restrain_omp.cpp
+++ b/src/OPENMP/bond_harmonic_restrain_omp.cpp
@@ -1,0 +1,140 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#include "bond_harmonic_restrain_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "domain.h"
+#include "fix_store_atom.h"
+#include "force.h"
+#include "neighbor.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+#include "suffix.h"
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+BondHarmonicRestrainOMP::BondHarmonicRestrainOMP(class LAMMPS *lmp)
+  : BondHarmonicRestrain(lmp), ThrOMP(lmp,THR_BOND)
+{
+  suffix_flag |= Suffix::OMP;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void BondHarmonicRestrainOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = neighbor->nbondlist;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (inum > 0) {
+      if (evflag) {
+        if (eflag) {
+          if (force->newton_bond) eval<1,1,1>(ifrom, ito, thr);
+          else eval<1,1,0>(ifrom, ito, thr);
+        } else {
+          if (force->newton_bond) eval<1,0,1>(ifrom, ito, thr);
+          else eval<1,0,0>(ifrom, ito, thr);
+        }
+      } else {
+        if (force->newton_bond) eval<0,0,1>(ifrom, ito, thr);
+        else eval<0,0,0>(ifrom, ito, thr);
+      }
+    }
+    thr->timer(Timer::BOND);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+void BondHarmonicRestrainOMP::eval(int nfrom, int nto, ThrData * const thr)
+{
+  int i1,i2,n,type;
+  double delx,dely,delz,ebond,fbond;
+  double rsq,r,r0,dr,rk;
+
+  ebond = 0.0;
+
+  const auto * _noalias const x = (dbl3_t *) atom->x[0];
+  const double * const * const x0 = initial->astore;
+  auto * _noalias const f = (dbl3_t *) thr->get_f()[0];
+  const int3_t * _noalias const bondlist = (int3_t *) neighbor->bondlist[0];
+  const int nlocal = atom->nlocal;
+
+  for (n = nfrom; n < nto; n++) {
+    i1 = bondlist[n].a;
+    i2 = bondlist[n].b;
+    type = bondlist[n].t;
+
+    double dx0 = x0[i1][0] - x0[i2][0];
+    double dy0 = x0[i1][1] - x0[i2][1];
+    double dz0 = x0[i1][2] - x0[i2][2];
+    domain->minimum_image(FLERR, dx0,dy0,dz0);
+    r0 = sqrt(dx0*dx0 + dy0*dy0 + dz0*dz0);
+
+    delx = x[i1].x - x[i2].x;
+    dely = x[i1].y - x[i2].y;
+    delz = x[i1].z - x[i2].z;
+    rsq = delx*delx + dely*dely + delz*delz;
+    r = sqrt(rsq);
+    dr = r - r0;
+    rk = k[type] * dr;
+
+    // force & energy
+
+    if (r > 0.0) fbond = -2.0*rk/r;
+    else fbond = 0.0;
+
+    if (EFLAG) ebond = rk*dr;
+
+    // apply force to each of 2 atoms
+
+    if (NEWTON_BOND || i1 < nlocal) {
+      f[i1].x += delx*fbond;
+      f[i1].y += dely*fbond;
+      f[i1].z += delz*fbond;
+    }
+
+    if (NEWTON_BOND || i2 < nlocal) {
+      f[i2].x -= delx*fbond;
+      f[i2].y -= dely*fbond;
+      f[i2].z -= delz*fbond;
+    }
+
+    if (EVFLAG) ev_tally_thr(this,i1,i2,nlocal,NEWTON_BOND,
+                              ebond,fbond,delx,dely,delz,thr);
+  }
+}

--- a/src/OPENMP/bond_harmonic_restrain_omp.h
+++ b/src/OPENMP/bond_harmonic_restrain_omp.h
@@ -11,34 +11,33 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
-#ifdef IMPROPER_CLASS
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#ifdef BOND_CLASS
 // clang-format off
-ImproperStyle(distance,ImproperDistance);
+BondStyle(harmonic/restrain/omp,BondHarmonicRestrainOMP);
 // clang-format on
 #else
 
-#ifndef LMP_IMPROPER_DISTANCE_H
-#define LMP_IMPROPER_DISTANCE_H
+#ifndef LMP_BOND_HARMONIC_RESTRAIN_OMP_H
+#define LMP_BOND_HARMONIC_RESTRAIN_OMP_H
 
-#include "improper.h"
+#include "bond_harmonic_restrain.h"
+#include "thr_omp.h"
 
 namespace LAMMPS_NS {
 
-class ImproperDistance : public Improper {
+class BondHarmonicRestrainOMP : public BondHarmonicRestrain, public ThrOMP {
+
  public:
-  ImproperDistance(class LAMMPS *);
-  ~ImproperDistance() override;
+  BondHarmonicRestrainOMP(class LAMMPS *lmp);
   void compute(int, int) override;
-  void coeff(int, char **) override;
-  void write_restart(FILE *) override;
-  void read_restart(FILE *) override;
-  void write_data(FILE *) override;
-  void *extract(const char *, int &) override;
 
- protected:
-  double *k, *chi;
-
-  void allocate();
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+  void eval(int ifrom, int ito, ThrData *const thr);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/OPENMP/dihedral_charmmfsw_omp.cpp
+++ b/src/OPENMP/dihedral_charmmfsw_omp.cpp
@@ -1,0 +1,316 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#include "dihedral_charmmfsw_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "neighbor.h"
+#include "pair.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+#include "suffix.h"
+using namespace LAMMPS_NS;
+
+static constexpr double TOLERANCE = 0.05;
+
+/* ---------------------------------------------------------------------- */
+
+DihedralCharmmfswOMP::DihedralCharmmfswOMP(class LAMMPS *lmp)
+  : DihedralCharmmfsw(lmp), ThrOMP(lmp,THR_DIHEDRAL|THR_CHARMM)
+{
+  suffix_flag |= Suffix::OMP;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DihedralCharmmfswOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  // ensure pair->ev_tally() will use 1-4 virial contribution
+
+  if (weightflag && vflag_global == VIRIAL_FDOTR)
+    force->pair->vflag_either = force->pair->vflag_global = 1;
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = neighbor->ndihedrallist;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, cvatom, thr);
+
+    if (inum > 0) {
+      if (evflag) {
+        if (eflag) {
+          if (force->newton_bond) eval<1,1,1>(ifrom, ito, thr);
+          else eval<1,1,0>(ifrom, ito, thr);
+        } else {
+          if (force->newton_bond) eval<1,0,1>(ifrom, ito, thr);
+          else eval<1,0,0>(ifrom, ito, thr);
+        }
+      } else {
+        if (force->newton_bond) eval<0,0,1>(ifrom, ito, thr);
+        else eval<0,0,0>(ifrom, ito, thr);
+      }
+    }
+    thr->timer(Timer::BOND);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+void DihedralCharmmfswOMP::eval(int nfrom, int nto, ThrData * const thr)
+{
+  int i1,i2,i3,i4,i,m,n,type;
+  double vb1x,vb1y,vb1z,vb2x,vb2y,vb2z,vb3x,vb3y,vb3z,vb2xm,vb2ym,vb2zm;
+  double edihedral,f1[3],f2[3],f3[3],f4[3];
+  double ax,ay,az,bx,by,bz,rasq,rbsq,rgsq,rg,rginv,ra2inv,rb2inv,rabinv;
+  double df,df1,ddf1,fg,hg,fga,hgb,gaa,gbb;
+  double dtfx,dtfy,dtfz,dtgx,dtgy,dtgz,dthx,dthy,dthz;
+  double c,s,p,sx2,sy2,sz2;
+  int itype,jtype;
+  double delx,dely,delz,rsq,r2inv,r6inv,r;
+  double forcecoul,forcelj,fpair,ecoul,evdwl;
+
+  ecoul = evdwl = edihedral = 0.0;
+
+  const auto * _noalias const x = (dbl3_t *) atom->x[0];
+  auto * _noalias const f = (dbl3_t *) thr->get_f()[0];
+  const double * _noalias const q = atom->q;
+  const int * const atomtype = atom->type;
+  const int5_t * _noalias const dihedrallist = (int5_t *) neighbor->dihedrallist[0];
+  const double qqrd2e = force->qqrd2e;
+  const int nlocal = atom->nlocal;
+
+  for (n = nfrom; n < nto; n++) {
+    i1 = dihedrallist[n].a;
+    i2 = dihedrallist[n].b;
+    i3 = dihedrallist[n].c;
+    i4 = dihedrallist[n].d;
+    type = dihedrallist[n].t;
+
+    // 1st bond
+
+    vb1x = x[i1].x - x[i2].x;
+    vb1y = x[i1].y - x[i2].y;
+    vb1z = x[i1].z - x[i2].z;
+
+    // 2nd bond
+
+    vb2x = x[i3].x - x[i2].x;
+    vb2y = x[i3].y - x[i2].y;
+    vb2z = x[i3].z - x[i2].z;
+
+    vb2xm = -vb2x;
+    vb2ym = -vb2y;
+    vb2zm = -vb2z;
+
+    // 3rd bond
+
+    vb3x = x[i4].x - x[i3].x;
+    vb3y = x[i4].y - x[i3].y;
+    vb3z = x[i4].z - x[i3].z;
+
+    ax = vb1y*vb2zm - vb1z*vb2ym;
+    ay = vb1z*vb2xm - vb1x*vb2zm;
+    az = vb1x*vb2ym - vb1y*vb2xm;
+    bx = vb3y*vb2zm - vb3z*vb2ym;
+    by = vb3z*vb2xm - vb3x*vb2zm;
+    bz = vb3x*vb2ym - vb3y*vb2xm;
+
+    rasq = ax*ax + ay*ay + az*az;
+    rbsq = bx*bx + by*by + bz*bz;
+    rgsq = vb2xm*vb2xm + vb2ym*vb2ym + vb2zm*vb2zm;
+    rg = sqrt(rgsq);
+
+    rginv = ra2inv = rb2inv = 0.0;
+    if (rg > 0) rginv = 1.0/rg;
+    if (rasq > 0) ra2inv = 1.0/rasq;
+    if (rbsq > 0) rb2inv = 1.0/rbsq;
+    rabinv = sqrt(ra2inv*rb2inv);
+
+    c = (ax*bx + ay*by + az*bz)*rabinv;
+    s = rg*rabinv*(ax*vb3x + ay*vb3y + az*vb3z);
+
+    // error check
+
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
+
+    if (c > 1.0) c = 1.0;
+    if (c < -1.0) c = -1.0;
+
+    m = multiplicity[type];
+    p = 1.0;
+    ddf1 = df1 = 0.0;
+
+    for (i = 0; i < m; i++) {
+      ddf1 = p*c - df1*s;
+      df1 = p*s + df1*c;
+      p = ddf1;
+    }
+
+    p = p*cos_shift[type] + df1*sin_shift[type];
+    df1 = df1*cos_shift[type] - ddf1*sin_shift[type];
+    df1 *= -m;
+    p += 1.0;
+
+    if (m == 0) {
+      p = 1.0 + cos_shift[type];
+      df1 = 0.0;
+    }
+
+    if (EFLAG) edihedral = k[type] * p;
+
+    fg = vb1x*vb2xm + vb1y*vb2ym + vb1z*vb2zm;
+    hg = vb3x*vb2xm + vb3y*vb2ym + vb3z*vb2zm;
+    fga = fg*ra2inv*rginv;
+    hgb = hg*rb2inv*rginv;
+    gaa = -ra2inv*rg;
+    gbb = rb2inv*rg;
+
+    dtfx = gaa*ax;
+    dtfy = gaa*ay;
+    dtfz = gaa*az;
+    dtgx = fga*ax - hgb*bx;
+    dtgy = fga*ay - hgb*by;
+    dtgz = fga*az - hgb*bz;
+    dthx = gbb*bx;
+    dthy = gbb*by;
+    dthz = gbb*bz;
+
+    df = -k[type] * df1;
+
+    sx2 = df*dtgx;
+    sy2 = df*dtgy;
+    sz2 = df*dtgz;
+
+    f1[0] = df*dtfx;
+    f1[1] = df*dtfy;
+    f1[2] = df*dtfz;
+
+    f2[0] = sx2 - f1[0];
+    f2[1] = sy2 - f1[1];
+    f2[2] = sz2 - f1[2];
+
+    f4[0] = df*dthx;
+    f4[1] = df*dthy;
+    f4[2] = df*dthz;
+
+    f3[0] = -sx2 - f4[0];
+    f3[1] = -sy2 - f4[1];
+    f3[2] = -sz2 - f4[2];
+
+    // apply force to each of 4 atoms
+
+    if (NEWTON_BOND || i1 < nlocal) {
+      f[i1].x += f1[0];
+      f[i1].y += f1[1];
+      f[i1].z += f1[2];
+    }
+
+    if (NEWTON_BOND || i2 < nlocal) {
+      f[i2].x += f2[0];
+      f[i2].y += f2[1];
+      f[i2].z += f2[2];
+    }
+
+    if (NEWTON_BOND || i3 < nlocal) {
+      f[i3].x += f3[0];
+      f[i3].y += f3[1];
+      f[i3].z += f3[2];
+    }
+
+    if (NEWTON_BOND || i4 < nlocal) {
+      f[i4].x += f4[0];
+      f[i4].y += f4[1];
+      f[i4].z += f4[2];
+    }
+
+    if (EVFLAG)
+      ev_tally_thr(this,i1,i2,i3,i4,nlocal,NEWTON_BOND,edihedral,f1,f3,f4,
+                   vb1x,vb1y,vb1z,vb2x,vb2y,vb2z,vb3x,vb3y,vb3z,thr);
+
+    // 1-4 LJ and Coulomb interactions
+    // tally energy/virial in pair, using newton_bond as newton flag
+
+    if (weight[type] > 0.0) {
+      itype = atomtype[i1];
+      jtype = atomtype[i4];
+
+      delx = x[i1].x - x[i4].x;
+      dely = x[i1].y - x[i4].y;
+      delz = x[i1].z - x[i4].z;
+      rsq = delx*delx + dely*dely + delz*delz;
+      r2inv = 1.0/rsq;
+      r6inv = r2inv*r2inv*r2inv;
+
+      // modifying coul and LJ force and energies to apply
+      //   force_shift and force_switch as in CHARMM pairwise
+
+      r = sqrt(rsq);
+      if (implicit)
+        forcecoul = qqrd2e * q[i1]*q[i4]*r2inv;
+      else if (dihedflag)
+        forcecoul = qqrd2e * q[i1]*q[i4]*sqrt(r2inv);
+      else
+        forcecoul = qqrd2e * q[i1]*q[i4]*(sqrt(r2inv) - r*cut_coulinv14*cut_coulinv14);
+      forcelj = r6inv * (lj14_1[itype][jtype]*r6inv - lj14_2[itype][jtype]);
+      fpair = weight[type] * (forcelj+forcecoul)*r2inv;
+
+      if (EFLAG) {
+        if (dihedflag)
+          ecoul = weight[type] * forcecoul;
+        else
+          ecoul = weight[type] * qqrd2e * q[i1]*q[i4] *
+            (sqrt(r2inv) + r*cut_coulinv14*cut_coulinv14 - 2.0*cut_coulinv14);
+        double local_evdwl14_12 = r6inv * lj14_3[itype][jtype]*r6inv -
+          lj14_3[itype][jtype]*cut_lj_inner6inv*cut_lj6inv;
+        double local_evdwl14_6 = -lj14_4[itype][jtype]*r6inv +
+          lj14_4[itype][jtype]*cut_lj_inner3inv*cut_lj3inv;
+        evdwl = (local_evdwl14_12 + local_evdwl14_6) * weight[type];
+      }
+
+      if (NEWTON_BOND || i1 < nlocal) {
+        f[i1].x += delx*fpair;
+        f[i1].y += dely*fpair;
+        f[i1].z += delz*fpair;
+      }
+      if (NEWTON_BOND || i4 < nlocal) {
+        f[i4].x -= delx*fpair;
+        f[i4].y -= dely*fpair;
+        f[i4].z -= delz*fpair;
+      }
+
+      if (EVFLAG) ev_tally_thr(force->pair,i1,i4,nlocal,NEWTON_BOND,
+                               evdwl,ecoul,fpair,delx,dely,delz,thr);
+    }
+  }
+}

--- a/src/OPENMP/dihedral_charmmfsw_omp.h
+++ b/src/OPENMP/dihedral_charmmfsw_omp.h
@@ -11,34 +11,33 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
-#ifdef IMPROPER_CLASS
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#ifdef DIHEDRAL_CLASS
 // clang-format off
-ImproperStyle(distance,ImproperDistance);
+DihedralStyle(charmmfsw/omp,DihedralCharmmfswOMP);
 // clang-format on
 #else
 
-#ifndef LMP_IMPROPER_DISTANCE_H
-#define LMP_IMPROPER_DISTANCE_H
+#ifndef LMP_DIHEDRAL_CHARMMFSW_OMP_H
+#define LMP_DIHEDRAL_CHARMMFSW_OMP_H
 
-#include "improper.h"
+#include "dihedral_charmmfsw.h"
+#include "thr_omp.h"
 
 namespace LAMMPS_NS {
 
-class ImproperDistance : public Improper {
+class DihedralCharmmfswOMP : public DihedralCharmmfsw, public ThrOMP {
+
  public:
-  ImproperDistance(class LAMMPS *);
-  ~ImproperDistance() override;
+  DihedralCharmmfswOMP(class LAMMPS *lmp);
   void compute(int, int) override;
-  void coeff(int, char **) override;
-  void write_restart(FILE *) override;
-  void read_restart(FILE *) override;
-  void write_data(FILE *) override;
-  void *extract(const char *, int &) override;
 
- protected:
-  double *k, *chi;
-
-  void allocate();
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+  void eval(int ifrom, int ito, ThrData *const thr);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/OPENMP/dihedral_class2xe_omp.cpp
+++ b/src/OPENMP/dihedral_class2xe_omp.cpp
@@ -1,0 +1,540 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#include "dihedral_class2xe_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "neighbor.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+using namespace LAMMPS_NS;
+
+static constexpr double TOLERANCE = 0.05;
+static constexpr double SMALL =     0.0000001;
+
+/* ---------------------------------------------------------------------- */
+
+DihedralClass2xeOMP::DihedralClass2xeOMP(class LAMMPS *lmp)
+  : DihedralClass2xe(lmp), ThrOMP(lmp,THR_DIHEDRAL)
+{
+  suffix_flag |= Suffix::OMP;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DihedralClass2xeOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = neighbor->ndihedrallist;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, cvatom, thr);
+
+    if (inum > 0) {
+      if (evflag) {
+        if (eflag) {
+          if (force->newton_bond) eval<1,1,1>(ifrom, ito, thr);
+          else eval<1,1,0>(ifrom, ito, thr);
+        } else {
+          if (force->newton_bond) eval<1,0,1>(ifrom, ito, thr);
+          else eval<1,0,0>(ifrom, ito, thr);
+        }
+      } else {
+        if (force->newton_bond) eval<0,0,1>(ifrom, ito, thr);
+        else eval<0,0,0>(ifrom, ito, thr);
+      }
+    }
+    thr->timer(Timer::BOND);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+void DihedralClass2xeOMP::eval(int nfrom, int nto, ThrData * const thr)
+{
+  int i1,i2,i3,i4,i,j,k,n,type;
+  double vb1x,vb1y,vb1z,vb2x,vb2y,vb2z,vb3x,vb3y,vb3z,vb2xm,vb2ym,vb2zm;
+  double edihedral;
+  double r1mag2,r1,r2mag2,r2,r3mag2,r3;
+  double sb1,rb1,sb2,rb2,sb3,rb3,c0,r12c1;
+  double r12c2,costh12,costh13,costh23,sc1,sc2,s1,s2,c;
+  double cosphi,phi,sinphi,a11,a22,a33,a12,a13,a23,sx1,sx2;
+  double sx12,sy1,sy2,sy12,sz1,sz2,sz12,dphi1,dphi2,dphi3;
+  double de_dihedral,t1,t2,t3,t4,cos2phi,cos3phi,bt1,bt2;
+  double bt3,sumbte,db,sumbtf,at1,at2,at3,da,da1,da2;
+  double dr1,dr2,tk1,tk2,s12,sin2;
+  double dcosphidr[4][3],dphidr[4][3],dbonddr[3][4][3],dthetadr[2][4][3];
+  double fabcd[4][3];
+  double bb13_ralpha1,bb13_ralpha2;
+  double mbt_dr2,mbt_ralpha2;
+  double ebt_dr1,ebt_dr3,ebt_ralpha1,ebt_ralpha3;
+
+  edihedral = 0.0;
+
+  const auto * _noalias const x = (dbl3_t *) atom->x[0];
+  auto * _noalias const f = (dbl3_t *) thr->get_f()[0];
+  const int5_t * _noalias const dihedrallist = (int5_t *) neighbor->dihedrallist[0];
+  const int nlocal = atom->nlocal;
+
+  for (n = nfrom; n < nto; n++) {
+    i1 = dihedrallist[n].a;
+    i2 = dihedrallist[n].b;
+    i3 = dihedrallist[n].c;
+    i4 = dihedrallist[n].d;
+    type = dihedrallist[n].t;
+
+    // 1st bond
+
+    vb1x = x[i1].x - x[i2].x;
+    vb1y = x[i1].y - x[i2].y;
+    vb1z = x[i1].z - x[i2].z;
+
+    // 2nd bond
+
+    vb2x = x[i3].x - x[i2].x;
+    vb2y = x[i3].y - x[i2].y;
+    vb2z = x[i3].z - x[i2].z;
+
+    vb2xm = -vb2x;
+    vb2ym = -vb2y;
+    vb2zm = -vb2z;
+
+    // 3rd bond
+
+    vb3x = x[i4].x - x[i3].x;
+    vb3y = x[i4].y - x[i3].y;
+    vb3z = x[i4].z - x[i3].z;
+
+    // distances
+
+    r1mag2 = vb1x*vb1x + vb1y*vb1y + vb1z*vb1z;
+    r1 = sqrt(r1mag2);
+    r2mag2 = vb2x*vb2x + vb2y*vb2y + vb2z*vb2z;
+    r2 = sqrt(r2mag2);
+    r3mag2 = vb3x*vb3x + vb3y*vb3y + vb3z*vb3z;
+    r3 = sqrt(r3mag2);
+
+    sb1 = 1.0/r1mag2;
+    rb1 = 1.0/r1;
+    sb2 = 1.0/r2mag2;
+    rb2 = 1.0/r2;
+    sb3 = 1.0/r3mag2;
+    rb3 = 1.0/r3;
+
+    c0 = (vb1x*vb3x + vb1y*vb3y + vb1z*vb3z) * rb1*rb3;
+
+    // angles
+
+    r12c1 = rb1*rb2;
+    r12c2 = rb2*rb3;
+    costh12 = (vb1x*vb2x + vb1y*vb2y + vb1z*vb2z) * r12c1;
+    costh13 = c0;
+    costh23 = (vb2xm*vb3x + vb2ym*vb3y + vb2zm*vb3z) * r12c2;
+
+    costh12 = MAX(MIN(costh12, 1.0), -1.0);
+    costh13 = MAX(MIN(costh13, 1.0), -1.0);
+    costh23 = MAX(MIN(costh23, 1.0), -1.0);
+    c0 = costh13;
+
+    // cos and sin of 2 angles and final c
+
+    sin2 = MAX(1.0 - costh12*costh12,0.0);
+    sc1 = sqrt(sin2);
+    if (sc1 < SMALL) sc1 = SMALL;
+    sc1 = 1.0/sc1;
+
+    sin2 = MAX(1.0 - costh23*costh23,0.0);
+    sc2 = sqrt(sin2);
+    if (sc2 < SMALL) sc2 = SMALL;
+    sc2 = 1.0/sc2;
+
+    s1 = sc1 * sc1;
+    s2 = sc2 * sc2;
+    s12 = sc1 * sc2;
+    c = (c0 + costh12*costh23) * s12;
+
+    // error check
+
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
+
+    if (c > 1.0) c = 1.0;
+    if (c < -1.0) c = -1.0;
+    cosphi = c;
+    phi = acos(c);
+
+    sinphi = sqrt(1.0 - c*c);
+    sinphi = MAX(sinphi,SMALL);
+
+    // n123 = vb1 x vb2
+
+    double n123x = vb1y*vb2z - vb1z*vb2y;
+    double n123y = vb1z*vb2x - vb1x*vb2z;
+    double n123z = vb1x*vb2y - vb1y*vb2x;
+    double n123_dot_vb3 = n123x*vb3x + n123y*vb3y + n123z*vb3z;
+    if (n123_dot_vb3 > 0.0) {
+      phi = -phi;
+      sinphi = -sinphi;
+    }
+
+    a11 = -c*sb1*s1;
+    a22 = sb2 * (2.0*costh13*s12 - c*(s1+s2));
+    a33 = -c*sb3*s2;
+    a12 = r12c1 * (costh12*c*s1 + costh23*s12);
+    a13 = rb1*rb3*s12;
+    a23 = r12c2 * (-costh23*c*s2 - costh12*s12);
+
+    sx1  = a11*vb1x + a12*vb2x + a13*vb3x;
+    sx2  = a12*vb1x + a22*vb2x + a23*vb3x;
+    sx12 = a13*vb1x + a23*vb2x + a33*vb3x;
+    sy1  = a11*vb1y + a12*vb2y + a13*vb3y;
+    sy2  = a12*vb1y + a22*vb2y + a23*vb3y;
+    sy12 = a13*vb1y + a23*vb2y + a33*vb3y;
+    sz1  = a11*vb1z + a12*vb2z + a13*vb3z;
+    sz2  = a12*vb1z + a22*vb2z + a23*vb3z;
+    sz12 = a13*vb1z + a23*vb2z + a33*vb3z;
+
+    // set up d(cos(phi))/d(r) and dphi/dr arrays
+
+    dcosphidr[0][0] = -sx1;
+    dcosphidr[0][1] = -sy1;
+    dcosphidr[0][2] = -sz1;
+    dcosphidr[1][0] = sx2 + sx1;
+    dcosphidr[1][1] = sy2 + sy1;
+    dcosphidr[1][2] = sz2 + sz1;
+    dcosphidr[2][0] = sx12 - sx2;
+    dcosphidr[2][1] = sy12 - sy2;
+    dcosphidr[2][2] = sz12 - sz2;
+    dcosphidr[3][0] = -sx12;
+    dcosphidr[3][1] = -sy12;
+    dcosphidr[3][2] = -sz12;
+
+    for (i = 0; i < 4; i++)
+      for (j = 0; j < 3; j++)
+        dphidr[i][j] = -dcosphidr[i][j] / sinphi;
+
+    // energy
+
+    dphi1 = phi - phi1[type];
+    dphi2 = 2.0*phi - phi2[type];
+    dphi3 = 3.0*phi - phi3[type];
+
+    if (EFLAG) edihedral = k1[type]*(1.0 - cos(dphi1)) +
+                 k2[type]*(1.0 - cos(dphi2)) +
+                 k3[type]*(1.0 - cos(dphi3));
+
+    de_dihedral = k1[type]*sin(dphi1) + 2.0*k2[type]*sin(dphi2) +
+      3.0*k3[type]*sin(dphi3);
+
+    // torsion forces on all 4 atoms
+
+    for (i = 0; i < 4; i++)
+      for (j = 0; j < 3; j++)
+        fabcd[i][j] = de_dihedral*dphidr[i][j];
+
+    // set up d(bond)/d(r) array
+    // dbonddr(i,j,k) = bond i, atom j, coordinate k
+
+    for (i = 0; i < 3; i++)
+      for (j = 0; j < 4; j++)
+        for (k = 0; k < 3; k++)
+          dbonddr[i][j][k] = 0.0;
+
+    // bond1
+
+    dbonddr[0][0][0] = vb1x / r1;
+    dbonddr[0][0][1] = vb1y / r1;
+    dbonddr[0][0][2] = vb1z / r1;
+    dbonddr[0][1][0] = -vb1x / r1;
+    dbonddr[0][1][1] = -vb1y / r1;
+    dbonddr[0][1][2] = -vb1z / r1;
+
+    // bond2
+
+    dbonddr[1][1][0] = vb2x / r2;
+    dbonddr[1][1][1] = vb2y / r2;
+    dbonddr[1][1][2] = vb2z / r2;
+    dbonddr[1][2][0] = -vb2x / r2;
+    dbonddr[1][2][1] = -vb2y / r2;
+    dbonddr[1][2][2] = -vb2z / r2;
+
+    // bond3
+
+    dbonddr[2][2][0] = vb3x / r3;
+    dbonddr[2][2][1] = vb3y / r3;
+    dbonddr[2][2][2] = vb3z / r3;
+    dbonddr[2][3][0] = -vb3x / r3;
+    dbonddr[2][3][1] = -vb3y / r3;
+    dbonddr[2][3][2] = -vb3z / r3;
+
+    // set up d(theta)/d(r) array
+    // dthetadr(i,j,k) = angle i, atom j, coordinate k
+
+    for (i = 0; i < 2; i++)
+      for (j = 0; j < 4; j++)
+        for (k = 0; k < 3; k++)
+          dthetadr[i][j][k] = 0.0;
+
+    t1 = costh12 / r1mag2;
+    t2 = costh23 / r2mag2;
+    t3 = costh12 / r2mag2;
+    t4 = costh23 / r3mag2;
+
+    // angle12
+
+    dthetadr[0][0][0] = sc1 * ((t1 * vb1x) - (vb2x * r12c1));
+    dthetadr[0][0][1] = sc1 * ((t1 * vb1y) - (vb2y * r12c1));
+    dthetadr[0][0][2] = sc1 * ((t1 * vb1z) - (vb2z * r12c1));
+
+    dthetadr[0][1][0] = sc1 * ((-t1 * vb1x) + (vb2x * r12c1) +
+                               (-t3 * vb2x) + (vb1x * r12c1));
+    dthetadr[0][1][1] = sc1 * ((-t1 * vb1y) + (vb2y * r12c1) +
+                               (-t3 * vb2y) + (vb1y * r12c1));
+    dthetadr[0][1][2] = sc1 * ((-t1 * vb1z) + (vb2z * r12c1) +
+                               (-t3 * vb2z) + (vb1z * r12c1));
+
+    dthetadr[0][2][0] = sc1 * ((t3 * vb2x) - (vb1x * r12c1));
+    dthetadr[0][2][1] = sc1 * ((t3 * vb2y) - (vb1y * r12c1));
+    dthetadr[0][2][2] = sc1 * ((t3 * vb2z) - (vb1z * r12c1));
+
+    // angle23
+
+    dthetadr[1][1][0] = sc2 * ((t2 * vb2x) + (vb3x * r12c2));
+    dthetadr[1][1][1] = sc2 * ((t2 * vb2y) + (vb3y * r12c2));
+    dthetadr[1][1][2] = sc2 * ((t2 * vb2z) + (vb3z * r12c2));
+
+    dthetadr[1][2][0] = sc2 * ((-t2 * vb2x) - (vb3x * r12c2) +
+                               (t4 * vb3x) + (vb2x * r12c2));
+    dthetadr[1][2][1] = sc2 * ((-t2 * vb2y) - (vb3y * r12c2) +
+                               (t4 * vb3y) + (vb2y * r12c2));
+    dthetadr[1][2][2] = sc2 * ((-t2 * vb2z) - (vb3z * r12c2) +
+                               (t4 * vb3z) + (vb2z * r12c2));
+
+    dthetadr[1][3][0] = -sc2 * ((t4 * vb3x) + (vb2x * r12c2));
+    dthetadr[1][3][1] = -sc2 * ((t4 * vb3y) + (vb2y * r12c2));
+    dthetadr[1][3][2] = -sc2 * ((t4 * vb3z) + (vb2z * r12c2));
+
+    // mid-bond/torsion coupling
+    // energy on bond2 (middle bond)
+
+    cos2phi = cos(2.0*phi);
+    cos3phi = cos(3.0*phi);
+
+    bt1 = mbt_f1[type]*cosphi;
+    bt2 = mbt_f2[type]*cos2phi;
+    bt3 = mbt_f3[type]*cos3phi;
+    sumbte = bt1 + bt2 + bt3;
+
+    mbt_dr2 = r2 - mbt_r0[type];
+    mbt_ralpha2 = exp(-mbt_alpha2[type]*mbt_dr2);
+    db = 1 - mbt_ralpha2;
+    if (EFLAG) edihedral += db*sumbte;
+
+    // force on bond2
+
+    bt1 = -mbt_f1[type]*sinphi;
+    bt2 = -2.0*mbt_f2[type]*sin(2.0*phi);
+    bt3 = -3.0*mbt_f3[type]*sin(3.0*phi);
+    sumbtf = bt1 + bt2 + bt3;
+
+    for (i = 0; i < 4; i++)
+      for (j = 0; j < 3; j++)
+        fabcd[i][j] += db*sumbtf*dphidr[i][j] + sumbte*(mbt_alpha2[type]*mbt_ralpha2)*dbonddr[1][i][j];
+
+    // end-bond/torsion coupling
+    // energy on bond1 (first bond)
+
+    bt1 = ebt_f1_1[type]*cosphi;
+    bt2 = ebt_f2_1[type]*cos2phi;
+    bt3 = ebt_f3_1[type]*cos3phi;
+    sumbte = bt1 + bt2 + bt3;
+
+    ebt_dr1 = r1 - ebt_r0_1[type];
+    ebt_ralpha1 = exp(-ebt_alpha1[type]*ebt_dr1);
+    db = 1 - ebt_ralpha1;
+    if (EFLAG) edihedral += db*(bt1+bt2+bt3);
+
+    // force on bond1
+
+    bt1 = ebt_f1_1[type]*sinphi;
+    bt2 = 2.0*ebt_f2_1[type]*sin(2.0*phi);
+    bt3 = 3.0*ebt_f3_1[type]*sin(3.0*phi);
+    sumbtf = bt1 + bt2 + bt3;
+
+    for (i = 0; i < 4; i++)
+      for (j = 0; j < 3; j++)
+        fabcd[i][j] -= db*sumbtf*dphidr[i][j] + sumbte*(ebt_alpha1[type]*ebt_ralpha1)*dbonddr[0][i][j];
+
+    // end-bond/torsion coupling
+    // energy on bond3 (last bond)
+
+    bt1 = ebt_f1_2[type]*cosphi;
+    bt2 = ebt_f2_2[type]*cos2phi;
+    bt3 = ebt_f3_2[type]*cos3phi;
+    sumbte = bt1 + bt2 + bt3;
+
+    ebt_dr3 = r3 - ebt_r0_2[type];
+    ebt_ralpha3 = exp(-ebt_alpha3[type]*ebt_dr3);
+    db = 1 - ebt_ralpha3;
+    if (EFLAG) edihedral += db*(bt1+bt2+bt3);
+
+    // force on bond3
+
+    bt1 = -ebt_f1_2[type]*sinphi;
+    bt2 = -2.0*ebt_f2_2[type]*sin(2.0*phi);
+    bt3 = -3.0*ebt_f3_2[type]*sin(3.0*phi);
+    sumbtf = bt1 + bt2 + bt3;
+
+    for (i = 0; i < 4; i++)
+      for (j = 0; j < 3; j++)
+        fabcd[i][j] += db*sumbtf*dphidr[i][j] + sumbte*(ebt_alpha3[type]*ebt_ralpha3)*dbonddr[2][i][j];
+
+    // angle/torsion coupling
+    // energy on angle1
+
+    at1 = at_f1_1[type] * cosphi;
+    at2 = at_f2_1[type] * cos2phi;
+    at3 = at_f3_1[type] * cos3phi;
+    sumbte = at1 + at2 + at3;
+
+    da = acos(costh12) - at_theta0_1[type];
+    if (EFLAG) edihedral += da * (at1+at2+at3);
+
+    // force on angle1
+
+    bt1 = at_f1_1[type] * sinphi;
+    bt2 = 2.0 * at_f2_1[type] * sin(2.0*phi);
+    bt3 = 3.0 * at_f3_1[type] * sin(3.0*phi);
+    sumbtf = bt1 + bt2 + bt3;
+
+    for (i = 0; i < 4; i++)
+      for (j = 0; j < 3; j++)
+        fabcd[i][j] -= da*sumbtf*dphidr[i][j] + sumbte*dthetadr[0][i][j];
+
+    // energy on angle2
+
+    at1 = at_f1_2[type] * cosphi;
+    at2 = at_f2_2[type] * cos2phi;
+    at3 = at_f3_2[type] * cos3phi;
+    sumbte = at1 + at2 + at3;
+
+    da = acos(costh23) - at_theta0_2[type];
+    if (EFLAG) edihedral += da * (at1+at2+at3);
+
+    // force on angle2
+
+    bt1 = -at_f1_2[type] * sinphi;
+    bt2 = -2.0 * at_f2_2[type] * sin(2.0*phi);
+    bt3 = -3.0 * at_f3_2[type] * sin(3.0*phi);
+    sumbtf = bt1 + bt2 + bt3;
+
+    for (i = 0; i < 4; i++)
+      for (j = 0; j < 3; j++)
+        fabcd[i][j] += da*sumbtf*dphidr[i][j] + sumbte*dthetadr[1][i][j];
+
+    // angle/angle/torsion coupling
+
+    da1 = acos(costh12) - aat_theta0_1[type];
+    da2 = acos(costh23) - aat_theta0_2[type];
+
+    if (EFLAG) edihedral += aat_k[type]*da1*da2*cosphi;
+
+    for (i = 0; i < 4; i++)
+      for (j = 0; j < 3; j++)
+        fabcd[i][j] -= aat_k[type] *
+          (cosphi * (da2*dthetadr[0][i][j] - da1*dthetadr[1][i][j]) +
+           sinphi * da1*da2*dphidr[i][j]);
+
+    // bond1/bond3 coupling
+
+    if (fabs(bb13t_d0[type]) > SMALL) {
+
+      dr1 = r1 - bb13t_r10[type];
+      dr2 = r3 - bb13t_r30[type];
+      bb13_ralpha1 = exp(-bb13t_alpha[type]*dr1);
+      bb13_ralpha2 = exp(-bb13t_alpha[type]*dr2);
+      tk1 = -bb13t_d0[type]*bb13t_alpha[type]*bb13_ralpha1*(1 - bb13_ralpha2)/r3;
+      tk2 = -bb13t_d0[type]*bb13t_alpha[type]*bb13_ralpha2*(1 - bb13_ralpha1)/r1;
+
+      if (EFLAG) edihedral += bb13t_d0[type]*(1 - bb13_ralpha1)*(1 - bb13_ralpha2);
+
+      fabcd[0][0] += tk2*vb1x;
+      fabcd[0][1] += tk2*vb1y;
+      fabcd[0][2] += tk2*vb1z;
+
+      fabcd[1][0] -= tk2*vb1x;
+      fabcd[1][1] -= tk2*vb1y;
+      fabcd[1][2] -= tk2*vb1z;
+
+      fabcd[2][0] -= tk1*vb3x;
+      fabcd[2][1] -= tk1*vb3y;
+      fabcd[2][2] -= tk1*vb3z;
+
+      fabcd[3][0] += tk1*vb3x;
+      fabcd[3][1] += tk1*vb3y;
+      fabcd[3][2] += tk1*vb3z;
+    }
+
+    // apply force to each of 4 atoms
+
+    if (NEWTON_BOND || i1 < nlocal) {
+      f[i1].x += fabcd[0][0];
+      f[i1].y += fabcd[0][1];
+      f[i1].z += fabcd[0][2];
+    }
+
+    if (NEWTON_BOND || i2 < nlocal) {
+      f[i2].x += fabcd[1][0];
+      f[i2].y += fabcd[1][1];
+      f[i2].z += fabcd[1][2];
+    }
+
+    if (NEWTON_BOND || i3 < nlocal) {
+      f[i3].x += fabcd[2][0];
+      f[i3].y += fabcd[2][1];
+      f[i3].z += fabcd[2][2];
+    }
+
+    if (NEWTON_BOND || i4 < nlocal) {
+      f[i4].x += fabcd[3][0];
+      f[i4].y += fabcd[3][1];
+      f[i4].z += fabcd[3][2];
+    }
+
+    if (EVFLAG)
+      ev_tally_thr(this,i1,i2,i3,i4,nlocal,NEWTON_BOND,edihedral,
+                   fabcd[0],fabcd[2],fabcd[3],
+                   vb1x,vb1y,vb1z,vb2x,vb2y,vb2z,vb3x,vb3y,vb3z,thr);
+  }
+}

--- a/src/OPENMP/dihedral_class2xe_omp.h
+++ b/src/OPENMP/dihedral_class2xe_omp.h
@@ -1,0 +1,46 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#ifdef DIHEDRAL_CLASS
+// clang-format off
+DihedralStyle(class2xe/omp,DihedralClass2xeOMP);
+// clang-format on
+#else
+
+#ifndef LMP_DIHEDRAL_CLASS2XE_OMP_H
+#define LMP_DIHEDRAL_CLASS2XE_OMP_H
+
+#include "dihedral_class2xe.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class DihedralClass2xeOMP : public DihedralClass2xe, public ThrOMP {
+
+ public:
+  DihedralClass2xeOMP(class LAMMPS *lmp);
+  void compute(int, int) override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/dihedral_cosine_squared_restricted_omp.cpp
+++ b/src/OPENMP/dihedral_cosine_squared_restricted_omp.cpp
@@ -1,0 +1,253 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#include "dihedral_cosine_squared_restricted_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "neighbor.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+#include "suffix.h"
+using namespace LAMMPS_NS;
+
+static constexpr double TOLERANCE = 0.05;
+static constexpr double SMALL = 0.001;
+
+/* ---------------------------------------------------------------------- */
+
+DihedralCosineSquaredRestrictedOMP::DihedralCosineSquaredRestrictedOMP(class LAMMPS *lmp)
+  : DihedralCosineSquaredRestricted(lmp), ThrOMP(lmp,THR_DIHEDRAL)
+{
+  suffix_flag |= Suffix::OMP;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DihedralCosineSquaredRestrictedOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = neighbor->ndihedrallist;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, cvatom, thr);
+
+    if (inum > 0) {
+      if (evflag) {
+        if (eflag) {
+          if (force->newton_bond) eval<1,1,1>(ifrom, ito, thr);
+          else eval<1,1,0>(ifrom, ito, thr);
+        } else {
+          if (force->newton_bond) eval<1,0,1>(ifrom, ito, thr);
+          else eval<1,0,0>(ifrom, ito, thr);
+        }
+      } else {
+        if (force->newton_bond) eval<0,0,1>(ifrom, ito, thr);
+        else eval<0,0,0>(ifrom, ito, thr);
+      }
+    }
+    thr->timer(Timer::BOND);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+void DihedralCosineSquaredRestrictedOMP::eval(int nfrom, int nto, ThrData * const thr)
+{
+  int i1,i2,i3,i4,n,type;
+  double vb1x,vb1y,vb1z,vb2x,vb2y,vb2z,vb3x,vb3y,vb3z,vb2xm,vb2ym,vb2zm;
+  double edihedral,f1[3],f2[3],f3[3],f4[3];
+  double sb1,sb2,sb3,rb1,rb3,c0,b1mag2,b1mag,b2mag2;
+  double b2mag,b3mag2,b3mag,ctmp,r12c1,c1mag,r12c2;
+  double c2mag,sc1,sc2,s1,s12,c,pd,a,a11,a22;
+  double a33,a12,a13,a23,sx2,sy2,sz2;
+  double s2,sin2;
+
+  edihedral = 0.0;
+
+  const auto * _noalias const x = (dbl3_t *) atom->x[0];
+  auto * _noalias const f = (dbl3_t *) thr->get_f()[0];
+  const int5_t * _noalias const dihedrallist = (int5_t *) neighbor->dihedrallist[0];
+  const int nlocal = atom->nlocal;
+
+  for (n = nfrom; n < nto; n++) {
+    i1 = dihedrallist[n].a;
+    i2 = dihedrallist[n].b;
+    i3 = dihedrallist[n].c;
+    i4 = dihedrallist[n].d;
+    type = dihedrallist[n].t;
+
+    // 1st bond
+
+    vb1x = x[i1].x - x[i2].x;
+    vb1y = x[i1].y - x[i2].y;
+    vb1z = x[i1].z - x[i2].z;
+
+    // 2nd bond
+
+    vb2x = x[i3].x - x[i2].x;
+    vb2y = x[i3].y - x[i2].y;
+    vb2z = x[i3].z - x[i2].z;
+
+    vb2xm = -vb2x;
+    vb2ym = -vb2y;
+    vb2zm = -vb2z;
+
+    // 3rd bond
+
+    vb3x = x[i4].x - x[i3].x;
+    vb3y = x[i4].y - x[i3].y;
+    vb3z = x[i4].z - x[i3].z;
+
+    // c0 calculation
+
+    sb1 = 1.0 / (vb1x*vb1x + vb1y*vb1y + vb1z*vb1z);
+    sb2 = 1.0 / (vb2x*vb2x + vb2y*vb2y + vb2z*vb2z);
+    sb3 = 1.0 / (vb3x*vb3x + vb3y*vb3y + vb3z*vb3z);
+
+    rb1 = sqrt(sb1);
+    rb3 = sqrt(sb3);
+
+    c0 = (vb1x*vb3x + vb1y*vb3y + vb1z*vb3z) * rb1*rb3;
+
+    // 1st and 2nd angle
+
+    b1mag2 = vb1x*vb1x + vb1y*vb1y + vb1z*vb1z;
+    b1mag = sqrt(b1mag2);
+    b2mag2 = vb2x*vb2x + vb2y*vb2y + vb2z*vb2z;
+    b2mag = sqrt(b2mag2);
+    b3mag2 = vb3x*vb3x + vb3y*vb3y + vb3z*vb3z;
+    b3mag = sqrt(b3mag2);
+
+    ctmp = vb1x*vb2x + vb1y*vb2y + vb1z*vb2z;
+    r12c1 = 1.0 / (b1mag*b2mag);
+    c1mag = ctmp*r12c1;
+
+    ctmp = vb2xm*vb3x + vb2ym*vb3y + vb2zm*vb3z;
+    r12c2 = 1.0 / (b2mag*b3mag);
+    c2mag = ctmp*r12c2;
+
+    // cos and sin of 2 angles and final c
+
+    sin2 = MAX(1.0 - c1mag*c1mag,0.0);
+    sc1 = sqrt(sin2);
+    if (sc1 < SMALL) sc1 = SMALL;
+    sc1 = 1.0/sc1;
+
+    sin2 = MAX(1.0 - c2mag*c2mag,0.0);
+    sc2 = sqrt(sin2);
+    if (sc2 < SMALL) sc2 = SMALL;
+    sc2 = 1.0/sc2;
+
+    s1 = sc1*sc1;
+    s2 = sc2*sc2;
+    s12 = sc1*sc2;
+    c = (c0 + c1mag*c2mag) * s12;
+
+    // error check
+
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
+
+    if (c > 1.0) c = 1.0;
+    if (c < -1.0) c = -1.0;
+
+    // force & energy
+
+    double p0 = cos(phi0[type]);
+    double sq_sin = 1.0 - c*c;
+
+    pd = 2*k[type]*(c - p0)*(1.0 - c*p0) / (sq_sin*sq_sin);
+
+    if (EFLAG) edihedral = k[type]*(c - p0)*(c - p0)/sq_sin;
+
+    a = pd;
+    c = c*a;
+    s12 = s12*a;
+    a11 = c*sb1*s1;
+    a22 = -sb2*(2.0*c0*s12 - c*(s1+s2));
+    a33 = c*sb3*s2;
+    a12 = -r12c1*(c1mag*c*s1 + c2mag*s12);
+    a13 = -rb1*rb3*s12;
+    a23 = r12c2*(c2mag*c*s2 + c1mag*s12);
+
+    sx2 = a12*vb1x + a22*vb2x + a23*vb3x;
+    sy2 = a12*vb1y + a22*vb2y + a23*vb3y;
+    sz2 = a12*vb1z + a22*vb2z + a23*vb3z;
+
+    f1[0] = a11*vb1x + a12*vb2x + a13*vb3x;
+    f1[1] = a11*vb1y + a12*vb2y + a13*vb3y;
+    f1[2] = a11*vb1z + a12*vb2z + a13*vb3z;
+
+    f2[0] = -sx2 - f1[0];
+    f2[1] = -sy2 - f1[1];
+    f2[2] = -sz2 - f1[2];
+
+    f4[0] = a13*vb1x + a23*vb2x + a33*vb3x;
+    f4[1] = a13*vb1y + a23*vb2y + a33*vb3y;
+    f4[2] = a13*vb1z + a23*vb2z + a33*vb3z;
+
+    f3[0] = sx2 - f4[0];
+    f3[1] = sy2 - f4[1];
+    f3[2] = sz2 - f4[2];
+
+    // apply force to each of 4 atoms
+
+    if (NEWTON_BOND || i1 < nlocal) {
+      f[i1].x += f1[0];
+      f[i1].y += f1[1];
+      f[i1].z += f1[2];
+    }
+
+    if (NEWTON_BOND || i2 < nlocal) {
+      f[i2].x += f2[0];
+      f[i2].y += f2[1];
+      f[i2].z += f2[2];
+    }
+
+    if (NEWTON_BOND || i3 < nlocal) {
+      f[i3].x += f3[0];
+      f[i3].y += f3[1];
+      f[i3].z += f3[2];
+    }
+
+    if (NEWTON_BOND || i4 < nlocal) {
+      f[i4].x += f4[0];
+      f[i4].y += f4[1];
+      f[i4].z += f4[2];
+    }
+
+    if (EVFLAG)
+      ev_tally_thr(this,i1,i2,i3,i4,nlocal,NEWTON_BOND,edihedral,f1,f3,f4,
+                   vb1x,vb1y,vb1z,vb2x,vb2y,vb2z,vb3x,vb3y,vb3z,thr);
+  }
+}

--- a/src/OPENMP/dihedral_cosine_squared_restricted_omp.h
+++ b/src/OPENMP/dihedral_cosine_squared_restricted_omp.h
@@ -11,34 +11,33 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
-#ifdef IMPROPER_CLASS
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#ifdef DIHEDRAL_CLASS
 // clang-format off
-ImproperStyle(distance,ImproperDistance);
+DihedralStyle(cosine/squared/restricted/omp,DihedralCosineSquaredRestrictedOMP);
 // clang-format on
 #else
 
-#ifndef LMP_IMPROPER_DISTANCE_H
-#define LMP_IMPROPER_DISTANCE_H
+#ifndef LMP_DIHEDRAL_COSINE_SQUARED_RESTRICTED_OMP_H
+#define LMP_DIHEDRAL_COSINE_SQUARED_RESTRICTED_OMP_H
 
-#include "improper.h"
+#include "dihedral_cosine_squared_restricted.h"
+#include "thr_omp.h"
 
 namespace LAMMPS_NS {
 
-class ImproperDistance : public Improper {
+class DihedralCosineSquaredRestrictedOMP : public DihedralCosineSquaredRestricted, public ThrOMP {
+
  public:
-  ImproperDistance(class LAMMPS *);
-  ~ImproperDistance() override;
+  DihedralCosineSquaredRestrictedOMP(class LAMMPS *lmp);
   void compute(int, int) override;
-  void coeff(int, char **) override;
-  void write_restart(FILE *) override;
-  void read_restart(FILE *) override;
-  void write_data(FILE *) override;
-  void *extract(const char *, int &) override;
 
- protected:
-  double *k, *chi;
-
-  void allocate();
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+  void eval(int ifrom, int ito, ThrData *const thr);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/OPENMP/dihedral_spherical_omp.cpp
+++ b/src/OPENMP/dihedral_spherical_omp.cpp
@@ -1,0 +1,369 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#include "dihedral_spherical_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "domain.h"
+#include "force.h"
+#include "math_const.h"
+#include "math_extra.h"
+#include "neighbor.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+#include "suffix.h"
+using namespace LAMMPS_NS;
+using namespace MathConst;
+using namespace MathExtra;
+
+// --------------------------------------------
+// ------- Calculate the dihedral angle -------
+// --------------------------------------------
+static const int g_dim = 3;
+
+static void norm3safe(double *v)
+{
+  double inv_scale = sqrt(v[0]*v[0] + v[1]*v[1] + v[2]*v[2]);
+  double scale = 1.0;
+  if (inv_scale > 0.0) scale = 1.0 / inv_scale;
+  v[0] *= scale;
+  v[1] *= scale;
+  v[2] *= scale;
+}
+
+static double Phi(double const *x1,    //array holding x,y,z coords atom 1
+                  double const *x2,    // :       :      :      :        2
+                  double const *x3,    // :       :      :      :        3
+                  double const *x4,    // :       :      :      :        4
+                  Domain *domain,      //<-periodic boundary information
+                  double *vb12,        //<-preallocated vector will store x2-x1
+                  double *vb23,        //<-preallocated vector will store x3-x2
+                  double *vb34,        //<-preallocated vector will store x4-x3
+                  double *n123,        //<-will store normal to plane x1,x2,x3
+                  double *n234)        //<-will store normal to plane x2,x3,x4
+{
+  for (int d = 0; d < g_dim; ++d) {
+    vb12[d] = x2[d] - x1[d];    // 1st bond
+    vb23[d] = x3[d] - x2[d];    // 2nd bond
+    vb34[d] = x4[d] - x3[d];    // 3rd bond
+  }
+
+  //Consider periodic boundary conditions:
+  domain->minimum_image(FLERR, vb12[0],vb12[1],vb12[2]);
+  domain->minimum_image(FLERR, vb23[0],vb23[1],vb23[2]);
+  domain->minimum_image(FLERR, vb34[0],vb34[1],vb34[2]);
+
+  //--- Compute the normal to the planes formed by atoms 1,2,3 and 2,3,4 ---
+
+  cross3(vb23, vb12, n123);    // <- n123=vb23 x vb12
+  cross3(vb23, vb34, n234);    // <- n234=vb23 x vb34
+
+  norm3safe(n123);
+  norm3safe(n234);
+
+  double cos_phi = -dot3(n123, n234);
+
+  if (cos_phi > 1.0)
+    cos_phi = 1.0;
+  else if (cos_phi < -1.0)
+    cos_phi = -1.0;
+
+  double phi = acos(cos_phi);
+
+  if (dot3(n123, vb34) > 0.0) {
+    phi = -phi;       //(Note: Negative dihedral angles are possible only in 3-D.)
+    phi += MY_2PI;    //<- This ensure phi is always in the range 0 to 2*PI
+  }
+  return phi;
+}    // Phi()
+
+/* ---------------------------------------------------------------------- */
+
+DihedralSphericalOMP::DihedralSphericalOMP(class LAMMPS *lmp)
+  : DihedralSpherical(lmp), ThrOMP(lmp,THR_DIHEDRAL)
+{
+  suffix_flag |= Suffix::OMP;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DihedralSphericalOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = neighbor->ndihedrallist;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, cvatom, thr);
+
+    if (inum > 0) {
+      if (evflag) {
+        if (eflag) {
+          if (force->newton_bond) eval<1,1,1>(ifrom, ito, thr);
+          else eval<1,1,0>(ifrom, ito, thr);
+        } else {
+          if (force->newton_bond) eval<1,0,1>(ifrom, ito, thr);
+          else eval<1,0,0>(ifrom, ito, thr);
+        }
+      } else {
+        if (force->newton_bond) eval<0,0,1>(ifrom, ito, thr);
+        else eval<0,0,0>(ifrom, ito, thr);
+      }
+    }
+    thr->timer(Timer::BOND);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+void DihedralSphericalOMP::eval(int nfrom, int nto, ThrData * const thr)
+{
+  int i1,i2,i3,i4,n,type;
+  double edihedral,f1[3],f2[3],f3[3],f4[3];
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const int * const * const dihedrallist = neighbor->dihedrallist;
+  const int nlocal = atom->nlocal;
+
+  double vb12[g_dim];    // displacement vector from atom i1 towards atom i2
+  double vb23[g_dim];    // displacement vector from atom i2 towards atom i3
+  double vb34[g_dim];    // displacement vector from atom i3 towards atom i4
+
+  double n123[g_dim];    //n123=vb23 x vb12 / |vb23 x vb12|
+  double n234[g_dim];    //n234=vb23 x vb34 / |vb23 x vb34|
+
+  double proj12on23[g_dim];
+  double proj34on23[g_dim];
+  double perp12on23[g_dim];
+  double perp34on23[g_dim];
+
+  edihedral = 0.0;
+
+  for (n = nfrom; n < nto; n++) {
+    i1 = dihedrallist[n][0];
+    i2 = dihedrallist[n][1];
+    i3 = dihedrallist[n][2];
+    i4 = dihedrallist[n][3];
+    type = dihedrallist[n][4];
+
+    // ------ Step 1: Compute the dihedral angle "phi" ------
+
+    double phi = Phi(x[i1], x[i2], x[i3], x[i4], domain,
+                     vb12, vb23, vb34, n123, n234);
+
+    // Step 2: Compute the gradients of phi, theta1, theta2 with atom position
+
+    // ===================== Step2a) phi dependence: ========================
+
+    double dphi_dx1[g_dim];
+    double dphi_dx2[g_dim];
+    double dphi_dx3[g_dim];
+    double dphi_dx4[g_dim];
+
+    double dot123 = dot3(vb12, vb23);
+    double dot234 = dot3(vb23, vb34);
+
+    double L23sqr = dot3(vb23, vb23);
+    double L23 = sqrt(L23sqr);
+
+    double inv_L23sqr = 0.0;
+    double inv_L23 = 0.0;
+    if (L23sqr != 0.0) {
+      inv_L23sqr = 1.0 / L23sqr;
+      inv_L23 = 1.0 / L23;
+    }
+
+    double neg_inv_L23 = -inv_L23;
+    double dot123_over_L23sqr = dot123 * inv_L23sqr;
+    double dot234_over_L23sqr = dot234 * inv_L23sqr;
+
+    for (int d = 0; d < g_dim; ++d) {
+      proj12on23[d] = vb23[d] * dot123_over_L23sqr;
+      proj34on23[d] = vb23[d] * dot234_over_L23sqr;
+      perp12on23[d] = vb12[d] - proj12on23[d];
+      perp34on23[d] = vb34[d] - proj34on23[d];
+    }
+
+    double perp12on23_len = sqrt(dot3(perp12on23, perp12on23));
+    double perp34on23_len = sqrt(dot3(perp34on23, perp34on23));
+
+    double inv_perp12on23 = 0.0;
+    if (perp12on23_len != 0.0) inv_perp12on23 = 1.0 / perp12on23_len;
+    double inv_perp34on23 = 0.0;
+    if (perp34on23_len != 0.0) inv_perp34on23 = 1.0 / perp34on23_len;
+
+    for (int d = 0; d < g_dim; ++d) {
+      dphi_dx1[d] = n123[d] * inv_perp12on23;
+      dphi_dx4[d] = n234[d] * inv_perp34on23;
+    }
+
+    double proj12on23_len = dot123 * inv_L23;
+    double proj34on23_len = dot234 * inv_L23;
+
+    double dphi123_dx2_coef = neg_inv_L23 * (L23 + proj12on23_len);
+    double dphi234_dx2_coef = inv_L23 * proj34on23_len;
+
+    double dphi234_dx3_coef = neg_inv_L23 * (L23 + proj34on23_len);
+    double dphi123_dx3_coef = inv_L23 * proj12on23_len;
+
+    for (int d = 0; d < g_dim; ++d) {
+      dphi_dx2[d] = dphi123_dx2_coef*dphi_dx1[d] + dphi234_dx2_coef*dphi_dx4[d];
+      dphi_dx3[d] = dphi123_dx3_coef*dphi_dx1[d] + dphi234_dx3_coef*dphi_dx4[d];
+    }
+
+    // ============= Step2b) theta1 and theta2 dependence: =============
+
+    double dth1_dx1[g_dim];
+    double dth1_dx2[g_dim];
+    double dth1_dx3[g_dim];
+
+    double dth2_dx2[g_dim];
+    double dth2_dx3[g_dim];
+    double dth2_dx4[g_dim];
+
+    double L12sqr = dot3(vb12, vb12);
+    double L12 = sqrt(L12sqr);
+    double L34sqr = dot3(vb34, vb34);
+    double L34 = sqrt(L34sqr);
+    double inv_L12sqr = 0.0;
+    double inv_L12 = 0.0;
+    double inv_L34sqr = 0.0;
+    double inv_L34 = 0.0;
+    if (L12sqr != 0.0) {
+      inv_L12sqr = 1.0 / L12sqr;
+      inv_L12 = 1.0 / L12;
+    }
+    if (L34sqr != 0.0) {
+      inv_L34sqr = 1.0 / L34sqr;
+      inv_L34 = 1.0 / L34;
+    }
+
+    double proj23on12[g_dim];
+    double perp23on12[g_dim];
+    double proj23on34[g_dim];
+    double perp23on34[g_dim];
+
+    double dot123_over_L12sqr = dot123 * inv_L12sqr;
+    double dot234_over_L34sqr = dot234 * inv_L34sqr;
+
+    for (int d = 0; d < g_dim; ++d) {
+      proj23on12[d] = vb12[d] * dot123_over_L12sqr;
+      proj23on34[d] = vb34[d] * dot234_over_L34sqr;
+      perp23on12[d] = vb23[d] - proj23on12[d];
+      perp23on34[d] = vb23[d] - proj23on34[d];
+    }
+
+    double perp23on12_len = sqrt(dot3(perp23on12, perp23on12));
+    double perp23on34_len = sqrt(dot3(perp23on34, perp23on34));
+
+    double inv_perp23on12 = 0.0;
+    if (perp23on12_len != 0.0) inv_perp23on12 = 1.0 / perp23on12_len;
+    double inv_perp23on34 = 0.0;
+    if (perp23on34_len != 0.0) inv_perp23on34 = 1.0 / perp23on34_len;
+
+    double coeff_dth1_dx1 = -inv_perp23on12 * inv_L12;
+    double coeff_dth1_dx3 = inv_perp12on23 * inv_L23;
+    double coeff_dth2_dx2 = -inv_perp34on23 * inv_L23;
+    double coeff_dth2_dx4 = inv_perp23on34 * inv_L34;
+
+    for (int d = 0; d < g_dim; ++d) {
+      dth1_dx1[d] = perp23on12[d] * coeff_dth1_dx1;
+      dth1_dx3[d] = perp12on23[d] * coeff_dth1_dx3;
+      dth1_dx2[d] = -(dth1_dx1[d] + dth1_dx3[d]);
+
+      dth2_dx2[d] = perp34on23[d] * coeff_dth2_dx2;
+      dth2_dx4[d] = perp23on34[d] * coeff_dth2_dx4;
+      dth2_dx3[d] = -(dth2_dx2[d] + dth2_dx4[d]);
+    }
+
+    double ct1 = -dot123 * inv_L12 * inv_L23;
+    if (ct1 < -1.0) ct1 = -1.0;
+    else if (ct1 > 1.0) ct1 = 1.0;
+    double theta1 = acos(ct1);
+
+    double ct2 = -dot234 * inv_L23 * inv_L34;
+    if (ct2 < -1.0) ct2 = -1.0;
+    else if (ct2 > 1.0) ct2 = 1.0;
+    double theta2 = acos(ct2);
+
+    // - Step 3: Calculate the energy and force in the phi & theta1/2 directions
+
+    double u = 0.0;
+    double m_du_dth1 = 0.0;
+    double m_du_dth2 = 0.0;
+    double m_du_dphi = 0.0;
+
+    u = CalcGeneralizedForces(type, phi, theta1, theta2, &m_du_dth1, &m_du_dth2, &m_du_dphi);
+
+    if (EFLAG) edihedral = u;
+
+    // ----- Step 4: Calculate the force direction in real space -----
+
+    for (int d = 0; d < g_dim; ++d) {
+      f1[d] = m_du_dphi*dphi_dx1[d] + m_du_dth1*dth1_dx1[d];
+      f2[d] = m_du_dphi*dphi_dx2[d] + m_du_dth1*dth1_dx2[d] + m_du_dth2*dth2_dx2[d];
+      f3[d] = m_du_dphi*dphi_dx3[d] + m_du_dth1*dth1_dx3[d] + m_du_dth2*dth2_dx3[d];
+      f4[d] = m_du_dphi*dphi_dx4[d] + m_du_dth2*dth2_dx4[d];
+    }
+
+    // apply force to each of 4 atoms
+
+    if (NEWTON_BOND || i1 < nlocal) {
+      f[i1][0] += f1[0];
+      f[i1][1] += f1[1];
+      f[i1][2] += f1[2];
+    }
+
+    if (NEWTON_BOND || i2 < nlocal) {
+      f[i2][0] += f2[0];
+      f[i2][1] += f2[1];
+      f[i2][2] += f2[2];
+    }
+
+    if (NEWTON_BOND || i3 < nlocal) {
+      f[i3][0] += f3[0];
+      f[i3][1] += f3[1];
+      f[i3][2] += f3[2];
+    }
+
+    if (NEWTON_BOND || i4 < nlocal) {
+      f[i4][0] += f4[0];
+      f[i4][1] += f4[1];
+      f[i4][2] += f4[2];
+    }
+
+    if (EVFLAG)
+      ev_tally_thr(this,i1,i2,i3,i4,nlocal,NEWTON_BOND,edihedral,f1,f3,f4,
+                   vb12[0],vb12[1],vb12[2],vb23[0],vb23[1],vb23[2],
+                   vb34[0],vb34[1],vb34[2],thr);
+  }
+}

--- a/src/OPENMP/dihedral_spherical_omp.h
+++ b/src/OPENMP/dihedral_spherical_omp.h
@@ -11,34 +11,33 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
-#ifdef IMPROPER_CLASS
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#ifdef DIHEDRAL_CLASS
 // clang-format off
-ImproperStyle(distance,ImproperDistance);
+DihedralStyle(spherical/omp,DihedralSphericalOMP);
 // clang-format on
 #else
 
-#ifndef LMP_IMPROPER_DISTANCE_H
-#define LMP_IMPROPER_DISTANCE_H
+#ifndef LMP_DIHEDRAL_SPHERICAL_OMP_H
+#define LMP_DIHEDRAL_SPHERICAL_OMP_H
 
-#include "improper.h"
+#include "dihedral_spherical.h"
+#include "thr_omp.h"
 
 namespace LAMMPS_NS {
 
-class ImproperDistance : public Improper {
+class DihedralSphericalOMP : public DihedralSpherical, public ThrOMP {
+
  public:
-  ImproperDistance(class LAMMPS *);
-  ~ImproperDistance() override;
+  DihedralSphericalOMP(class LAMMPS *lmp);
   void compute(int, int) override;
-  void coeff(int, char **) override;
-  void write_restart(FILE *) override;
-  void read_restart(FILE *) override;
-  void write_data(FILE *) override;
-  void *extract(const char *, int &) override;
 
- protected:
-  double *k, *chi;
-
-  void allocate();
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+  void eval(int ifrom, int ito, ThrData *const thr);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/OPENMP/dihedral_table_cut_omp.cpp
+++ b/src/OPENMP/dihedral_table_cut_omp.cpp
@@ -1,0 +1,361 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#include "dihedral_table_cut_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "math_const.h"
+#include "neighbor.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+#include "suffix.h"
+using namespace LAMMPS_NS;
+using namespace MathConst;
+
+static constexpr double TOLERANCE = 0.05;
+static constexpr double SMALL =     0.0000001;
+
+/* ---------------------------------------------------------------------- */
+
+DihedralTableCutOMP::DihedralTableCutOMP(class LAMMPS *lmp)
+  : DihedralTableCut(lmp), ThrOMP(lmp,THR_DIHEDRAL)
+{
+  suffix_flag |= Suffix::OMP;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DihedralTableCutOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = neighbor->ndihedrallist;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, cvatom, thr);
+
+    if (inum > 0) {
+      if (evflag) {
+        if (eflag) {
+          if (force->newton_bond) eval<1,1,1>(ifrom, ito, thr);
+          else eval<1,1,0>(ifrom, ito, thr);
+        } else {
+          if (force->newton_bond) eval<1,0,1>(ifrom, ito, thr);
+          else eval<1,0,0>(ifrom, ito, thr);
+        }
+      } else {
+        if (force->newton_bond) eval<0,0,1>(ifrom, ito, thr);
+        else eval<0,0,0>(ifrom, ito, thr);
+      }
+    }
+    thr->timer(Timer::BOND);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+void DihedralTableCutOMP::eval(int nfrom, int nto, ThrData * const thr)
+{
+  int i1,i2,i3,i4,i,j,k,n,type;
+  double edihedral;
+  double vb1x,vb1y,vb1z,vb2x,vb2y,vb2z,vb3x,vb3y,vb3z,vb2xm,vb2ym,vb2zm;
+  double fphi,fpphi;
+  double r1mag2,r1,r2mag2,r2,r3mag2,r3;
+  double sb1,rb1,sb2,rb2,sb3,rb3,c0,r12c1;
+  double r12c2,costh12,costh13,costh23,sc1,sc2,s1,s2,c;
+  double phi,sinphi,a11,a22,a33,a12,a13,a23,sx1,sx2;
+  double sx12,sy1,sy2,sy12,sz1,sz2,sz12;
+  double t1,t2,t3,t4;
+  double da1,da2;
+  double s12,sin2;
+  double dcosphidr[4][3],dphidr[4][3],dthetadr[2][4][3];
+  double fabcd[4][3];
+
+  edihedral = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const int * const * const dihedrallist = neighbor->dihedrallist;
+  const int nlocal = atom->nlocal;
+
+  for (n = nfrom; n < nto; n++) {
+    i1 = dihedrallist[n][0];
+    i2 = dihedrallist[n][1];
+    i3 = dihedrallist[n][2];
+    i4 = dihedrallist[n][3];
+    type = dihedrallist[n][4];
+
+    // 1st bond
+
+    vb1x = x[i1][0] - x[i2][0];
+    vb1y = x[i1][1] - x[i2][1];
+    vb1z = x[i1][2] - x[i2][2];
+
+    // 2nd bond
+
+    vb2x = x[i3][0] - x[i2][0];
+    vb2y = x[i3][1] - x[i2][1];
+    vb2z = x[i3][2] - x[i2][2];
+
+    vb2xm = -vb2x;
+    vb2ym = -vb2y;
+    vb2zm = -vb2z;
+
+    // 3rd bond
+
+    vb3x = x[i4][0] - x[i3][0];
+    vb3y = x[i4][1] - x[i3][1];
+    vb3z = x[i4][2] - x[i3][2];
+
+    // distances
+
+    r1mag2 = vb1x*vb1x + vb1y*vb1y + vb1z*vb1z;
+    r1 = sqrt(r1mag2);
+    r2mag2 = vb2x*vb2x + vb2y*vb2y + vb2z*vb2z;
+    r2 = sqrt(r2mag2);
+    r3mag2 = vb3x*vb3x + vb3y*vb3y + vb3z*vb3z;
+    r3 = sqrt(r3mag2);
+
+    sb1 = 1.0/r1mag2;
+    rb1 = 1.0/r1;
+    sb2 = 1.0/r2mag2;
+    rb2 = 1.0/r2;
+    sb3 = 1.0/r3mag2;
+    rb3 = 1.0/r3;
+
+    c0 = (vb1x*vb3x + vb1y*vb3y + vb1z*vb3z) * rb1*rb3;
+
+    // angles
+
+    r12c1 = rb1*rb2;
+    r12c2 = rb2*rb3;
+    costh12 = (vb1x*vb2x + vb1y*vb2y + vb1z*vb2z) * r12c1;
+    costh13 = c0;
+    costh23 = (vb2xm*vb3x + vb2ym*vb3y + vb2zm*vb3z) * r12c2;
+
+    // cos and sin of 2 angles and final c
+
+    sin2 = MAX(1.0 - costh12*costh12,0.0);
+    sc1 = sqrt(sin2);
+    if (sc1 < SMALL) sc1 = SMALL;
+    sc1 = 1.0/sc1;
+
+    sin2 = MAX(1.0 - costh23*costh23,0.0);
+    sc2 = sqrt(sin2);
+    if (sc2 < SMALL) sc2 = SMALL;
+    sc2 = 1.0/sc2;
+
+    s1 = sc1 * sc1;
+    s2 = sc2 * sc2;
+    s12 = sc1 * sc2;
+    c = (c0 + costh12*costh23) * s12;
+
+    // error check
+
+    if (c > 1.0 + TOLERANCE || c < (-1.0 - TOLERANCE))
+      problem(FLERR, i1, i2, i3, i4);
+
+    if (c > 1.0) c = 1.0;
+    if (c < -1.0) c = -1.0;
+    double phil = acos(c);
+    phi = acos(c);
+
+    sinphi = sqrt(1.0 - c*c);
+    sinphi = MAX(sinphi,SMALL);
+
+    // n123 = vb1 x vb2
+
+    double n123x = vb1y*vb2z - vb1z*vb2y;
+    double n123y = vb1z*vb2x - vb1x*vb2z;
+    double n123z = vb1x*vb2y - vb1y*vb2x;
+    double n123_dot_vb3 = n123x*vb3x + n123y*vb3y + n123z*vb3z;
+    if (n123_dot_vb3 > 0.0) {
+      phil = -phil;
+      phi = -phi;
+      sinphi = -sinphi;
+    }
+
+    a11 = -c*sb1*s1;
+    a22 = sb2 * (2.0*costh13*s12 - c*(s1+s2));
+    a33 = -c*sb3*s2;
+    a12 = r12c1 * (costh12*c*s1 + costh23*s12);
+    a13 = rb1*rb3*s12;
+    a23 = r12c2 * (-costh23*c*s2 - costh12*s12);
+
+    sx1  = a11*vb1x + a12*vb2x + a13*vb3x;
+    sx2  = a12*vb1x + a22*vb2x + a23*vb3x;
+    sx12 = a13*vb1x + a23*vb2x + a33*vb3x;
+    sy1  = a11*vb1y + a12*vb2y + a13*vb3y;
+    sy2  = a12*vb1y + a22*vb2y + a23*vb3y;
+    sy12 = a13*vb1y + a23*vb2y + a33*vb3y;
+    sz1  = a11*vb1z + a12*vb2z + a13*vb3z;
+    sz2  = a12*vb1z + a22*vb2z + a23*vb3z;
+    sz12 = a13*vb1z + a23*vb2z + a33*vb3z;
+
+    // set up d(cos(phi))/d(r) and dphi/dr arrays
+
+    dcosphidr[0][0] = -sx1;
+    dcosphidr[0][1] = -sy1;
+    dcosphidr[0][2] = -sz1;
+    dcosphidr[1][0] = sx2 + sx1;
+    dcosphidr[1][1] = sy2 + sy1;
+    dcosphidr[1][2] = sz2 + sz1;
+    dcosphidr[2][0] = sx12 - sx2;
+    dcosphidr[2][1] = sy12 - sy2;
+    dcosphidr[2][2] = sz12 - sz2;
+    dcosphidr[3][0] = -sx12;
+    dcosphidr[3][1] = -sy12;
+    dcosphidr[3][2] = -sz12;
+
+    for (i = 0; i < 4; i++)
+      for (j = 0; j < 3; j++)
+        dphidr[i][j] = -dcosphidr[i][j] / sinphi;
+
+
+    for (i = 0; i < 4; i++)
+      for (j = 0; j < 3; j++)
+        fabcd[i][j] = 0;
+    edihedral = 0;
+
+
+    // set up d(theta)/d(r) array
+    // dthetadr(i,j,k) = angle i, atom j, coordinate k
+
+    for (i = 0; i < 2; i++)
+      for (j = 0; j < 4; j++)
+        for (k = 0; k < 3; k++)
+          dthetadr[i][j][k] = 0.0;
+
+    t1 = costh12 / r1mag2;
+    t2 = costh23 / r2mag2;
+    t3 = costh12 / r2mag2;
+    t4 = costh23 / r3mag2;
+
+    // angle12
+
+    dthetadr[0][0][0] = sc1 * ((t1 * vb1x) - (vb2x * r12c1));
+    dthetadr[0][0][1] = sc1 * ((t1 * vb1y) - (vb2y * r12c1));
+    dthetadr[0][0][2] = sc1 * ((t1 * vb1z) - (vb2z * r12c1));
+
+    dthetadr[0][1][0] = sc1 * ((-t1 * vb1x) + (vb2x * r12c1) +
+                               (-t3 * vb2x) + (vb1x * r12c1));
+    dthetadr[0][1][1] = sc1 * ((-t1 * vb1y) + (vb2y * r12c1) +
+                               (-t3 * vb2y) + (vb1y * r12c1));
+    dthetadr[0][1][2] = sc1 * ((-t1 * vb1z) + (vb2z * r12c1) +
+                               (-t3 * vb2z) + (vb1z * r12c1));
+
+    dthetadr[0][2][0] = sc1 * ((t3 * vb2x) - (vb1x * r12c1));
+    dthetadr[0][2][1] = sc1 * ((t3 * vb2y) - (vb1y * r12c1));
+    dthetadr[0][2][2] = sc1 * ((t3 * vb2z) - (vb1z * r12c1));
+
+    // angle23
+
+    dthetadr[1][1][0] = sc2 * ((t2 * vb2x) + (vb3x * r12c2));
+    dthetadr[1][1][1] = sc2 * ((t2 * vb2y) + (vb3y * r12c2));
+    dthetadr[1][1][2] = sc2 * ((t2 * vb2z) + (vb3z * r12c2));
+
+    dthetadr[1][2][0] = sc2 * ((-t2 * vb2x) - (vb3x * r12c2) +
+                               (t4 * vb3x) + (vb2x * r12c2));
+    dthetadr[1][2][1] = sc2 * ((-t2 * vb2y) - (vb3y * r12c2) +
+                               (t4 * vb3y) + (vb2y * r12c2));
+    dthetadr[1][2][2] = sc2 * ((-t2 * vb2z) - (vb3z * r12c2) +
+                               (t4 * vb3z) + (vb2z * r12c2));
+
+    dthetadr[1][3][0] = -sc2 * ((t4 * vb3x) + (vb2x * r12c2));
+    dthetadr[1][3][1] = -sc2 * ((t4 * vb3y) + (vb2y * r12c2));
+    dthetadr[1][3][2] = -sc2 * ((t4 * vb3z) + (vb2z * r12c2));
+
+    // angle/angle/torsion cutoff
+
+    da1 = acos(costh12) - aat_theta0_1[type];
+    da2 = acos(costh23) - aat_theta0_1[type];
+    double dtheta = aat_theta0_2[type]-aat_theta0_1[type];
+
+    fphi = 0.0;
+    fpphi = 0.0;
+    if (phil < 0) phil += MY_2PI;
+    uf_lookup(type, phil, fphi, fpphi);
+
+    double gt = aat_k[type];
+    double gtt = aat_k[type];
+    double gpt = 0;
+    double gptt = 0;
+
+    if (acos(costh12) > aat_theta0_1[type]) {
+      gt *= 1-da1*da1/dtheta/dtheta;
+      gpt = -aat_k[type]*2*da1/dtheta/dtheta;
+    }
+
+    if (acos(costh23) > aat_theta0_1[type]) {
+      gtt *= 1-da2*da2/dtheta/dtheta;
+      gptt = -aat_k[type]*2*da2/dtheta/dtheta;
+    }
+
+    if (EFLAG) edihedral = gt*gtt*fphi;
+
+    for (i = 0; i < 4; i++)
+      for (j = 0; j < 3; j++)
+        fabcd[i][j] -= gt*gtt*fpphi*dphidr[i][j]
+          - gt*gptt*fphi*dthetadr[1][i][j] + gpt*gtt*fphi*dthetadr[0][i][j];
+
+    // apply force to each of 4 atoms
+
+    if (NEWTON_BOND || i1 < nlocal) {
+      f[i1][0] += fabcd[0][0];
+      f[i1][1] += fabcd[0][1];
+      f[i1][2] += fabcd[0][2];
+    }
+
+    if (NEWTON_BOND || i2 < nlocal) {
+      f[i2][0] += fabcd[1][0];
+      f[i2][1] += fabcd[1][1];
+      f[i2][2] += fabcd[1][2];
+    }
+
+    if (NEWTON_BOND || i3 < nlocal) {
+      f[i3][0] += fabcd[2][0];
+      f[i3][1] += fabcd[2][1];
+      f[i3][2] += fabcd[2][2];
+    }
+
+    if (NEWTON_BOND || i4 < nlocal) {
+      f[i4][0] += fabcd[3][0];
+      f[i4][1] += fabcd[3][1];
+      f[i4][2] += fabcd[3][2];
+    }
+
+    if (EVFLAG)
+      ev_tally_thr(this,i1,i2,i3,i4,nlocal,NEWTON_BOND,edihedral,
+                   fabcd[0],fabcd[2],fabcd[3],
+                   vb1x,vb1y,vb1z,vb2x,vb2y,vb2z,vb3x,vb3y,vb3z,thr);
+  }
+}

--- a/src/OPENMP/dihedral_table_cut_omp.h
+++ b/src/OPENMP/dihedral_table_cut_omp.h
@@ -11,34 +11,33 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
-#ifdef IMPROPER_CLASS
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#ifdef DIHEDRAL_CLASS
 // clang-format off
-ImproperStyle(distance,ImproperDistance);
+DihedralStyle(table/cut/omp,DihedralTableCutOMP);
 // clang-format on
 #else
 
-#ifndef LMP_IMPROPER_DISTANCE_H
-#define LMP_IMPROPER_DISTANCE_H
+#ifndef LMP_DIHEDRAL_TABLE_CUT_OMP_H
+#define LMP_DIHEDRAL_TABLE_CUT_OMP_H
 
-#include "improper.h"
+#include "dihedral_table_cut.h"
+#include "thr_omp.h"
 
 namespace LAMMPS_NS {
 
-class ImproperDistance : public Improper {
+class DihedralTableCutOMP : public DihedralTableCut, public ThrOMP {
+
  public:
-  ImproperDistance(class LAMMPS *);
-  ~ImproperDistance() override;
+  DihedralTableCutOMP(class LAMMPS *lmp);
   void compute(int, int) override;
-  void coeff(int, char **) override;
-  void write_restart(FILE *) override;
-  void read_restart(FILE *) override;
-  void write_data(FILE *) override;
-  void *extract(const char *, int &) override;
 
- protected:
-  double *k, *chi;
-
-  void allocate();
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+  void eval(int ifrom, int ito, ThrData *const thr);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/OPENMP/improper_distance_omp.cpp
+++ b/src/OPENMP/improper_distance_omp.cpp
@@ -1,0 +1,203 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#include "improper_distance_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "domain.h"
+#include "force.h"
+#include "neighbor.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+#include "suffix.h"
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+ImproperDistanceOMP::ImproperDistanceOMP(class LAMMPS *lmp)
+  : ImproperDistance(lmp), ThrOMP(lmp,THR_IMPROPER)
+{
+  suffix_flag |= Suffix::OMP;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ImproperDistanceOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = neighbor->nimproperlist;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, cvatom, thr);
+
+    if (inum > 0) {
+      if (evflag) {
+        if (eflag) {
+          if (force->newton_bond) eval<1,1,1>(ifrom, ito, thr);
+          else eval<1,1,0>(ifrom, ito, thr);
+        } else {
+          if (force->newton_bond) eval<1,0,1>(ifrom, ito, thr);
+          else eval<1,0,0>(ifrom, ito, thr);
+        }
+      } else {
+        if (force->newton_bond) eval<0,0,1>(ifrom, ito, thr);
+        else eval<0,0,0>(ifrom, ito, thr);
+      }
+    }
+    thr->timer(Timer::BOND);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+void ImproperDistanceOMP::eval(int nfrom, int nto, ThrData * const thr)
+{
+  int i1,i2,i3,i4,n,type;
+  double xab, yab, zab; // bond 1-2
+  double xac, yac, zac; // bond 1-3
+  double xad, yad, zad; // bond 1-4
+  double xbc, ybc, zbc; // bond 2-3
+  double xbd, ybd, zbd; // bond 2-4
+  double xna, yna, zna, rna; // normal
+  double da;
+  double eimproper,f1[3],f2[3],f3[3],f4[3];
+  double domega,a;
+
+  eimproper = 0.0;
+
+  const auto * _noalias const x = (dbl3_t *) atom->x[0];
+  auto * _noalias const f = (dbl3_t *) thr->get_f()[0];
+  const int5_t * _noalias const improperlist = (int5_t *) neighbor->improperlist[0];
+  const int nlocal = atom->nlocal;
+
+  for (n = nfrom; n < nto; n++) {
+    i1 = improperlist[n].a;
+    i2 = improperlist[n].b;
+    i3 = improperlist[n].c;
+    i4 = improperlist[n].d;
+    type = improperlist[n].t;
+
+    // geometry of 4-body
+    // 1 is the central atom
+
+    // bond 1->2
+    xab = x[i2].x - x[i1].x;
+    yab = x[i2].y - x[i1].y;
+    zab = x[i2].z - x[i1].z;
+    domain->minimum_image(FLERR, xab,yab,zab);
+
+    // bond 1->3
+    xac = x[i3].x - x[i1].x;
+    yac = x[i3].y - x[i1].y;
+    zac = x[i3].z - x[i1].z;
+    domain->minimum_image(FLERR, xac,yac,zac);
+
+    // bond 1->4
+    xad = x[i4].x - x[i1].x;
+    yad = x[i4].y - x[i1].y;
+    zad = x[i4].z - x[i1].z;
+    domain->minimum_image(FLERR, xad,yad,zad);
+
+    // bond 2-3
+    xbc = x[i3].x - x[i2].x;
+    ybc = x[i3].y - x[i2].y;
+    zbc = x[i3].z - x[i2].z;
+    domain->minimum_image(FLERR, xbc,ybc,zbc);
+
+    // bond 2-4
+    xbd = x[i4].x - x[i2].x;
+    ybd = x[i4].y - x[i2].y;
+    zbd = x[i4].z - x[i2].z;
+    domain->minimum_image(FLERR, xbd,ybd,zbd);
+
+    xna =   ybc*zbd - zbc*ybd;
+    yna = -(xbc*zbd - zbc*xbd);
+    zna =   xbc*ybd - ybc*xbd;
+    rna = 1.0 / sqrt(xna*xna+yna*yna+zna*zna);
+    xna *= rna;
+    yna *= rna;
+    zna *= rna;
+
+    da = xna*xab + yna*yab + zna*zab;
+
+    domega = k[type]*da*da + chi[type]*da*da*da*da;
+    a =  2.0* (k[type]*da + 2.0*chi[type]*da*da*da);
+
+    if (EFLAG) eimproper = domega;
+
+    f1[0] = a*( xna);
+    f1[1] = a*( yna);
+    f1[2] = a*( zna);
+
+    f2[0] = a*( -xna               -yab*(zbd-zbc)*rna +zab*(ybd-ybc)*rna -da*( -yna*(zbd-zbc) + zna*(ybd-ybc) )*rna);
+    f2[1] = a*( +xab*(zbd-zbc)*rna -yna               +zab*(xbc-xbd)*rna -da*( +xna*(zbd-zbc) + zna*(xbc-xbd) )*rna);
+    f2[2] = a*( -xab*(ybd-ybc)*rna -yab*(xbc-xbd)*rna -zna               -da*( +xna*(ybc-ybd) - yna*(xbc-xbd) )*rna);
+
+    f3[0] = a*( (           yab*zbd -zab*ybd ) *rna +da*( -yna*zbd +zna*ybd )*rna);
+    f3[1] = a*( ( -xab*zbd          +zab*xbd ) *rna +da*( +xna*zbd -zna*xbd )*rna);
+    f3[2] = a*( ( +xab*ybd -yab*xbd          ) *rna +da*( -xna*ybd +yna*xbd )*rna);
+
+    f4[0] = a*( (          -yab*zbc +zab*ybc ) *rna -da*( -yna*zbc +zna*ybc )*rna);
+    f4[1] = a*( ( +xab*zbc          -zab*xbc ) *rna -da*( +xna*zbc -zna*xbc )*rna);
+    f4[2] = a*( ( -xab*ybc +yab*xbc          ) *rna -da*( -xna*ybc +yna*xbc )*rna);
+
+    // apply force to each of 4 atoms
+
+    if (NEWTON_BOND || i1 < nlocal) {
+      f[i1].x += f1[0];
+      f[i1].y += f1[1];
+      f[i1].z += f1[2];
+    }
+
+    if (NEWTON_BOND || i2 < nlocal) {
+      f[i2].x += f2[0];
+      f[i2].y += f2[1];
+      f[i2].z += f2[2];
+    }
+
+    if (NEWTON_BOND || i3 < nlocal) {
+      f[i3].x += f3[0];
+      f[i3].y += f3[1];
+      f[i3].z += f3[2];
+    }
+
+    if (NEWTON_BOND || i4 < nlocal) {
+      f[i4].x += f4[0];
+      f[i4].y += f4[1];
+      f[i4].z += f4[2];
+    }
+
+    if (EVFLAG)
+      ev_tally_thr(this,i1,i2,i3,i4,nlocal,NEWTON_BOND,eimproper,f2,f3,f4,
+                   xab,yab,zab,xac,yac,zac,xad-xac,yad-yac,zad-zac,thr);
+  }
+}

--- a/src/OPENMP/improper_distance_omp.h
+++ b/src/OPENMP/improper_distance_omp.h
@@ -11,34 +11,33 @@
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
+/* ----------------------------------------------------------------------
+   Contributing author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
 #ifdef IMPROPER_CLASS
 // clang-format off
-ImproperStyle(distance,ImproperDistance);
+ImproperStyle(distance/omp,ImproperDistanceOMP);
 // clang-format on
 #else
 
-#ifndef LMP_IMPROPER_DISTANCE_H
-#define LMP_IMPROPER_DISTANCE_H
+#ifndef LMP_IMPROPER_DISTANCE_OMP_H
+#define LMP_IMPROPER_DISTANCE_OMP_H
 
-#include "improper.h"
+#include "improper_distance.h"
+#include "thr_omp.h"
 
 namespace LAMMPS_NS {
 
-class ImproperDistance : public Improper {
+class ImproperDistanceOMP : public ImproperDistance, public ThrOMP {
+
  public:
-  ImproperDistance(class LAMMPS *);
-  ~ImproperDistance() override;
+  ImproperDistanceOMP(class LAMMPS *lmp);
   void compute(int, int) override;
-  void coeff(int, char **) override;
-  void write_restart(FILE *) override;
-  void read_restart(FILE *) override;
-  void write_data(FILE *) override;
-  void *extract(const char *, int &) override;
 
- protected:
-  double *k, *chi;
-
-  void allocate();
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+  void eval(int ifrom, int ito, ThrData *const thr);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/Purge.list
+++ b/src/Purge.list
@@ -1034,6 +1034,8 @@ kim_units.cpp
 pair_kim.cpp
 angle_charmm_kokkos.h
 angle_class2_kokkos.h
+angle_class2xe.cpp
+angle_class2xe.h
 angle_cosine_kokkos.h
 angle_harmonic_kokkos.h
 angle_hybrid_kokkos.h
@@ -1074,6 +1076,8 @@ compute_temp_kokkos.h
 dihedral_charmmfsw_kokkos.h
 dihedral_charmm_kokkos.h
 dihedral_class2_kokkos.h
+dihedral_class2xe.cpp
+dihedral_class2xe.h
 dihedral_fourier_kokkos.h
 dihedral_harmonic_kokkos.h
 dihedral_hybrid_kokkos.h

--- a/src/Purge.list
+++ b/src/Purge.list
@@ -1034,8 +1034,6 @@ kim_units.cpp
 pair_kim.cpp
 angle_charmm_kokkos.h
 angle_class2_kokkos.h
-angle_class2xe.cpp
-angle_class2xe.h
 angle_cosine_kokkos.h
 angle_harmonic_kokkos.h
 angle_hybrid_kokkos.h
@@ -1076,8 +1074,6 @@ compute_temp_kokkos.h
 dihedral_charmmfsw_kokkos.h
 dihedral_charmm_kokkos.h
 dihedral_class2_kokkos.h
-dihedral_class2xe.cpp
-dihedral_class2xe.h
 dihedral_fourier_kokkos.h
 dihedral_harmonic_kokkos.h
 dihedral_hybrid_kokkos.h


### PR DESCRIPTION
**Summary**

This continues pull request #4956 by adding styles for bonded interactions that were ported to the OPENMP package by GitHub Copilot using the Claude Sonnet 4.6 engine.

**Related Issue(s)**

N/A

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

The porting was exclusively done by GitHub Copilot using Claude Sonnet 4.6

**Backward Compatibility**

Yes

**Implementation Notes**

The following 9 styles were ported:
- bond_style harmonic/restrain
- angle_style class2xe
- angle_style gaussian
- angle_style mlwc
- dihedral_style charmmfsw
- dihedral_style class2xe
- dihedral_style spherical
- dihedral_style table/cut
- improper_style distance

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
