### PR TITLE
Fixing region bugs

### DIFF
--- a/doc/src/region.rst
+++ b/doc/src/region.rst
@@ -258,6 +258,11 @@ consisting of the volume that is common to all the listed regions.
    from their list of sub-regions.  Thus you cannot delete the
    sub-regions after defining a *union* or *intersection* region.
 
+.. note::
+   The *union* and *intersect* regions require all subregions have
+   the same *move* and *rotation* settings to ensure all regions
+   move in unison
+
 ----------
 
 The *side* keyword determines whether the region is considered to be

--- a/doc/src/region.rst
+++ b/doc/src/region.rst
@@ -258,11 +258,6 @@ consisting of the volume that is common to all the listed regions.
    from their list of sub-regions.  Thus you cannot delete the
    sub-regions after defining a *union* or *intersection* region.
 
-.. note::
-   The *union* and *intersect* regions require all subregions have
-   the same *move* and *rotation* settings to ensure all regions
-   move in unison
-
 ----------
 
 The *side* keyword determines whether the region is considered to be
@@ -318,9 +313,9 @@ If the *move* or *rotate* keywords are used, the region is "dynamic",
 meaning its location or orientation changes with time.  These keywords
 cannot be used with a *union* or *intersect* style region.  Instead, the
 keywords should be used to make the individual sub-regions of the
-*union* or *intersect* region dynamic.  Normally, each sub-region should
-be "dynamic" in the same manner (e.g. rotate around the same point),
-though this is not a requirement.
+*union* or *intersect* region dynamic.  Each sub-region must be "dynamic"
+in the same manner (e.g. rotate around the same point) or else LAMMPS
+will return an error.
 
 The *move* keyword allows one or more :doc:`equal-style variables
 <variable>` to be used to specify the x,y,z displacement of the region,

--- a/doc/src/region.rst
+++ b/doc/src/region.rst
@@ -313,9 +313,7 @@ If the *move* or *rotate* keywords are used, the region is "dynamic",
 meaning its location or orientation changes with time.  These keywords
 cannot be used with a *union* or *intersect* style region.  Instead, the
 keywords should be used to make the individual sub-regions of the
-*union* or *intersect* region dynamic.  Each sub-region must be "dynamic"
-in the same manner (e.g. rotate around the same point) or else LAMMPS
-will return an error.
+*union* or *intersect* region dynamic.
 
 The *move* keyword allows one or more :doc:`equal-style variables
 <variable>` to be used to specify the x,y,z displacement of the region,

--- a/src/region.h
+++ b/src/region.h
@@ -89,7 +89,7 @@ class Region : protected Pointers {
   int surface(double, double, double, double);
 
   virtual void set_velocity();
-  void velocity_contact(double *, double *, int);
+  virtual void velocity_contact(double *, double *, int);
   virtual void write_restart(FILE *);
   virtual int restart(char *, int &);
   virtual void length_restart_string(int &);

--- a/src/region.h
+++ b/src/region.h
@@ -85,9 +85,9 @@ class Region : protected Pointers {
   // called by other classes to check point versus region
 
   void prematch();
-  int match(double, double, double);
   int surface(double, double, double, double);
 
+  virtual int match(double, double, double);
   virtual void set_velocity();
   virtual void velocity_contact(double *, double *, int);
   virtual void write_restart(FILE *);

--- a/src/region.h
+++ b/src/region.h
@@ -84,10 +84,10 @@ class Region : protected Pointers {
 
   // called by other classes to check point versus region
 
-  void prematch();
-  int surface(double, double, double, double);
+  virtual void prematch();
+  virtual int surface(double, double, double, double);
 
-  int match(double, double, double);
+  virtual int match(double, double, double);
   virtual void set_velocity();
   virtual void velocity_contact(double *, double *, int);
   virtual void write_restart(FILE *);
@@ -110,6 +110,8 @@ class Region : protected Pointers {
   virtual void set_velocity_shape() {}
   virtual void velocity_contact_shape(double *, double *) {}
 
+  void inverse_transform(double &, double &, double &);
+
  protected:
   void add_contact(int, double *, double, double, double);
   void options(int, char **);
@@ -121,7 +123,6 @@ class Region : protected Pointers {
   int xvar, yvar, zvar, tvar;
   double axis[3];
 
-  void inverse_transform(double &, double &, double &);
   void rotate(double &, double &, double &, double);
 };
 

--- a/src/region.h
+++ b/src/region.h
@@ -87,7 +87,7 @@ class Region : protected Pointers {
   void prematch();
   int surface(double, double, double, double);
 
-  virtual int match(double, double, double);
+  int match(double, double, double);
   virtual void set_velocity();
   virtual void velocity_contact(double *, double *, int);
   virtual void write_restart(FILE *);

--- a/src/region_cylinder.cpp
+++ b/src/region_cylinder.cpp
@@ -519,7 +519,10 @@ int RegCylinder::surface_exterior(double *x, double cutoff)
           xp = x[0];
         }
         d2 = d2prev = dr2 + dx * dx;
-        if (r > radius) crad = 2.0 * radius;
+        if (r > radius) {
+          crad = 2.0 * radius;
+          varflag = 1;
+        }
       }
 
       // closest point on bottom cap
@@ -619,7 +622,10 @@ int RegCylinder::surface_exterior(double *x, double cutoff)
           yp = x[1];
         }
         d2 = d2prev = dr2 + dx * dx;
-        if (r > radius) crad = 2.0 * radius;
+        if (r > radius) {
+          crad = 2.0 * radius;
+          varflag = 1;
+        }
       }
 
       // closest point on bottom cap
@@ -719,7 +725,10 @@ int RegCylinder::surface_exterior(double *x, double cutoff)
           zp = x[2];
         }
         d2prev = dr2 + dx * dx;
-        if (r > radius) crad = 2.0 * radius;
+        if (r > radius) {
+          crad = 2.0 * radius;
+          varflag = 1;
+        }
       }
 
       // closest point on bottom cap

--- a/src/region_cylinder.cpp
+++ b/src/region_cylinder.cpp
@@ -482,11 +482,11 @@ int RegCylinder::surface_exterior(double *x, double cutoff)
     // do not add contact point if r >= cutoff
 
     d2prev = BIG;
