### PR TITLE
Add R2SCAN-D3 pair dispersion implementation

### DIFF
--- a/doc/src/pair_dispersion_d3.rst
+++ b/doc/src/pair_dispersion_d3.rst
@@ -85,7 +85,7 @@ and depend on the selected damping function.
 | | bj             | | o-lyp, pbesol, bpbe, opbe, ssb, revssb, otpss, b3pw91, bh-lyp, revpbe0,      |
 | |                | | tpssh, mpw1b95, pwb6k, b1b95, bmk, cam-b3lyp, lc-wpbe, b2gp-plyp, ptpss,     |
 | |                | | pwpb95, hf/mixed, hf/sv, hf/minis, b3lyp/6-31gd, hcth120, pw1pw, pwgga,      |
-| |                | | hsesol, hf3c, hf3cv, pbeh3c, pbeh-3c, mn15                                   |
+| |                | | hsesol, hf3c, hf3cv, pbeh3c, pbeh-3c, mn15, r2scan                           |
 +------------------+--------------------------------------------------------------------------------+
 | bjm              |  b2-plyp, b3-lyp, b97-d, b-lyp, b-p, pbe, pbe0, lc-wpbe                        |
 +------------------+--------------------------------------------------------------------------------+

--- a/src/EXTRA-PAIR/pair_dispersion_d3.cpp
+++ b/src/EXTRA-PAIR/pair_dispersion_d3.cpp
@@ -1061,7 +1061,7 @@ void PairDispersionD3::set_funcpar(std::string &functional_name)
           {"hf/mixed", 41}, {"hf/sv", 42},       {"hf/minis", 43}, {"b3-lyp/6-31gd", 44},
           {"hcth120", 45},  {"pw1pw", 46},       {"pwgga", 47},    {"hsesol", 48},
           {"hf3c", 49},     {"hf3cv", 50},       {"pbeh3c", 51},   {"pbeh-3c", 52},
-          {"mn15", 53}};
+          {"mn15", 53},     {"r2scan", 54}};
 
       int functionalCode = functionalMap[functional_name];
       switch (functionalCode) {
@@ -1344,6 +1344,11 @@ void PairDispersionD3::set_funcpar(std::string &functional_name)
           a1 = 2.0971;
           s8 = 0.7862;
           a2 = 7.5923;
+          break;
+	case 54:
+	  a1 = 0.4948;
+	  s8 = 0.7898;
+	  a2 = 5.7308;
           break;
         default:
           error->all(FLERR, Error::NOLASTLINE,

--- a/src/EXTRA-PAIR/pair_dispersion_d3.cpp
+++ b/src/EXTRA-PAIR/pair_dispersion_d3.cpp
@@ -1345,10 +1345,10 @@ void PairDispersionD3::set_funcpar(std::string &functional_name)
           s8 = 0.7862;
           a2 = 7.5923;
           break;
-	case 54:
-	  a1 = 0.4948;
-	  s8 = 0.7898;
-	  a2 = 5.7308;
+        case 54:
+          a1 = 0.4948;
+          s8 = 0.7898;
+          a2 = 5.7308;
           break;
         default:
           error->all(FLERR, Error::NOLASTLINE,


### PR DESCRIPTION
**Summary**
Add support for the r2scan functional with D3 dispersion correction in the pair_dispersion_d3 implementation.

**Changes**
Documentation: Updated the supported functionals table to include r2scan with the bj damping function
Implementation: Added r2scan functional mapping and its corresponding D3 parameters
Functional code: 54
D3 damping parameters: a1=0.4948, s8=0.7898, a2=5.7308 [1]

**Details**
This change enables users to perform molecular dynamics simulations with the r2scan meta-GGA mlips coupled with the D3 dispersion correction scheme. The D3 parameters for r2scan follow the official recommendations and are compatible with the existing D3 damping framework (bj damping).

**References**
[1] Sebastian Ehlert, Uwe Huniar, Jinliang Ning, James W. Furness, Jianwei Sun, Aaron D. Kaplan, John P. Perdew, Jan Gerit Brandenburg; r2SCAN-D4: Dispersion corrected meta-generalized gradient approximation for general chemical applications. J. Chem. Phys. 14 February 2021; 154 (6): 061101. https://doi.org/10.1063/5.0041008

