### PR TITLE
Migrate Modify::find_fix/find_compute call sites to get_*_by_id

### DIFF
--- a/src/DIFFRACTION/fix_saed_vtk.cpp
+++ b/src/DIFFRACTION/fix_saed_vtk.cpp
@@ -62,12 +62,12 @@ FixSAEDVTK::FixSAEDVTK(LAMMPS *lmp, int narg, char **arg) :
     error->all(FLERR,"Illegal fix saed/vtk command");
 
   ids = argi.copy_name();
-  int icompute = modify->find_compute(ids);
-  if (icompute < 0)
+  auto *icompute = modify->get_compute_by_id(ids);
+  if (!icompute)
     error->all(FLERR,"Compute ID for fix saed/vtk does not exist");
 
   // Check that specified compute is for SAED
-  compute_saed = dynamic_cast<ComputeSAED *>(modify->compute[icompute]);
+  compute_saed = dynamic_cast<ComputeSAED *>(icompute);
   if (strcmp(compute_saed->style,"saed") != 0)
     error->all(FLERR,"Fix saed/vtk has invalid compute assigned");
 
@@ -272,8 +272,7 @@ void FixSAEDVTK::init()
   // set current indices for all computes,fixes,variables
 
 
-  int icompute = modify->find_compute(ids);
-  if (icompute < 0)
+  if (!modify->get_compute_by_id(ids))
     error->all(FLERR,"Compute ID for fix saed/vtk does not exist");
 
   // need to reset nvalid if nvalid < ntimestep b/c minimize was performed