+    if (r > radius) crad = 2.0 * radius;
     if (!openflag) {
       if (r > radius) {
         yp = c1 + del1 * radius / r;
         zp = c2 + del2 * radius / r;
-        crad = 2.0 * radius;
         varflag = 1;
       } else {
         yp = x[1];
@@ -581,11 +581,11 @@ int RegCylinder::surface_exterior(double *x, double cutoff)
     // do not add contact point if r >= cutoff
 
     d2prev = BIG;
+    if (r > radius) crad = 2.0 * radius;
     if (!openflag) {
       if (r > radius) {
         xp = c1 + del1 * radius / r;
         zp = c2 + del2 * radius / r;
-        crad = 2.0 * radius;
         varflag = 1;
       } else {
         xp = x[0];
@@ -680,11 +680,11 @@ int RegCylinder::surface_exterior(double *x, double cutoff)
     // do not add contact point if r >= cutoff
 
     d2prev = BIG;
+    if (r > radius) crad = 2.0 * radius;
     if (!openflag) {
       if (r > radius) {
         xp = c1 + del1 * radius / r;
         yp = c2 + del2 * radius / r;
-        crad = 2.0 * radius;
         varflag = 1;
       } else {
         xp = x[0];

--- a/src/region_cylinder.cpp
+++ b/src/region_cylinder.cpp
@@ -482,11 +482,11 @@ int RegCylinder::surface_exterior(double *x, double cutoff)
     // do not add contact point if r >= cutoff
 
     d2prev = BIG;
-    if (r > radius) crad = 2.0 * radius;
     if (!openflag) {
       if (r > radius) {
         yp = c1 + del1 * radius / r;
         zp = c2 + del2 * radius / r;
+        crad = 2.0 * radius;
         varflag = 1;
       } else {
         yp = x[1];
@@ -519,6 +519,7 @@ int RegCylinder::surface_exterior(double *x, double cutoff)
           xp = x[0];
         }
         d2 = d2prev = dr2 + dx * dx;
+        if (r > radius) crad = 2.0 * radius;
       }
 
       // closest point on bottom cap
@@ -581,11 +582,11 @@ int RegCylinder::surface_exterior(double *x, double cutoff)
     // do not add contact point if r >= cutoff
 
     d2prev = BIG;
-    if (r > radius) crad = 2.0 * radius;
     if (!openflag) {
       if (r > radius) {
         xp = c1 + del1 * radius / r;
         zp = c2 + del2 * radius / r;
+        crad = 2.0 * radius;
         varflag = 1;
       } else {
         xp = x[0];
@@ -618,6 +619,7 @@ int RegCylinder::surface_exterior(double *x, double cutoff)
           yp = x[1];
         }
         d2 = d2prev = dr2 + dx * dx;
+        if (r > radius) crad = 2.0 * radius;
       }
 
       // closest point on bottom cap
@@ -680,11 +682,11 @@ int RegCylinder::surface_exterior(double *x, double cutoff)
     // do not add contact point if r >= cutoff
 
     d2prev = BIG;
-    if (r > radius) crad = 2.0 * radius;
     if (!openflag) {
       if (r > radius) {
         xp = c1 + del1 * radius / r;
         yp = c2 + del2 * radius / r;
+        crad = 2.0 * radius;
         varflag = 1;
       } else {
         xp = x[0];
@@ -717,6 +719,7 @@ int RegCylinder::surface_exterior(double *x, double cutoff)
           zp = x[2];
         }
         d2prev = dr2 + dx * dx;
+        if (r > radius) crad = 2.0 * radius;
       }
 
       // closest point on bottom cap

--- a/src/region_intersect.cpp
+++ b/src/region_intersect.cpp
@@ -60,28 +60,28 @@ RegIntersect::RegIntersect(LAMMPS *lmp, int narg, char **arg) :
   }
 
   // make sure all subregions have the same motion
-  //   needed such that pretransform gives the same result (performed by union)
+  //   needed such that pretransform gives the same result (performed by intersect)
 
   if (moveflag) {
-    // copy 1st value if union motion not defined
+    // copy 1st value if intersect motion not defined
     if (moveflag0 == 0) {
-      strcpy(xstr, reglist[0]->xstr);
-      strcpy(ystr, reglist[0]->ystr);
-      strcpy(zstr, reglist[0]->zstr);
+      if (reglist[0]->xstr) xstr = utils::strdup(std::string (reglist[0]->xstr));
+      if (reglist[0]->ystr) ystr = utils::strdup(std::string (reglist[0]->ystr));
+      if (reglist[0]->zstr) zstr = utils::strdup(std::string (reglist[0]->zstr));
     }
     for (int ilist = 0; ilist < nregion; ilist++) {
-      if (strcmp(xstr, reglist[ilist]->xstr) == 0)
-        error->all(FLERR, "All regions in union must have the same move x variable");
-      if (strcmp(ystr, reglist[ilist]->ystr) == 0)
-        error->all(FLERR, "All regions in union must have the same move y variable");
-      if (strcmp(zstr, reglist[ilist]->zstr) == 0)
-        error->all(FLERR, "All regions in union must have the same move z variable");
+      if (xstr && reglist[ilist]->xstr && strcmp(xstr, reglist[ilist]->xstr) != 0)
+        error->all(FLERR, "All regions in intersect must have the same move x variable");
+      if (ystr && reglist[ilist]->ystr && strcmp(ystr, reglist[ilist]->ystr) != 0)
+        error->all(FLERR, "All regions in intersect must have the same move y variable");
+      if (zstr && reglist[ilist]->zstr && strcmp(zstr, reglist[ilist]->zstr) != 0)
+        error->all(FLERR, "All regions in intersect must have the same move z variable");
     }
   }
 
   if (rotateflag) {
-    // copy 1st value if union rotation not defined
-    if (moveflag0 == 0) {
+    // copy 1st value if intersect rotation not defined
+    if (rotateflag0 == 0) {
       point[0] = reglist[0]->point[0];
       point[1] = reglist[0]->point[1];
       point[2] = reglist[0]->point[2];
@@ -94,11 +94,11 @@ RegIntersect::RegIntersect(LAMMPS *lmp, int narg, char **arg) :
       if (point[0] != region->point[0] ||
           point[1] != region->point[1] ||
           point[2] != region->point[2])
-        error->all(FLERR, "All regions in union must have the same rotaton origin");
+        error->all(FLERR, "All regions in intersect must have the same rotaton origin");
       if (axis[0] != region->axis[0] ||
           axis[1] != region->axis[1] ||
           axis[2] != region->axis[2])
-        error->all(FLERR, "All regions in union must have the same rotaton axis");
+        error->all(FLERR, "All regions in intersect must have the same rotaton axis");
     }
 
     double len = sqrt(axis[0] * axis[0] + axis[1] * axis[1] + axis[2] * axis[2]);

--- a/src/region_intersect.cpp
+++ b/src/region_intersect.cpp
@@ -47,65 +47,13 @@ RegIntersect::RegIntersect(LAMMPS *lmp, int narg, char **arg) :
     nregion++;
   }
 
-
   // this region is variable shape or dynamic if any of sub-regions are
 
-  int moveflag0 = moveflag;
-  int rotateflag0 = rotateflag;
   for (int ilist = 0; ilist < nregion; ilist++) {
     if (reglist[ilist]->varshape) varshape = 1;
     if (reglist[ilist]->dynamic) dynamic = 1;
     if (reglist[ilist]->moveflag) moveflag = 1;
     if (reglist[ilist]->rotateflag) rotateflag = 1;
-  }
-
-  // make sure all subregions have the same motion
-  //   needed such that pretransform gives the same result (performed by intersect)
-
-  if (moveflag) {
-    // copy 1st value if intersect motion not defined
-    if (moveflag0 == 0) {
-      if (reglist[0]->xstr) xstr = utils::strdup(std::string (reglist[0]->xstr));
-      if (reglist[0]->ystr) ystr = utils::strdup(std::string (reglist[0]->ystr));
-      if (reglist[0]->zstr) zstr = utils::strdup(std::string (reglist[0]->zstr));
-    }
-    for (int ilist = 0; ilist < nregion; ilist++) {
-      if (xstr && reglist[ilist]->xstr && strcmp(xstr, reglist[ilist]->xstr) != 0)
-        error->all(FLERR, "All regions in intersect must have the same move x variable");
-      if (ystr && reglist[ilist]->ystr && strcmp(ystr, reglist[ilist]->ystr) != 0)
-        error->all(FLERR, "All regions in intersect must have the same move y variable");
-      if (zstr && reglist[ilist]->zstr && strcmp(zstr, reglist[ilist]->zstr) != 0)
-        error->all(FLERR, "All regions in intersect must have the same move z variable");
-    }
-  }
-
-  if (rotateflag) {
-    // copy 1st value if intersect rotation not defined
-    if (rotateflag0 == 0) {
-      point[0] = reglist[0]->point[0];
-      point[1] = reglist[0]->point[1];
-      point[2] = reglist[0]->point[2];
-      axis[0] = reglist[0]->axis[0];
-      axis[1] = reglist[0]->axis[1];
-      axis[2] = reglist[0]->axis[2];
-    }
-    for (int ilist = 0; ilist < nregion; ilist++) {
-      auto region = reglist[ilist];
-      if (point[0] != region->point[0] ||
-          point[1] != region->point[1] ||
-          point[2] != region->point[2])
-        error->all(FLERR, "All regions in intersect must have the same rotaton origin");
-      if (axis[0] != region->axis[0] ||
-          axis[1] != region->axis[1] ||
-          axis[2] != region->axis[2])
-        error->all(FLERR, "All regions in intersect must have the same rotaton axis");
-    }
-
-    double len = sqrt(axis[0] * axis[0] + axis[1] * axis[1] + axis[2] * axis[2]);
-    if (len == 0.0) error->all(FLERR, Error::NOPOINTER, "Region cannot have 0 length rotation vector");
-    runit[0] = axis[0] / len;
-    runit[1] = axis[1] / len;
-    runit[2] = axis[2] / len;
   }
 
   // extent of intersection of regions
@@ -188,6 +136,27 @@ void RegIntersect::init()
 }
 
 /* ----------------------------------------------------------------------
+   overwrite parent to call for subregions
+------------------------------------------------------------------------- */
+
+void RegIntersect::prematch()
+{
+  int ilist;
+  for (ilist = 0; ilist < nregion; ilist++)
+    reglist[ilist]->prematch();
+}
+
+/* ----------------------------------------------------------------------
+   overwrite parent to skip dynamic methods (may not be defined for union)
+     will be performed by subregion match calls from inside()
+------------------------------------------------------------------------- */
+
+int RegIntersect::match(double x, double y, double z)
+{
+  return !(inside(x, y, z) ^ interior);
+}
+
+/* ----------------------------------------------------------------------
    inside = 1 if x,y,z is match() with all sub-regions
    else inside = 0
 ------------------------------------------------------------------------- */
@@ -203,25 +172,57 @@ int RegIntersect::inside(double x, double y, double z)
 }
 
 /* ----------------------------------------------------------------------
+   overwrite parent to skip dynamic methods (may not be defined for union)
+     will be performed by surface interior/exterior calls separately
+     for each subregion
+------------------------------------------------------------------------- */
+
+int RegIntersect::surface(double x, double y, double z, double cutoff)
+{
+  int ncontact;
+  double xorig[3] = {x, y, z};
+
+  if (!openflag) {
+    if (interior)
+      ncontact = surface_interior(xorig, cutoff);
+    else
+      ncontact = surface_exterior(xorig, cutoff);
+  } else {
+    // one of surface_int/ext() will return 0
+    // so no need to worry about offset of contact indices
+    ncontact = surface_exterior(xorig, cutoff) + surface_interior(xorig, cutoff);
+  }
+
+  return ncontact;
+}
+
+/* ----------------------------------------------------------------------
    compute contacts with interior of intersection of sub-regions
    (1) compute contacts in each sub-region
    (2) only keep a contact if surface point is match() to all other regions
 ------------------------------------------------------------------------- */
 
-int RegIntersect::surface_interior(double *x, double cutoff)
+int RegIntersect::surface_interior(double *xorig, double cutoff)
 {
   int m, ilist, jlist, ncontacts;
   double xs, ys, zs;
+  double xnear[3];
 
   int n = 0;
   int walloffset = 0;
   for (ilist = 0; ilist < nregion; ilist++) {
     auto *region = reglist[ilist];
-    ncontacts = region->surface(x[0], x[1], x[2], cutoff);
+
+    // copy coordinates b/c values will change
+    xnear[0] = xorig[0];
+    xnear[1] = xorig[1];
+    xnear[2] = xorig[2];
+
+    ncontacts = region->surface(xnear[0], xnear[1], xnear[2], cutoff);
     for (m = 0; m < ncontacts; m++) {
-      xs = x[0] - region->contact[m].delx;
-      ys = x[1] - region->contact[m].dely;
-      zs = x[2] - region->contact[m].delz;
+      xs = xnear[0] - region->contact[m].delx;
+      ys = xnear[1] - region->contact[m].dely;
+      zs = xnear[2] - region->contact[m].delz;
       for (jlist = 0; jlist < nregion; jlist++) {
         if (jlist == ilist) continue;
         if (!reglist[jlist]->match(xs, ys, zs)) break;
@@ -239,6 +240,19 @@ int RegIntersect::surface_interior(double *x, double cutoff)
         n++;
       }
     }
+
+    if (region->rotateflag && ncontacts) {
+      for (int i = 0; i < ncontacts; i++) {
+        xs = xnear[0] - contact[i].delx;
+        ys = xnear[1] - contact[i].dely;
+        zs = xnear[2] - contact[i].delz;
+        region->forward_transform(xs, ys, zs);
+        contact[i].delx = xorig[0] - xs;
+        contact[i].dely = xorig[1] - ys;
+        contact[i].delz = xorig[2] - zs;
+      }
+    }
+
     // increment by cmax instead of tmax to ensure
     // possible wall IDs for sub-regions are non overlapping
     walloffset += region->cmax;
@@ -256,21 +270,28 @@ int RegIntersect::surface_interior(double *x, double cutoff)
    this is effectively same algorithm as surface_interior() for RegUnion
 ------------------------------------------------------------------------- */
 
-int RegIntersect::surface_exterior(double *x, double cutoff)
+int RegIntersect::surface_exterior(double *xorig, double cutoff)
 {
   int m, ilist, jlist, ncontacts;
   double xs, ys, zs;
+  double xnear[3];
 
   int n = 0;
   for (ilist = 0; ilist < nregion; ilist++) reglist[ilist]->interior ^= 1;
 
   for (ilist = 0; ilist < nregion; ilist++) {
     auto *region = reglist[ilist];
-    ncontacts = region->surface(x[0], x[1], x[2], cutoff);
+
+    // copy coordinates b/c values will change
+    xnear[0] = xorig[0];
+    xnear[1] = xorig[1];
+    xnear[2] = xorig[2];
+
+    ncontacts = region->surface(xnear[0], xnear[1], xnear[2], cutoff);
     for (m = 0; m < ncontacts; m++) {
-      xs = x[0] - region->contact[m].delx;
-      ys = x[1] - region->contact[m].dely;
-      zs = x[2] - region->contact[m].delz;
+      xs = xnear[0] - region->contact[m].delx;
+      ys = xnear[1] - region->contact[m].dely;
+      zs = xnear[2] - region->contact[m].delz;
       for (jlist = 0; jlist < nregion; jlist++) {
         if (jlist == ilist) continue;
         if (reglist[jlist]->match(xs, ys, zs)) break;
@@ -286,6 +307,18 @@ int RegIntersect::surface_exterior(double *x, double cutoff)
         contact_indx[n].ilist = ilist;
         contact_indx[n].ic = m;
         n++;
+      }
+    }
+
+    if (region->rotateflag && ncontacts) {
+      for (int i = 0; i < ncontacts; i++) {
+        xs = xnear[0] - contact[i].delx;
+        ys = xnear[1] - contact[i].dely;
+        zs = xnear[2] - contact[i].delz;
+        region->forward_transform(xs, ys, zs);
+        contact[i].delx = xorig[0] - xs;
+        contact[i].dely = xorig[1] - ys;
+        contact[i].delz = xorig[2] - zs;
       }
     }
   }

--- a/src/region_intersect.cpp
+++ b/src/region_intersect.cpp
@@ -242,7 +242,7 @@ int RegIntersect::surface_interior(double *xorig, double cutoff)
     }
 
     if (region->rotateflag && ncontacts) {
-      for (int i = 0; i < ncontacts; i++) {
+      for (int i = n - ncontacts; i < n; i++) {
         xs = xnear[0] - contact[i].delx;
         ys = xnear[1] - contact[i].dely;
         zs = xnear[2] - contact[i].delz;
@@ -311,7 +311,7 @@ int RegIntersect::surface_exterior(double *xorig, double cutoff)
     }
 
     if (region->rotateflag && ncontacts) {
-      for (int i = 0; i < ncontacts; i++) {
+      for (int i = n - ncontacts; i < n; i++) {
         xs = xnear[0] - contact[i].delx;
         ys = xnear[1] - contact[i].dely;
         zs = xnear[2] - contact[i].delz;

--- a/src/region_intersect.cpp
+++ b/src/region_intersect.cpp
@@ -23,7 +23,7 @@ using namespace LAMMPS_NS;
 /* ---------------------------------------------------------------------- */
 
 RegIntersect::RegIntersect(LAMMPS *lmp, int narg, char **arg) :
-    Region(lmp, narg, arg), idsub(nullptr)
+    Region(lmp, narg, arg), contact_indx(nullptr), idsub(nullptr)
 {
   nregion = 0;
 
@@ -47,11 +47,65 @@ RegIntersect::RegIntersect(LAMMPS *lmp, int narg, char **arg) :
     nregion++;
   }
 
+
   // this region is variable shape or dynamic if any of sub-regions are
 
+  int moveflag0 = moveflag;
+  int rotateflag0 = rotateflag;
   for (int ilist = 0; ilist < nregion; ilist++) {
     if (reglist[ilist]->varshape) varshape = 1;
     if (reglist[ilist]->dynamic) dynamic = 1;
+    if (reglist[ilist]->moveflag) moveflag = 1;
+    if (reglist[ilist]->rotateflag) rotateflag = 1;
+  }
+
+  // make sure all subregions have the same motion
+  //   needed such that pretransform gives the same result (performed by union)
+
+  if (moveflag) {
+    // copy 1st value if union motion not defined
+    if (moveflag0 == 0) {
+      strcpy(xstr, reglist[0]->xstr);
+      strcpy(ystr, reglist[0]->ystr);
+      strcpy(zstr, reglist[0]->zstr);
+    }
+    for (int ilist = 0; ilist < nregion; ilist++) {
+      if (strcmp(xstr, reglist[ilist]->xstr) == 0)
+        error->all(FLERR, "All regions in union must have the same move x variable");
+      if (strcmp(ystr, reglist[ilist]->ystr) == 0)
+        error->all(FLERR, "All regions in union must have the same move y variable");
+      if (strcmp(zstr, reglist[ilist]->zstr) == 0)
+        error->all(FLERR, "All regions in union must have the same move z variable");
+    }
+  }
+
+  if (rotateflag) {
+    // copy 1st value if union rotation not defined
+    if (moveflag0 == 0) {
+      point[0] = reglist[0]->point[0];
+      point[1] = reglist[0]->point[1];
+      point[2] = reglist[0]->point[2];
+      axis[0] = reglist[0]->axis[0];
+      axis[1] = reglist[0]->axis[1];
+      axis[2] = reglist[0]->axis[2];
+    }
+    for (int ilist = 0; ilist < nregion; ilist++) {
+      auto region = reglist[ilist];
+      if (point[0] != region->point[0] ||
+          point[1] != region->point[1] ||
+          point[2] != region->point[2])
+        error->all(FLERR, "All regions in union must have the same rotaton origin");
+      if (axis[0] != region->axis[0] ||
+          axis[1] != region->axis[1] ||
+          axis[2] != region->axis[2])
+        error->all(FLERR, "All regions in union must have the same rotaton axis");
+    }
+
+    double len = sqrt(axis[0] * axis[0] + axis[1] * axis[1] + axis[2] * axis[2]);
+    if (len == 0.0) error->all(FLERR, Error::NOPOINTER, "Region cannot have 0 length rotation vector");
+    runit[0] = axis[0] / len;
+    runit[1] = axis[1] / len;
+    runit[2] = axis[2] / len;
   }
 
   // extent of intersection of regions
@@ -91,6 +145,7 @@ RegIntersect::RegIntersect(LAMMPS *lmp, int narg, char **arg) :
   cmax = 0;
   for (int ilist = 0; ilist < nregion; ilist++) cmax += reglist[ilist]->cmax;
   contact = new Contact[cmax];
+  contact_indx = new ContactIndx[cmax];
 
   tmax = 0;
   for (int ilist = 0; ilist < nregion; ilist++) {
@@ -109,6 +164,7 @@ RegIntersect::~RegIntersect()
   delete[] idsub;
   delete[] reglist;
   delete[] contact;
+  delete[] contact_indx;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -178,6 +234,8 @@ int RegIntersect::surface_interior(double *x, double cutoff)
         contact[n].delz = region->contact[m].delz;
         contact[n].iwall = region->contact[m].iwall + walloffset;
         contact[n].varflag = region->contact[m].varflag;
+        contact_indx[n].ilist = ilist;
+        contact_indx[n].ic = m;
         n++;
       }
     }
@@ -225,6 +283,8 @@ int RegIntersect::surface_exterior(double *x, double cutoff)
         contact[n].delz = region->contact[m].delz;
         contact[n].iwall = ilist;
         contact[n].varflag = region->contact[m].varflag;
+        contact_indx[n].ilist = ilist;
+        contact_indx[n].ic = m;
         n++;
       }
     }
@@ -260,6 +320,16 @@ void RegIntersect::pretransform()
 void RegIntersect::set_velocity()
 {
   for (int ilist = 0; ilist < nregion; ilist++) reglist[ilist]->set_velocity();
+}
+
+/* ----------------------------------------------------------------------
+   call subregion method to compute velocity of wall for given contact
+------------------------------------------------------------------------- */
+
+void RegIntersect::velocity_contact(double *vwall, double *x, int ic)
+{
+  auto *region = reglist[contact_indx[ic].ilist];
+  region->velocity_contact(vwall, x, contact_indx[ic].ic);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/region_intersect.h
+++ b/src/region_intersect.h
@@ -30,10 +30,13 @@ class RegIntersect : public Region {
   ~RegIntersect() override;
   void init() override;
   int inside(double, double, double) override;
+  void prematch() override;
   int surface_interior(double *, double) override;
   int surface_exterior(double *, double) override;
   void shape_update() override;
   void pretransform() override;
+  int surface(double, double, double, double) override;
+  int match(double, double, double) override;
   void set_velocity() override;
   void velocity_contact(double *, double *, int) override;
   void length_restart_string(int &) override;

--- a/src/region_intersect.h
+++ b/src/region_intersect.h
@@ -35,6 +35,7 @@ class RegIntersect : public Region {
   void shape_update() override;
   void pretransform() override;
   void set_velocity() override;
+  void velocity_contact(double *, double *, int) override;
   void length_restart_string(int &) override;
   void write_restart(FILE *) override;
   int restart(char *, int &) override;
@@ -42,6 +43,12 @@ class RegIntersect : public Region {
 
  private:
   char **idsub;
+
+  struct ContactIndx {
+    int ilist;         // index of contact in list of regions
+    int ic;            // index in subregions list of contacts
+  };
+  ContactIndx *contact_indx;
 };
 
 }    // namespace LAMMPS_NS

--- a/src/region_union.cpp
+++ b/src/region_union.cpp
@@ -233,7 +233,7 @@ int RegUnion::surface_interior(double *xorig, double cutoff)
     }
 
     if (region->rotateflag && ncontacts) {
-      for (int i = 0; i < ncontacts; i++) {
+      for (int i = n - ncontacts; i < n; i++) {
         xs = xnear[0] - contact[i].delx;
         ys = xnear[1] - contact[i].dely;
         zs = xnear[2] - contact[i].delz;
@@ -302,7 +302,7 @@ int RegUnion::surface_exterior(double *xorig, double cutoff)
     }
 
     if (region->rotateflag && ncontacts) {
-      for (int i = 0; i < ncontacts; i++) {
+      for (int i = n - ncontacts; i < n; i++) {
         xs = xnear[0] - contact[i].delx;
         ys = xnear[1] - contact[i].dely;
         zs = xnear[2] - contact[i].delz;

--- a/src/region_union.cpp
+++ b/src/region_union.cpp
@@ -50,62 +50,11 @@ RegUnion::RegUnion(LAMMPS *lmp, int narg, char **arg) : Region(lmp, narg, arg), 
 
   // this region is variable shape or dynamic if any of sub-regions are
 
-  int moveflag0 = moveflag;
-  int rotateflag0 = rotateflag;
   for (int ilist = 0; ilist < nregion; ilist++) {
     if (reglist[ilist]->varshape) varshape = 1;
     if (reglist[ilist]->dynamic) dynamic = 1;
     if (reglist[ilist]->moveflag) moveflag = 1;
     if (reglist[ilist]->rotateflag) rotateflag = 1;
-  }
-
-  // make sure all subregions have the same motion
-  //   needed such that pretransform gives the same result (performed by union)
-
-  if (moveflag) {
-    // copy 1st value if union motion not defined
-    if (moveflag0 == 0) {
-      if (reglist[0]->xstr) xstr = utils::strdup(std::string (reglist[0]->xstr));
-      if (reglist[0]->ystr) ystr = utils::strdup(std::string (reglist[0]->ystr));
-      if (reglist[0]->zstr) zstr = utils::strdup(std::string (reglist[0]->zstr));
-    }
-    for (int ilist = 0; ilist < nregion; ilist++) {
-      if (xstr && reglist[ilist]->xstr && strcmp(xstr, reglist[ilist]->xstr) != 0)
-        error->all(FLERR, "All regions in union must have the same move x variable");
-      if (ystr && reglist[ilist]->ystr && strcmp(ystr, reglist[ilist]->ystr) != 0)
-        error->all(FLERR, "All regions in union must have the same move y variable");
-      if (zstr && reglist[ilist]->zstr && strcmp(zstr, reglist[ilist]->zstr) != 0)
-        error->all(FLERR, "All regions in union must have the same move z variable");
-    }
-  }
-
-  if (rotateflag) {
-    // copy 1st value if union rotation not defined
-    if (rotateflag0 == 0) {
-      point[0] = reglist[0]->point[0];
-      point[1] = reglist[0]->point[1];
-      point[2] = reglist[0]->point[2];
-      axis[0] = reglist[0]->axis[0];
-      axis[1] = reglist[0]->axis[1];
-      axis[2] = reglist[0]->axis[2];
-    }
-    for (int ilist = 0; ilist < nregion; ilist++) {
-      auto region = reglist[ilist];
-      if (point[0] != region->point[0] ||
-          point[1] != region->point[1] ||
-          point[2] != region->point[2])
-        error->all(FLERR, "All regions in union must have the same rotaton origin");
-      if (axis[0] != region->axis[0] ||
-          axis[1] != region->axis[1] ||
-          axis[2] != region->axis[2])
-        error->all(FLERR, "All regions in union must have the same rotaton axis");
-    }
-
-    double len = sqrt(axis[0] * axis[0] + axis[1] * axis[1] + axis[2] * axis[2]);
-    if (len == 0.0) error->all(FLERR, Error::NOPOINTER, "Region cannot have 0 length rotation vector");
-    runit[0] = axis[0] / len;
-    runit[1] = axis[1] / len;
-    runit[2] = axis[2] / len;
   }
 
   // extent of union of regions
@@ -178,6 +127,27 @@ void RegUnion::init()
 }
 
 /* ----------------------------------------------------------------------
+   overwrite parent to call for subregions
+------------------------------------------------------------------------- */
+
+void RegUnion::prematch()
+{
+  int ilist;
+  for (ilist = 0; ilist < nregion; ilist++)
+    reglist[ilist]->prematch();
+}
+
+/* ----------------------------------------------------------------------
+   overwrite parent to skip dynamic methods (may not be defined for union)
+     will be performed by subregion match calls from inside()
+------------------------------------------------------------------------- */
+
+int RegUnion::match(double x, double y, double z)
+{
+  return !(inside(x, y, z) ^ interior);
+}
+
+/* ----------------------------------------------------------------------
    inside = 1 if x,y,z is match() with any sub-region
    else inside = 0
 ------------------------------------------------------------------------- */
@@ -193,25 +163,57 @@ int RegUnion::inside(double x, double y, double z)
 }
 
 /* ----------------------------------------------------------------------
+   overwrite parent to skip dynamic methods (may not be defined for union)
+     will be performed by surface interior/exterior calls separately
+     for each subregion
+------------------------------------------------------------------------- */
+
+int RegUnion::surface(double x, double y, double z, double cutoff)
+{
+  int ncontact;
+  double xorig[3] = {x, y, z};
+
+  if (!openflag) {
+    if (interior)
+      ncontact = surface_interior(xorig, cutoff);
+    else
+      ncontact = surface_exterior(xorig, cutoff);
+  } else {
+    // one of surface_int/ext() will return 0
+    // so no need to worry about offset of contact indices
+    ncontact = surface_exterior(xorig, cutoff) + surface_interior(xorig, cutoff);
+  }
+
+  return ncontact;
+}
+
+/* ----------------------------------------------------------------------
    compute contacts with interior of union of sub-regions
    (1) compute contacts in each sub-region
    (2) only keep a contact if surface point is not match() to all other regions
 ------------------------------------------------------------------------- */
 
-int RegUnion::surface_interior(double *x, double cutoff)
+int RegUnion::surface_interior(double *xorig, double cutoff)
 {
   int m, ilist, jlist, ncontacts;
   double xs, ys, zs;
+  double xnear[3];
 
   int n = 0;
   int walloffset = 0;
   for (ilist = 0; ilist < nregion; ilist++) {
     auto *region = reglist[ilist];
-    ncontacts = region->surface(x[0], x[1], x[2], cutoff);
+
+    // copy coordinates b/c values will change
+    xnear[0] = xorig[0];
+    xnear[1] = xorig[1];
+    xnear[2] = xorig[2];
+
+    ncontacts = region->surface(xnear[0], xnear[1], xnear[2], cutoff);
     for (m = 0; m < ncontacts; m++) {
-      xs = x[0] - region->contact[m].delx;
-      ys = x[1] - region->contact[m].dely;
-      zs = x[2] - region->contact[m].delz;
+      xs = xnear[0] - region->contact[m].delx;
+      ys = xnear[1] - region->contact[m].dely;
+      zs = xnear[2] - region->contact[m].delz;
       for (jlist = 0; jlist < nregion; jlist++) {
         if (jlist == ilist) continue;
         if (reglist[jlist]->match(xs, ys, zs) && !reglist[jlist]->openflag) break;
@@ -229,6 +231,19 @@ int RegUnion::surface_interior(double *x, double cutoff)
         n++;
       }
     }
+
+    if (region->rotateflag && ncontacts) {
+      for (int i = 0; i < ncontacts; i++) {
+        xs = xnear[0] - contact[i].delx;
+        ys = xnear[1] - contact[i].dely;
+        zs = xnear[2] - contact[i].delz;
+        region->forward_transform(xs, ys, zs);
+        contact[i].delx = xorig[0] - xs;
+        contact[i].dely = xorig[1] - ys;
+        contact[i].delz = xorig[2] - zs;
+      }
+    }
+
     // increment by cmax instead of tmax to ensure
     // possible wall IDs for sub-regions are non overlapping
     walloffset += region->cmax;
@@ -246,21 +261,28 @@ int RegUnion::surface_interior(double *x, double cutoff)
    this is effectively same algorithm as surface_interior() for RegIntersect
 ------------------------------------------------------------------------- */
 
-int RegUnion::surface_exterior(double *x, double cutoff)
+int RegUnion::surface_exterior(double *xorig, double cutoff)
 {
   int m, ilist, jlist, ncontacts;
   double xs, ys, zs;
+  double xnear[3];
 
   int n = 0;
   for (ilist = 0; ilist < nregion; ilist++) reglist[ilist]->interior ^= 1;
 
   for (ilist = 0; ilist < nregion; ilist++) {
     auto *region = reglist[ilist];
-    ncontacts = region->surface(x[0], x[1], x[2], cutoff);
+
+    // copy coordinates b/c values will change
+    xnear[0] = xorig[0];
+    xnear[1] = xorig[1];
+    xnear[2] = xorig[2];
+
+    ncontacts = region->surface(xnear[0], xnear[1], xnear[2], cutoff);
     for (m = 0; m < ncontacts; m++) {
-      xs = x[0] - region->contact[m].delx;
-      ys = x[1] - region->contact[m].dely;
-      zs = x[2] - region->contact[m].delz;
+      xs = xnear[0] - region->contact[m].delx;
+      ys = xnear[1] - region->contact[m].dely;
+      zs = xnear[2] - region->contact[m].delz;
       for (jlist = 0; jlist < nregion; jlist++) {
         if (jlist == ilist) continue;
         if (reglist[jlist]->match(xs, ys, zs)) break;
@@ -276,6 +298,18 @@ int RegUnion::surface_exterior(double *x, double cutoff)
         contact_indx[n].ilist = ilist;
         contact_indx[n].ic = m;
         n++;
+      }
+    }
+
+    if (region->rotateflag && ncontacts) {
+      for (int i = 0; i < ncontacts; i++) {
+        xs = xnear[0] - contact[i].delx;
+        ys = xnear[1] - contact[i].dely;
+        zs = xnear[2] - contact[i].delz;
+        region->forward_transform(xs, ys, zs);
+        contact[i].delx = xorig[0] - xs;
+        contact[i].dely = xorig[1] - ys;
+        contact[i].delz = xorig[2] - zs;
       }
     }
   }

--- a/src/region_union.cpp
+++ b/src/region_union.cpp
@@ -24,7 +24,7 @@ static constexpr double BIG = 1.0e20;
 
 /* ---------------------------------------------------------------------- */
 
-RegUnion::RegUnion(LAMMPS *lmp, int narg, char **arg) : Region(lmp, narg, arg), idsub(nullptr)
+RegUnion::RegUnion(LAMMPS *lmp, int narg, char **arg) : Region(lmp, narg, arg), contact_indx(nullptr), idsub(nullptr)
 {
   nregion = 0;
 
@@ -85,6 +85,7 @@ RegUnion::RegUnion(LAMMPS *lmp, int narg, char **arg) : Region(lmp, narg, arg), 
   cmax = 0;
   for (int ilist = 0; ilist < nregion; ilist++) cmax += reglist[ilist]->cmax;
   contact = new Contact[cmax];
+  contact_indx = new ContactIndx[cmax];
 
   tmax = 0;
   for (int ilist = 0; ilist < nregion; ilist++) {
@@ -103,6 +104,7 @@ RegUnion::~RegUnion()
   delete[] idsub;
   delete[] reglist;
   delete[] contact;
+  delete[] contact_indx;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -171,6 +173,8 @@ int RegUnion::surface_interior(double *x, double cutoff)
         contact[n].delz = region->contact[m].delz;
         contact[n].iwall = region->contact[m].iwall + walloffset;
         contact[n].varflag = region->contact[m].varflag;
+        contact_indx[n].ilist = ilist;
+        contact_indx[n].ic = m;
         n++;
       }
     }
@@ -218,6 +222,8 @@ int RegUnion::surface_exterior(double *x, double cutoff)
         contact[n].delz = region->contact[m].delz;
         contact[n].iwall = ilist;
         contact[n].varflag = region->contact[m].varflag;
+        contact_indx[n].ilist = ilist;
+        contact_indx[n].ic = m;
         n++;
       }
     }
@@ -253,6 +259,16 @@ void RegUnion::pretransform()
 void RegUnion::set_velocity()
 {
   for (int ilist = 0; ilist < nregion; ilist++) reglist[ilist]->set_velocity();
+}
+
+/* ----------------------------------------------------------------------
+   call subregion method to compute velocity of wall for given contact
+------------------------------------------------------------------------- */
+
+void RegUnion::velocity_contact(double *vwall, double *x, int ic)
+{
+  auto *region = reglist[contact_indx[ic].ilist];
+  region->velocity_contact(vwall, x, contact_indx[ic].ic);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/region_union.cpp
+++ b/src/region_union.cpp
@@ -65,23 +65,23 @@ RegUnion::RegUnion(LAMMPS *lmp, int narg, char **arg) : Region(lmp, narg, arg), 
   if (moveflag) {
     // copy 1st value if union motion not defined
     if (moveflag0 == 0) {
-      strcpy(xstr, reglist[0]->xstr);
-      strcpy(ystr, reglist[0]->ystr);
-      strcpy(zstr, reglist[0]->zstr);
+      if (reglist[0]->xstr) xstr = utils::strdup(std::string (reglist[0]->xstr));
+      if (reglist[0]->ystr) ystr = utils::strdup(std::string (reglist[0]->ystr));
+      if (reglist[0]->zstr) zstr = utils::strdup(std::string (reglist[0]->zstr));
     }
     for (int ilist = 0; ilist < nregion; ilist++) {
-      if (strcmp(xstr, reglist[ilist]->xstr) == 0)
+      if (xstr && reglist[ilist]->xstr && strcmp(xstr, reglist[ilist]->xstr) != 0)
         error->all(FLERR, "All regions in union must have the same move x variable");
-      if (strcmp(ystr, reglist[ilist]->ystr) == 0)
+      if (ystr && reglist[ilist]->ystr && strcmp(ystr, reglist[ilist]->ystr) != 0)
         error->all(FLERR, "All regions in union must have the same move y variable");
-      if (strcmp(zstr, reglist[ilist]->zstr) == 0)
+      if (zstr && reglist[ilist]->zstr && strcmp(zstr, reglist[ilist]->zstr) != 0)
         error->all(FLERR, "All regions in union must have the same move z variable");
     }
   }
 
   if (rotateflag) {
     // copy 1st value if union rotation not defined
-    if (moveflag0 == 0) {
+    if (rotateflag0 == 0) {
       point[0] = reglist[0]->point[0];
       point[1] = reglist[0]->point[1];
       point[2] = reglist[0]->point[2];

--- a/src/region_union.cpp
+++ b/src/region_union.cpp
@@ -50,11 +50,62 @@ RegUnion::RegUnion(LAMMPS *lmp, int narg, char **arg) : Region(lmp, narg, arg), 
 
   // this region is variable shape or dynamic if any of sub-regions are
 
+  int moveflag0 = moveflag;
+  int rotateflag0 = rotateflag;
   for (int ilist = 0; ilist < nregion; ilist++) {
     if (reglist[ilist]->varshape) varshape = 1;
     if (reglist[ilist]->dynamic) dynamic = 1;
     if (reglist[ilist]->moveflag) moveflag = 1;
     if (reglist[ilist]->rotateflag) rotateflag = 1;
+  }
+
+  // make sure all subregions have the same motion
+  //   needed such that pretransform gives the same result (performed by union)
+
+  if (moveflag) {
+    // copy 1st value if union motion not defined
+    if (moveflag0 == 0) {
+      strcpy(xstr, reglist[0]->xstr);
+      strcpy(ystr, reglist[0]->ystr);
+      strcpy(zstr, reglist[0]->zstr);
+    }
+    for (int ilist = 0; ilist < nregion; ilist++) {
+      if (strcmp(xstr, reglist[ilist]->xstr) == 0)
+        error->all(FLERR, "All regions in union must have the same move x variable");
+      if (strcmp(ystr, reglist[ilist]->ystr) == 0)
+        error->all(FLERR, "All regions in union must have the same move y variable");
+      if (strcmp(zstr, reglist[ilist]->zstr) == 0)
+        error->all(FLERR, "All regions in union must have the same move z variable");
+    }
+  }
+
+  if (rotateflag) {
+    // copy 1st value if union rotation not defined
+    if (moveflag0 == 0) {
+      point[0] = reglist[0]->point[0];
+      point[1] = reglist[0]->point[1];
+      point[2] = reglist[0]->point[2];
+      axis[0] = reglist[0]->axis[0];
+      axis[1] = reglist[0]->axis[1];
+      axis[2] = reglist[0]->axis[2];
+    }
+    for (int ilist = 0; ilist < nregion; ilist++) {
+      auto region = reglist[ilist];
+      if (point[0] != region->point[0] ||
+          point[1] != region->point[1] ||
+          point[2] != region->point[2])
+        error->all(FLERR, "All regions in union must have the same rotaton origin");
+      if (axis[0] != region->axis[0] ||
+          axis[1] != region->axis[1] ||
+          axis[2] != region->axis[2])
+        error->all(FLERR, "All regions in union must have the same rotaton axis");
+    }
+
+    double len = sqrt(axis[0] * axis[0] + axis[1] * axis[1] + axis[2] * axis[2]);
+    if (len == 0.0) error->all(FLERR, Error::NOPOINTER, "Region cannot have 0 length rotation vector");
+    runit[0] = axis[0] / len;
+    runit[1] = axis[1] / len;
+    runit[2] = axis[2] / len;
   }
 
   // extent of union of regions

--- a/src/region_union.h
+++ b/src/region_union.h
@@ -30,10 +30,13 @@ class RegUnion : public Region {
   ~RegUnion() override;
   void init() override;
   int inside(double, double, double) override;
+  void prematch() override;
   int surface_interior(double *, double) override;
   int surface_exterior(double *, double) override;
   void shape_update() override;
   void pretransform() override;
+  int surface(double, double, double, double) override;
+  int match(double, double, double) override;
   void set_velocity() override;
   void velocity_contact(double *, double *, int) override;
   void length_restart_string(int &) override;

--- a/src/region_union.h
+++ b/src/region_union.h
@@ -35,6 +35,7 @@ class RegUnion : public Region {
   void shape_update() override;
   void pretransform() override;
   void set_velocity() override;
+  void velocity_contact(double *, double *, int) override;
   void length_restart_string(int &) override;
   void write_restart(FILE *) override;
   int restart(char *, int &) override;
@@ -42,6 +43,12 @@ class RegUnion : public Region {
 
  private:
   char **idsub;
+
+  struct ContactIndx {
+    int ilist;         // index of contact in list of regions
+    int ic;            // index in subregions list of contacts
+  };
+  ContactIndx *contact_indx;
 };
 
 }    // namespace LAMMPS_NS


### PR DESCRIPTION
**Summary**

In dynamic unions/intersections of regions, there are several bugs due to the fact that relevant displacement/rotation variables were either never defined (*point*, *axis*) or are defaulted to zero (*dx*, *dy*, *dz*). This produces memory/physical errors when calling Region::inverse_transform() (through match() or surface()) and Region::velocity_contact(). 

This was patched by requiring all subregions have the same dynamic settings and copying data to RegionUnion. This restriction is noted in the documentation. This fixes the inverse_transform() issues but not velocity_contact() which is a bit more complicated. Thus, I just passed that call to the appropriate subregion.

**Alternatively** (!!!!!!!!!!!), the match() and surface() methods could also be passed to the appropriate subregion and region union/intersect don't need to worry about what the dynamic settings are. Can do this if preferred.

Secondly, the contact radius for the cylindrical region style was only defined for fully closed regions. Definitions were added to open regions. 

**Author(s)**

Joel Clemmer (SNL)
Gabriel Alkuino (Syracuse) 

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Backward Compatibility**

Using different dynamic settings for subregions of union/intersect will now error. However, if anyone was doing this, chances are results were just bogus. 