### PR TITLE
skip molecule tests when required packages are not built

### DIFF
--- a/unittest/formats/test_molecule_file.cpp
+++ b/unittest/formats/test_molecule_file.cpp
@@ -537,6 +537,7 @@ TEST_F(MoleculeFileTest, twomols)
 
 TEST_F(MoleculeFileTest, tenmols)
 {
+    if (!Info::has_package("MOLECULE")) GTEST_SKIP();
     BEGIN_CAPTURE_OUTPUT();
     run_mol_cmd(test_name, "",
                 "Comment\n10 atoms\n\n"
@@ -787,6 +788,7 @@ TEST_F(MoleculeFileTest, auto_invalidopt)
 
 TEST_F(MoleculeFileTest, auto_angle_dihedral)
 {
+    if (!info->has_style("atom", "full")) GTEST_SKIP();
     command("atom_style full");
     command("region box block 0 2 0 2 0 2");
     command("create_box 4 box bond/types 1 angle/types 1 dihedral/types 1 "
@@ -815,6 +817,7 @@ TEST_F(MoleculeFileTest, auto_angle_dihedral)
 
 TEST_F(MoleculeFileTest, auto_angle_improper)
 {
+    if (!info->has_style("atom", "full")) GTEST_SKIP();
     command("atom_style full");
     command("region box block 0 2 0 2 0 2");
     command("create_box 4 box bond/types 1 angle/types 1 improper/types 1 "


### PR DESCRIPTION
**Summary**

Some tests in `MoleculeFileTests` require features that aren't enabled by default at build time. This patch adds checking if those features were enabled.

**Related Issue(s)**

n/a

**Author(s)**

Vedran Miletić, Max Planck Computing and Data Facility

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Backward Compatibility**

n/a

**Implementation Notes**

I ran the changed tests before and after.

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

n/a