@@ -309,8 +308,8 @@ void FixSAEDVTK::end_of_step()
 void FixSAEDVTK::invoke_vector(bigint ntimestep)
 {
   // zero if first step
-  int icompute = modify->find_compute(ids);
-  if (icompute < 0)
+  Compute *compute = modify->get_compute_by_id(ids);
+  if (!compute)
     error->all(FLERR,"Compute ID for fix saed/vtk does not exist");
 
   if (irepeat == 0)
@@ -323,8 +322,6 @@ void FixSAEDVTK::invoke_vector(bigint ntimestep)
   modify->clearstep_compute();
 
   // invoke compute if not previously invoked
-
-  Compute *compute = modify->compute[icompute];
 
   if (!(compute->invoked_flag & Compute::INVOKED_VECTOR)) {
     compute->compute_vector();

--- a/src/DIFFRACTION/fix_saed_vtk.cpp
+++ b/src/DIFFRACTION/fix_saed_vtk.cpp
@@ -63,13 +63,10 @@ FixSAEDVTK::FixSAEDVTK(LAMMPS *lmp, int narg, char **arg) :
 
   ids = argi.copy_name();
   auto *icompute = modify->get_compute_by_id(ids);
-  if (!icompute)
-    error->all(FLERR,"Compute ID for fix saed/vtk does not exist");
-
-  // Check that specified compute is for SAED
   compute_saed = dynamic_cast<ComputeSAED *>(icompute);
-  if (strcmp(compute_saed->style,"saed") != 0)
-    error->all(FLERR,"Fix saed/vtk has invalid compute assigned");
+  if (!compute_saed)
+    error->all(FLERR, 6, "Compute ID {} for fix saed/vtk does not exist or is of "
+               "incorrect style", ids);
 
   // Gather variables from specified compute_saed
   double *saed_var = compute_saed->saed_var;

--- a/src/DRUDE/fix_langevin_drude.cpp
+++ b/src/DRUDE/fix_langevin_drude.cpp
@@ -182,10 +182,9 @@ int FixLangevinDrude::modify_param(int narg, char **arg)
     delete [] id_temp;
     id_temp = utils::strdup(arg[1]);
 
-    int icompute = modify->find_compute(id_temp);
-    if (icompute < 0)
+    temperature = modify->get_compute_by_id(id_temp);
+    if (!temperature)
       error->all(FLERR,"Could not find fix_modify temperature ID");
-    temperature = modify->compute[icompute];
 
     if (temperature->tempflag == 0)
       error->all(FLERR,

--- a/src/EFF/fix_temp_rescale_eff.cpp
+++ b/src/EFF/fix_temp_rescale_eff.cpp
@@ -170,9 +170,8 @@ int FixTempRescaleEff::modify_param(int narg, char **arg)
     delete [] id_temp;
     id_temp = utils::strdup(arg[1]);
 
-    int icompute = modify->find_compute(id_temp);
-    if (icompute < 0) error->all(FLERR,"Could not find fix_modify temperature ID");
-    temperature = modify->compute[icompute];
+    temperature = modify->get_compute_by_id(id_temp);
+    if (!temperature) error->all(FLERR,"Could not find fix_modify temperature ID");
 
     if (temperature->tempflag == 0)
       error->all(FLERR,"Fix_modify temperature ID does not compute temperature");

--- a/src/EXTRA-COMPUTE/compute_gyration_shape.cpp
+++ b/src/EXTRA-COMPUTE/compute_gyration_shape.cpp
@@ -62,13 +62,10 @@ ComputeGyrationShape::~ComputeGyrationShape()
 void ComputeGyrationShape::init()
 {
   // check that the compute gyration command exist
-  int icompute = modify->find_compute(id_gyration);
-  if (icompute < 0)
+  c_gyration = modify->get_compute_by_id(id_gyration);
+  if (!c_gyration)
     error->all(FLERR,"Compute gyration ID does not exist for "
                "compute gyration/shape");
-
-  // check the id_gyration corresponds really to a compute gyration command
-  c_gyration = (Compute *) modify->compute[icompute];
   if (strcmp(c_gyration->style,"gyration") != 0)
     error->all(FLERR,"Compute gyration compute ID does not point to "
                "gyration compute for compute gyration/shape");

--- a/src/EXTRA-FIX/fix_momentum_chunk.cpp
+++ b/src/EXTRA-FIX/fix_momentum_chunk.cpp
@@ -45,8 +45,7 @@ FixMomentumChunk::FixMomentumChunk(LAMMPS *lmp, int narg, char **arg) :
   if (nevery <= 0) error->all(FLERR,"Illegal fix momentum/chunk command");
 
   id_chunk = arg[4];
-  int icompute = modify->find_compute(id_chunk);
-  if (icompute < 0)
+  if (!modify->get_compute_by_id(id_chunk))
     error->all(FLERR,"Chunk/atom compute does not exist for fix momentum/chunk");
 
   id_com.clear();
@@ -107,38 +106,32 @@ void FixMomentumChunk::init()
 {
   // current indices for idchunk and idcom
 
-  int icompute = modify->find_compute(id_chunk);
-  if (icompute < 0)
+  auto *ccompute = modify->get_compute_by_id(id_chunk);
+  if (!ccompute)
     error->all(FLERR,"Chunk/atom compute does not exist for fix momentum/chunk");
-  cchunk = dynamic_cast<ComputeChunkAtom *>(modify->compute[icompute]);
+  cchunk = dynamic_cast<ComputeChunkAtom *>(ccompute);
   if (strcmp(cchunk->style,"chunk/atom") != 0)
     error->all(FLERR,"Fix momentum/chunk does not use chunk/atom compute");
 
   // create computes dependent on chunks
 
   id_com = id + id_chunk + "_com";
-  icompute = modify->find_compute(id_com);
-  if (icompute >= 0) modify->delete_compute(id_com);
+  if (modify->get_compute_by_id(id_com)) modify->delete_compute(id_com);
   auto cmd = fmt::format("{} {} com/chunk {}",id_com,group->names[igroup],id_chunk);
   modify->add_compute(cmd);
-  icompute = modify->find_compute(id_com);
-  ccom = dynamic_cast<ComputeCOMChunk *>(modify->compute[icompute]);
+  ccom = dynamic_cast<ComputeCOMChunk *>(modify->get_compute_by_id(id_com));
 
   id_vcm = id + id_chunk + "_vcm";
-  icompute = modify->find_compute(id_vcm);
-  if (icompute >= 0) modify->delete_compute(id_vcm);
+  if (modify->get_compute_by_id(id_vcm)) modify->delete_compute(id_vcm);
   cmd = fmt::format("{} {} vcm/chunk {}",id_vcm,group->names[igroup],id_chunk);
   modify->add_compute(cmd);
-  icompute = modify->find_compute(id_vcm);
-  cvcm = modify->compute[icompute];
+  cvcm = modify->get_compute_by_id(id_vcm);
 
   id_omega = id + id_chunk + "_omega";
-  icompute = modify->find_compute(id_omega);
-  if (icompute >= 0) modify->delete_compute(id_omega);
+  if (modify->get_compute_by_id(id_omega)) modify->delete_compute(id_omega);
   cmd = fmt::format("{} {} omega/chunk {}",id_omega,group->names[igroup],id_chunk);
   modify->add_compute(cmd);
-  icompute = modify->find_compute(id_omega);
-  comega = modify->compute[icompute];
+  comega = modify->get_compute_by_id(id_omega);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/GPU/gpu_extra.h
+++ b/src/GPU/gpu_extra.h
@@ -106,8 +106,7 @@ inline void check_flag(int error_flag, Error *error, MPI_Comm &world)
 
 inline void gpu_ready(LAMMPS_NS::Modify *modify, LAMMPS_NS::Error *error)
 {
-  int ifix = modify->find_fix("package_gpu");
-  if (ifix < 0)
+  if (!modify->get_fix_by_id("package_gpu"))
     error->all(FLERR, Error::NOLASTLINE, "The package gpu command is required for gpu styles");
 }
 }    // namespace GPU_EXTRA

--- a/src/MANIFOLD/fix_nvt_manifold_rattle.cpp
+++ b/src/MANIFOLD/fix_nvt_manifold_rattle.cpp
@@ -133,8 +133,7 @@ FixNVTManifoldRattle::FixNVTManifoldRattle(LAMMPS *lmp, int narg, char **arg,
 
   id_temp = utils::strdup(std::string(id) + "_temp");
   modify->add_compute(fmt::format("{} {} temp",id_temp,group->names[igroup]));
-  int icompute = modify->find_compute(id_temp);
-  temperature = modify->compute[icompute];
+  temperature = modify->get_compute_by_id(id_temp);
   if (temperature->tempbias) which = BIAS;
   else                        which = NOBIAS;
 

--- a/src/MC/fix_bond_swap.cpp
+++ b/src/MC/fix_bond_swap.cpp
@@ -698,10 +698,9 @@ int FixBondSwap::modify_param(int narg, char **arg)
     delete[] id_temp;
     id_temp = utils::strdup(arg[1]);
 
-    int icompute = modify->find_compute(id_temp);
-    if (icompute < 0)
+    temperature = modify->get_compute_by_id(id_temp);
+    if (!temperature)
       error->all(FLERR,"Could not find fix_modify temperature ID");
-    temperature = modify->compute[icompute];
 
     if (temperature->tempflag == 0)
       error->all(FLERR,"Fix_modify temperature ID does not "

--- a/src/MC/fix_charge_regulation.cpp
+++ b/src/MC/fix_charge_regulation.cpp
@@ -202,8 +202,7 @@ void FixChargeRegulation::init() {
     error->all(FLERR, Error::NOLASTLINE, "Fix {} is not compatible with /intel pair styles", style);
 
   triclinic = domain->triclinic;
-  int ipe = modify->find_compute("thermo_pe");
-  c_pe = modify->compute[ipe];
+  c_pe = modify->get_compute_by_id("thermo_pe");
 
   if (pHstr) {
     pHvar = input->variable->find(pHstr);

--- a/src/MC/fix_gcmc.cpp
+++ b/src/MC/fix_gcmc.cpp
@@ -546,7 +546,7 @@ void FixGCMC::init()
     }
   }
 
-  if (full_flag) c_pe = modify->compute[modify->find_compute("thermo_pe")];
+  if (full_flag) c_pe = modify->get_compute_by_id("thermo_pe");
 
   int *type = atom->type;
 

--- a/src/MC/fix_mol_swap.cpp
+++ b/src/MC/fix_mol_swap.cpp
@@ -443,13 +443,10 @@ double FixMolSwap::energy_full()
   }
 
   if (force->kspace) force->kspace->compute(eflag,vflag);
-
   if (modify->n_post_force_any) modify->post_force(vflag);
 
   update->eflag_global = update->ntimestep;
-  double total_energy = c_pe->compute_scalar();
-
-  return total_energy;
+  return c_pe->compute_scalar();
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/MC/fix_mol_swap.cpp
+++ b/src/MC/fix_mol_swap.cpp
@@ -166,9 +166,7 @@ void FixMolSwap::init()
 
   // c_pe = compute used to calculate before/after potential energy
 
-  auto *id_pe = (char *) "thermo_pe";
-  int ipe = modify->find_compute(id_pe);
-  c_pe = modify->compute[ipe];
+  c_pe = modify->get_compute_by_id("thermo_pe");
 
   // minmol = smallest molID with atoms of itype or jtype
   // maxmol = largest molID with atoms of itype or jtype

--- a/src/MISC/fix_ipi.cpp
+++ b/src/MISC/fix_ipi.cpp
@@ -425,7 +425,7 @@ void FixIPI::initial_integrate(int /*vflag*/)
   }
 
   // compute PE. makes sure that it will be evaluated at next step
-  modify->compute[modify->find_compute("thermo_pe")]->invoked_scalar = -1;
+  modify->get_compute_by_id("thermo_pe")->invoked_scalar = -1;
   modify->addstep_compute_all(update->ntimestep+1);
 
   hasdata=1;

--- a/src/OPENMP/npair_bin_ghost_omp.cpp
+++ b/src/OPENMP/npair_bin_ghost_omp.cpp
@@ -56,7 +56,7 @@ void NPairBinGhostOmp<HALF>::build(NeighList *list)
 
   NPAIR_OMP_INIT;
 #if defined(_OPENMP)
-#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(list) reduction(+:overflow)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(list,fix_package_omp) reduction(+:overflow)
 #endif
   NPAIR_OMP_SETUP(nall);
 

--- a/src/OPENMP/npair_bin_omp.cpp
+++ b/src/OPENMP/npair_bin_omp.cpp
@@ -60,7 +60,7 @@ void NPairBinOmp<HALF, NEWTON, TRI, SIZE, ATOMONLY>::build(NeighList *list)
 
   NPAIR_OMP_INIT;
 #if defined(_OPENMP)
-#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(list) reduction(+:overflow)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(list,fix_package_omp) reduction(+:overflow)
 #endif
   NPAIR_OMP_SETUP(nlocal);
 

--- a/src/OPENMP/npair_halffull_omp.cpp
+++ b/src/OPENMP/npair_halffull_omp.cpp
@@ -59,7 +59,7 @@ void NPairHalffullOmp<NEWTON, TRI, TRIM>::build(NeighList *list)
 
   NPAIR_OMP_INIT;
 #if defined(_OPENMP)
-#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(list) reduction(+:overflow)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(list,fix_package_omp) reduction(+:overflow)
 #endif
   NPAIR_OMP_SETUP(inum_full);
 

--- a/src/OPENMP/npair_multi_omp.cpp
+++ b/src/OPENMP/npair_multi_omp.cpp
@@ -62,7 +62,7 @@ void NPairMultiOmp<HALF, NEWTON, TRI, SIZE, ATOMONLY>::build(NeighList *list)
 
   NPAIR_OMP_INIT;
 #if defined(_OPENMP)
-#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(list) reduction(+:overflow)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(list,fix_package_omp) reduction(+:overflow)
 #endif
   NPAIR_OMP_SETUP(nlocal);
 

--- a/src/OPENMP/npair_nsq_ghost_omp.cpp
+++ b/src/OPENMP/npair_nsq_ghost_omp.cpp
@@ -55,7 +55,7 @@ void NPairNsqGhostOmp<HALF>::build(NeighList *list)
 
   NPAIR_OMP_INIT;
 #if defined(_OPENMP)
-#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(list) reduction(+:overflow)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(list,fix_package_omp) reduction(+:overflow)
 #endif
   NPAIR_OMP_SETUP(nall);
 

--- a/src/OPENMP/npair_nsq_omp.cpp
+++ b/src/OPENMP/npair_nsq_omp.cpp
@@ -69,7 +69,7 @@ void NPairNsqOmp<HALF, NEWTON, TRI, SIZE>::build(NeighList *list)
 
   NPAIR_OMP_INIT;
 #if defined(_OPENMP)
-#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(list) reduction(+:overflow)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(list,fix_package_omp) reduction(+:overflow)
 #endif
   NPAIR_OMP_SETUP(nlocal);
 

--- a/src/OPENMP/npair_omp.h
+++ b/src/OPENMP/npair_omp.h
@@ -19,6 +19,7 @@
 #endif
 
 #include "comm.h"
+#include "error.h"
 #include "fix_omp.h"
 #include "modify.h"
 #include "thr_data.h"

--- a/src/OPENMP/npair_omp.h
+++ b/src/OPENMP/npair_omp.h
@@ -33,7 +33,7 @@ namespace LAMMPS_NS {
 #define NPAIR_OMP_INIT                 \
   const int nthreads = comm->nthreads; \
   omp_set_num_threads(nthreads); \
-  const int ifix = modify->find_fix("package_omp")
+  Fix *fix_package_omp = modify->get_fix_by_id("package_omp")
 
 // get thread id and then assign each thread a fixed chunk of atoms
 #define NPAIR_OMP_SETUP(num)                                           \
@@ -42,7 +42,7 @@ namespace LAMMPS_NS {
     const int idelta = 1 + num / nthreads;                             \
     const int ifrom = tid * idelta;                                    \
     const int ito = ((ifrom + idelta) > num) ? num : (ifrom + idelta); \
-    FixOMP *fix = static_cast<FixOMP *>(modify->fix[ifix]);            \
+    FixOMP *fix = static_cast<FixOMP *>(fix_package_omp);             \
     ThrData *thr = fix->get_thr(tid);                                  \
     thr->timer(Timer::START);
 

--- a/src/OPENMP/npair_respa_bin_omp.cpp
+++ b/src/OPENMP/npair_respa_bin_omp.cpp
@@ -62,7 +62,7 @@ void NPairRespaBinOmp<NEWTON, TRI>::build(NeighList *list)
   const int respamiddle = list->respamiddle;
 
 #if defined(_OPENMP)
-#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(list) reduction(+:overflow)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(list,fix_package_omp) reduction(+:overflow)
 #endif
   NPAIR_OMP_SETUP(nlocal);
 

--- a/src/OPENMP/npair_respa_nsq_omp.cpp
+++ b/src/OPENMP/npair_respa_nsq_omp.cpp
@@ -71,7 +71,7 @@ void NPairRespaNsqOmp<NEWTON, TRI>::build(NeighList *list)
   const int respamiddle = list->respamiddle;
 
 #if defined(_OPENMP)
-#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(list) reduction(+:overflow)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(list,fix_package_omp) reduction(+:overflow)
 #endif
   NPAIR_OMP_SETUP(nlocal);
 

--- a/src/OPENMP/npair_trim_omp.cpp
+++ b/src/OPENMP/npair_trim_omp.cpp
@@ -39,7 +39,7 @@ void NPairTrimOmp::build(NeighList *list)
   NPAIR_OMP_INIT;
 
 #if defined(_OPENMP)
-#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(list) reduction(+:overflow)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(list,fix_package_omp) reduction(+:overflow)
 #endif
   NPAIR_OMP_SETUP(inum_copy);
 

--- a/src/PHONON/fix_phonon.cpp
+++ b/src/PHONON/fix_phonon.cpp
@@ -221,7 +221,6 @@ FixPhonon::FixPhonon(LAMMPS *lmp,  int narg, char **arg) : Fix(lmp, narg, arg)
   id_temp = utils::strdup("thermo_temp");
   temperature = modify->get_compute_by_id(id_temp);
   inv_nTemp = 1.0/group->count(temperature->igroup);
-
 } // end of constructor
 
 /* ---------------------------------------------------------------------- */

--- a/src/PHONON/fix_phonon.cpp
+++ b/src/PHONON/fix_phonon.cpp
@@ -219,8 +219,7 @@ FixPhonon::FixPhonon(LAMMPS *lmp,  int narg, char **arg) : Fix(lmp, narg, arg)
   // default temperature is from thermo
   TempSum = new double[sysdim];
   id_temp = utils::strdup("thermo_temp");
-  int icompute = modify->find_compute(id_temp);
-  temperature = modify->compute[icompute];
+  temperature = modify->get_compute_by_id(id_temp);
   inv_nTemp = 1.0/group->count(temperature->igroup);
 
 } // end of constructor
@@ -439,9 +438,8 @@ int FixPhonon::modify_param(int narg, char **arg)
     delete [] id_temp;
     id_temp = utils::strdup(arg[1]);
 
-    int icompute = modify->find_compute(id_temp);
-    if (icompute < 0) error->all(FLERR,"Could not find fix_modify temp ID");
-    temperature = modify->compute[icompute];
+    temperature = modify->get_compute_by_id(id_temp);
+    if (!temperature) error->all(FLERR,"Could not find fix_modify temp ID");
 
     if (temperature->tempflag == 0)
       error->all(FLERR,"Fix_modify temp ID does not compute temperature");

--- a/src/REPLICA/compute_event_displace.cpp
+++ b/src/REPLICA/compute_event_displace.cpp
@@ -66,10 +66,10 @@ void ComputeEventDisplace::init()
   // check if it is correct style
 
   if (id_event != nullptr) {
-    int ifix = modify->find_fix(id_event);
-    if (ifix < 0) error->all(FLERR,
-                             "Could not find compute event/displace fix ID");
-    fix_event = dynamic_cast<FixEvent*>(modify->fix[ifix]);
+    auto *ifix = modify->get_fix_by_id(id_event);
+    if (!ifix) error->all(FLERR,
+                          "Could not find compute event/displace fix ID");
+    fix_event = dynamic_cast<FixEvent*>(ifix);
 
     if (strcmp(fix_event->style,"EVENT/PRD") != 0 &&
         strcmp(fix_event->style,"EVENT/TAD") != 0 &&

--- a/src/REPLICA/compute_pressure_grem.cpp
+++ b/src/REPLICA/compute_pressure_grem.cpp
@@ -47,12 +47,12 @@ void ComputePressureGrem::init()
   ComputePressure::init();
 
   // Initialize hook to gREM fix
-  int ifix = modify->find_fix(fix_grem);
-  if (ifix < 0)
+  Fix *ifix = modify->get_fix_by_id(fix_grem);
+  if (!ifix)
     error->all(FLERR,"Fix grem ID for compute PRESSURE/GREM does not exist");
 
   int dim;
-  scale_grem = (double *)modify->fix[ifix]->extract("scale_grem",dim);
+  scale_grem = (double *)ifix->extract("scale_grem",dim);
 
   if (scale_grem == nullptr || dim != 0)
     error->all(FLERR,"Cannot extract gREM scale factor from fix grem");

--- a/src/REPLICA/fix_grem.cpp
+++ b/src/REPLICA/fix_grem.cpp
@@ -88,18 +88,18 @@ FixGrem::FixGrem(LAMMPS *lmp, int narg, char **arg) :
   id_pe = utils::strdup(std::string(id) + "_pe");
   modify->add_compute(fmt::format("{} all pe",id_pe));
 
-  int ifix = modify->find_fix(id_nh);
-  if (ifix < 0)
+  Fix *nh = modify->get_fix_by_id(id_nh);
+  if (!nh)
     error->all(FLERR,"Fix id for nvt or npt fix does not exist");
-  Fix *nh = modify->fix[ifix];
 
   pressflag = 0;
-  int *p_flag = (int *)nh->extract("p_flag",ifix);
-  if ((p_flag == nullptr) || (ifix != 1) || (p_flag[0] == 0)
+  int dim;
+  int *p_flag = (int *)nh->extract("p_flag",dim);
+  if ((p_flag == nullptr) || (dim != 1) || (p_flag[0] == 0)
       || (p_flag[1] == 0) || (p_flag[2] == 0)) {
     pressflag = 0;
   } else if ((p_flag[0] == 1) && (p_flag[1] == 1)
-             && (p_flag[2] == 1) && (ifix == 1)) {
+             && (p_flag[2] == 1) && (dim == 1)) {
     pressflag = 1;
     char *modargs[2];
     modargs[0] = (char *) "press";

--- a/src/REPLICA/hyper.cpp
+++ b/src/REPLICA/hyper.cpp
@@ -105,10 +105,10 @@ void Hyper::command(int narg, char **arg)
 
   // assign FixEventHyper to event-detection compute
   // necessary so it will know atom coords at last event
-
   auto *icompute = modify->get_compute_by_id(id_compute);
-  if (!icompute) error->all(FLERR,"Could not find compute ID for hyper");
   compute_event = dynamic_cast<ComputeEventDisplace *>(icompute);
+  if (!compute_event)
+    error->all(FLERR,"Could not find compute event/displace ID {} for hyper", id_compute);
   compute_event->reset_extra_compute_fix("hyper_event");
 
   // reset reneighboring criteria since will perform minimizations

--- a/src/REPLICA/hyper.cpp
+++ b/src/REPLICA/hyper.cpp
@@ -83,9 +83,9 @@ void Hyper::command(int narg, char **arg)
     hyperenable = 0;
     hyperstyle = NOHYPER;
   } else {
-    int ifix = modify->find_fix(id_fix);
-    if (ifix < 0) error->all(FLERR,"Could not find fix ID for hyper");
-    fix_hyper = dynamic_cast<FixHyper *>(modify->fix[ifix]);
+    auto *ifix = modify->get_fix_by_id(id_fix);
+    if (!ifix) error->all(FLERR,"Could not find fix ID for hyper");
+    fix_hyper = dynamic_cast<FixHyper *>(ifix);
     int dim;
     int *hyperflag = (int *) fix_hyper->extract("hyperflag",dim);
     if (hyperflag == nullptr || *hyperflag == 0)
@@ -106,9 +106,9 @@ void Hyper::command(int narg, char **arg)
   // assign FixEventHyper to event-detection compute
   // necessary so it will know atom coords at last event
 
-  int icompute = modify->find_compute(id_compute);
-  if (icompute < 0) error->all(FLERR,"Could not find compute ID for hyper");
-  compute_event = dynamic_cast<ComputeEventDisplace *>(modify->compute[icompute]);
+  auto *icompute = modify->get_compute_by_id(id_compute);
+  if (!icompute) error->all(FLERR,"Could not find compute ID for hyper");
+  compute_event = dynamic_cast<ComputeEventDisplace *>(icompute);
   compute_event->reset_extra_compute_fix("hyper_event");
 
   // reset reneighboring criteria since will perform minimizations

--- a/src/REPLICA/prd.cpp
+++ b/src/REPLICA/prd.cpp
@@ -181,9 +181,8 @@ void PRD::command(int narg, char **arg)
   // assign FixEventPRD to event-detection compute
   // necessary so it will know atom coords at last event
 
-  int icompute = modify->find_compute(id_compute);
-  if (icompute < 0) error->all(FLERR,"Could not find compute ID for PRD");
-  compute_event = modify->compute[icompute];
+  compute_event = modify->get_compute_by_id(id_compute);
+  if (!compute_event) error->all(FLERR,"Could not find compute ID for PRD");
   compute_event->reset_extra_compute_fix("prd_event");
 
   // reset reneighboring criteria since will perform minimizations

--- a/src/REPLICA/tad.cpp
+++ b/src/REPLICA/tad.cpp
@@ -144,9 +144,8 @@ void TAD::command(int narg, char **arg)
   // assign FixEventTAD to event-detection compute
   // necessary so it will know atom coords at last event
 
-  int icompute = modify->find_compute(id_compute);
-  if (icompute < 0) error->all(FLERR,"Could not find compute ID for TAD");
-  compute_event = modify->compute[icompute];
+  compute_event = modify->get_compute_by_id(id_compute);
+  if (!compute_event) error->all(FLERR,"Could not find compute ID for TAD");
   compute_event->reset_extra_compute_fix("tad_event");
 
   // reset reneighboring criteria since will perform minimizations

--- a/src/REPLICA/verlet_split.cpp
+++ b/src/REPLICA/verlet_split.cpp
@@ -295,10 +295,7 @@ void VerletSplit::run(int n)
 
   // check if OpenMP support fix defined
 
-  Fix *fix_omp;
-  int ifix = modify->find_fix("package_omp");
-  if (ifix < 0) fix_omp = nullptr;
-  else fix_omp = modify->fix[ifix];
+  Fix *fix_omp = modify->get_fix_by_id("package_omp");
 
   // flags for timestepping iterations
 


### PR DESCRIPTION
**Summary**

This completes the bulk of the refactor of the fix/compute accessor API in Modify

**Related Issue(s)**

Closes #2870 
Future refactoring will be described in new feature requests for discussion

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

These changes were generated with the help of Claude Opus 4.8. The AI identified the
call sites, classified them as easy vs. deferred, performed the mechanical
`find_fix`/`find_compute` -> `get_*_by_id` rewrites, and built/tested the result. The
work was reviewed by a human (consistent with the `Co-Authored-By` commit trailer).

**Backward Compatibility**

Yes. This only changes internal C++ usage of the `Modify` API; the deprecated
`find_fix`/`find_compute` functions remain in place and no user-facing input or behavior
changes.

**Implementation Notes**

Pattern of the change:

```c++
// before
int icompute = modify->find_compute(id);
if (icompute < 0) error->all(FLERR, "...");
Compute *c = modify->compute[icompute];
// after
Compute *c = modify->get_compute_by_id(id);
if (!c) error->all(FLERR, "...");
```

Existing error message text is preserved. A few sites needed minor care: `fix_grem.cpp`
reused the index variable as the `dim` out-parameter of `Fix::extract()` (now a separate
`int dim`); `npair_omp.h` defines the lookup in `NPAIR_OMP_INIT` and consumes it in
`NPAIR_OMP_SETUP`, so both macros switch to a `Fix *` instead of an index; sites that
`dynamic_cast` the result keep a temporary base pointer so the "does not exist" check and
the cast stay separate.

Intentionally **not** changed (left for follow-up work on #2870), because they are not the
"easy" local pattern:
- Call sites that store the list **index** as persistent class state and dereference it
  across calls (`fix_ave_grid.cpp` `value2index[]`, `CG-DNA/pair_oxdna_hbond.cpp`,
  `REACTION/fix_bond_react.cpp`, `RIGID/compute_ke_rigid.cpp`,
  `RIGID/compute_erotate_rigid.cpp`).
- Loops that iterate the entire fix/compute list (`modify->nfix`/`modify->ncompute`).
- `Modify::fmask` reads/writes via the list index (RIGID, GRAPHICS).
- The `Atom` callback fix-index bookkeeping (`atom.cpp` `extra_grow/restart/border`,
  `atom_vec*.cpp`).

Correctness verification: clean CMake build with the `gcc` + `most` presets (plus
MANIFOLD) and no new warnings; `make check-whitespace` / `check-permissions` pass; the
`FixTimestep:momentum_chunk` (exercises the most heavily rewritten file,
`fix_momentum_chunk.cpp`), `FixTimestep:spring_chunk`, and `ComputeChunk` regression tests
pass.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
