### PR TITLE
OPENMP: add /omp variants for analysis computes, angle cosine/buck6d, more pair styles, and QEQ/ORIENT fixes

### DIFF
--- a/doc/src/Commands_bond.rst
+++ b/doc/src/Commands_bond.rst
@@ -78,7 +78,7 @@ OPT.
    * :doc:`class2/p6 (ko) <angle_class2>`
    * :doc:`class2xe (ko) <angle_class2>`
    * :doc:`cosine (ko) <angle_cosine>`
-   * :doc:`cosine/buck6d <angle_cosine_buck6d>`
+   * :doc:`cosine/buck6d (o) <angle_cosine_buck6d>`
    * :doc:`cosine/delta (ko) <angle_cosine_delta>`
    * :doc:`cosine/periodic (ko) <angle_cosine_periodic>`
    * :doc:`cosine/shift (ko) <angle_cosine_shift>`

--- a/doc/src/Commands_compute.rst
+++ b/doc/src/Commands_compute.rst
@@ -111,7 +111,7 @@ OPT.
    * :doc:`property/local <compute_property_local>`
    * :doc:`ptm/atom <compute_ptm_atom>`
    * :doc:`rattlers/atom <compute_rattlers_atom>`
-   * :doc:`rdf <compute_rdf>`
+   * :doc:`rdf (o) <compute_rdf>`
    * :doc:`reaxff/atom (k) <compute_reaxff_atom>`
    * :doc:`reduce <compute_reduce>`
    * :doc:`reduce/chunk <compute_reduce_chunk>`

--- a/doc/src/Commands_compute.rst
+++ b/doc/src/Commands_compute.rst
@@ -54,7 +54,7 @@ OPT.
    * :doc:`erotate/asphere (k) <compute_erotate_asphere>`
    * :doc:`erotate/rigid <compute_erotate_rigid>`
    * :doc:`erotate/sphere (k) <compute_erotate_sphere>`
-   * :doc:`erotate/sphere/atom <compute_erotate_sphere_atom>`
+   * :doc:`erotate/sphere/atom (o) <compute_erotate_sphere_atom>`
    * :doc:`event/displace <compute_event_displace>`
    * :doc:`fabric <compute_fabric>`
    * :doc:`fep <compute_fep>`
@@ -78,7 +78,7 @@ OPT.
    * :doc:`improper/local <compute_improper_local>`
    * :doc:`inertia/chunk <compute_inertia_chunk>`
    * :doc:`ke <compute_ke>`
-   * :doc:`ke/atom <compute_ke_atom>`
+   * :doc:`ke/atom (o) <compute_ke_atom>`
    * :doc:`ke/atom/eff <compute_ke_atom_eff>`
    * :doc:`ke/eff <compute_ke_eff>`
    * :doc:`ke/rigid <compute_ke_rigid>`

--- a/doc/src/Commands_compute.rst
+++ b/doc/src/Commands_compute.rst
@@ -11,13 +11,13 @@ OPT.
 .. table_from_list::
    :columns: 4
 
-   * :doc:`ackland/atom <compute_ackland_atom>`
+   * :doc:`ackland/atom (o) <compute_ackland_atom>`
    * :doc:`adf <compute_adf>`
    * :doc:`aggregate/atom <compute_cluster_atom>`
    * :doc:`angle <compute_angle>`
    * :doc:`angle/local <compute_angle_local>`
    * :doc:`angmom/chunk <compute_angmom_chunk>`
-   * :doc:`ave/sphere/atom (k) <compute_ave_sphere_atom>`
+   * :doc:`ave/sphere/atom (ko) <compute_ave_sphere_atom>`
    * :doc:`basal/atom <compute_basal_atom>`
    * :doc:`body/local <compute_body_local>`
    * :doc:`bond <compute_bond>`
@@ -29,7 +29,7 @@ OPT.
    * :doc:`chunk/spread/atom <compute_chunk_spread_atom>`
    * :doc:`cluster/atom <compute_cluster_atom>`
    * :doc:`cna/atom (o) <compute_cna_atom>`
-   * :doc:`cnp/atom <compute_cnp_atom>`
+   * :doc:`cnp/atom (o) <compute_cnp_atom>`
    * :doc:`com <compute_com>`
    * :doc:`com/chunk <compute_com_chunk>`
    * :doc:`composition/atom (k) <compute_composition_atom>`
@@ -50,7 +50,7 @@ OPT.
    * :doc:`edpd/temp/atom <compute_edpd_temp_atom>`
    * :doc:`efield/atom <compute_efield_atom>`
    * :doc:`efield/wolf/atom <compute_efield_wolf_atom>`
-   * :doc:`entropy/atom <compute_entropy_atom>`
+   * :doc:`entropy/atom (o) <compute_entropy_atom>`
    * :doc:`erotate/asphere (k) <compute_erotate_asphere>`
    * :doc:`erotate/rigid <compute_erotate_rigid>`
    * :doc:`erotate/sphere (k) <compute_erotate_sphere>`

--- a/doc/src/Commands_compute.rst
+++ b/doc/src/Commands_compute.rst
@@ -34,7 +34,7 @@ OPT.
    * :doc:`com/chunk <compute_com_chunk>`
    * :doc:`composition/atom (k) <compute_composition_atom>`
    * :doc:`contact/atom <compute_contact_atom>`
-   * :doc:`coord/atom (k) <compute_coord_atom>`
+   * :doc:`coord/atom (ko) <compute_coord_atom>`
    * :doc:`count/type <compute_count_type>`
    * :doc:`damage/atom <compute_damage_atom>`
    * :doc:`dihedral <compute_dihedral>`
@@ -89,7 +89,7 @@ OPT.
    * :doc:`msd/nongauss <compute_msd_nongauss>`
    * :doc:`nbond/atom <compute_nbond_atom>`
    * :doc:`omega/chunk <compute_omega_chunk>`
-   * :doc:`orientorder/atom (k) <compute_orientorder_atom>`
+   * :doc:`orientorder/atom (ko) <compute_orientorder_atom>`
    * :doc:`pace <compute_pace>`
    * :doc:`pair <compute_pair>`
    * :doc:`pair/local <compute_pair_local>`

--- a/doc/src/Commands_compute.rst
+++ b/doc/src/Commands_compute.rst
@@ -23,12 +23,12 @@ OPT.
    * :doc:`bond <compute_bond>`
    * :doc:`bond/local <compute_bond_local>`
    * :doc:`born/matrix <compute_born_matrix>`
-   * :doc:`centro/atom <compute_centro_atom>`
+   * :doc:`centro/atom (o) <compute_centro_atom>`
    * :doc:`centroid/stress/atom <compute_stress_atom>`
    * :doc:`chunk/atom <compute_chunk_atom>`
    * :doc:`chunk/spread/atom <compute_chunk_spread_atom>`
    * :doc:`cluster/atom <compute_cluster_atom>`
-   * :doc:`cna/atom <compute_cna_atom>`
+   * :doc:`cna/atom (o) <compute_cna_atom>`
    * :doc:`cnp/atom <compute_cnp_atom>`
    * :doc:`com <compute_com>`
    * :doc:`com/chunk <compute_com_chunk>`
@@ -72,7 +72,7 @@ OPT.
    * :doc:`heat/flux <compute_heat_flux>`
    * :doc:`heat/flux/tally <compute_tally>`
    * :doc:`heat/flux/virial/tally <compute_tally>`
-   * :doc:`hexorder/atom <compute_hexorder_atom>`
+   * :doc:`hexorder/atom (o) <compute_hexorder_atom>`
    * :doc:`hma <compute_hma>`
    * :doc:`improper <compute_improper>`
    * :doc:`improper/local <compute_improper_local>`

--- a/doc/src/Commands_fix.rst
+++ b/doc/src/Commands_fix.rst
@@ -172,9 +172,9 @@ parenthesis: g = GPU, i = INTEL, k = KOKKOS, o = OPENMP, t = OPT.
    * :doc:`nvt/sphere (ko) <fix_nvt_sphere>`
    * :doc:`nvt/uef <fix_nh_uef>`
    * :doc:`oneway (k) <fix_oneway>`
-   * :doc:`orient/bcc <fix_orient>`
-   * :doc:`orient/fcc <fix_orient>`
-   * :doc:`orient/eco <fix_orient_eco>`
+   * :doc:`orient/bcc (o) <fix_orient>`
+   * :doc:`orient/fcc (o) <fix_orient>`
+   * :doc:`orient/eco (o) <fix_orient_eco>`
    * :doc:`pafi <fix_pafi>`
    * :doc:`pair <fix_pair>`
    * :doc:`phonon <fix_phonon>`
@@ -198,14 +198,14 @@ parenthesis: g = GPU, i = INTEL, k = KOKKOS, o = OPENMP, t = OPT.
    * :doc:`python/move <fix_python_move>`
    * :doc:`qbmsst <fix_qbmsst>`
    * :doc:`qeq/comb (o) <fix_qeq_comb>`
-   * :doc:`qeq/ctip <fix_qeq>`
-   * :doc:`qeq/dynamic <fix_qeq>`
-   * :doc:`qeq/fire <fix_qeq>`
-   * :doc:`qeq/point <fix_qeq>`
+   * :doc:`qeq/ctip (o) <fix_qeq>`
+   * :doc:`qeq/dynamic (o) <fix_qeq>`
+   * :doc:`qeq/fire (o) <fix_qeq>`
+   * :doc:`qeq/point (o) <fix_qeq>`
    * :doc:`qeq/reaxff (ko) <fix_qeq_reaxff>`
    * :doc:`qeq/rel/reaxff <fix_qeq_rel_reaxff>`
-   * :doc:`qeq/shielded <fix_qeq>`
-   * :doc:`qeq/slater <fix_qeq>`
+   * :doc:`qeq/shielded (o) <fix_qeq>`
+   * :doc:`qeq/slater (o) <fix_qeq>`
    * :doc:`qmmm <fix_qmmm>`
    * :doc:`qtb <fix_qtb>`
    * :doc:`qtpie/reaxff <fix_qtpie_reaxff>`

--- a/doc/src/Commands_pair.rst
+++ b/doc/src/Commands_pair.rst
@@ -36,12 +36,12 @@ parenthesis: g = GPU, i = INTEL, k = KOKKOS, o = OPENMP, t = OPT.
    * :doc:`bop <pair_bop>`
    * :doc:`born (gko) <pair_born>`
    * :doc:`born/coul/dsf <pair_born>`
-   * :doc:`born/coul/dsf/cs <pair_cs>`
+   * :doc:`born/coul/dsf/cs (o) <pair_cs>`
    * :doc:`born/coul/long (gko) <pair_born>`
-   * :doc:`born/coul/long/cs (g) <pair_cs>`
+   * :doc:`born/coul/long/cs (go) <pair_cs>`
    * :doc:`born/coul/msm (o) <pair_born>`
    * :doc:`born/coul/wolf (gko) <pair_born>`
-   * :doc:`born/coul/wolf/cs (g) <pair_cs>`
+   * :doc:`born/coul/wolf/cs (go) <pair_cs>`
    * :doc:`born/gauss (ko) <pair_born_gauss>`
    * :doc:`bpm/spring <pair_bpm_spring>`
    * :doc:`brownian (ko) <pair_brownian>`
@@ -49,7 +49,7 @@ parenthesis: g = GPU, i = INTEL, k = KOKKOS, o = OPENMP, t = OPT.
    * :doc:`buck (giko) <pair_buck>`
    * :doc:`buck/coul/cut (giko) <pair_buck>`
    * :doc:`buck/coul/long (giko) <pair_buck>`
-   * :doc:`buck/coul/long/cs <pair_cs>`
+   * :doc:`buck/coul/long/cs (o) <pair_cs>`
    * :doc:`buck/coul/msm (o) <pair_buck>`
    * :doc:`buck/long/coul/long (o) <pair_buck_long>`
    * :doc:`buck/mdf (ko) <pair_mdf>`
@@ -71,7 +71,7 @@ parenthesis: g = GPU, i = INTEL, k = KOKKOS, o = OPENMP, t = OPT.
    * :doc:`coul/esp <pair_coul>`
    * :doc:`coul/exclude <pair_coul>`
    * :doc:`coul/long (gko) <pair_coul>`
-   * :doc:`coul/long/cs (g) <pair_cs>`
+   * :doc:`coul/long/cs (go) <pair_cs>`
    * :doc:`coul/long/dielectric <pair_dielectric>`
    * :doc:`coul/long/soft (o) <pair_fep_soft>`
    * :doc:`coul/msm (o) <pair_coul>`
@@ -81,7 +81,7 @@ parenthesis: g = GPU, i = INTEL, k = KOKKOS, o = OPENMP, t = OPT.
    * :doc:`coul/streitz (o) <pair_coul>`
    * :doc:`coul/tt <pair_coul_tt>`
    * :doc:`coul/wolf (ko) <pair_coul>`
-   * :doc:`coul/wolf/cs <pair_cs>`
+   * :doc:`coul/wolf/cs (o) <pair_cs>`
    * :doc:`dispersion/d3 <pair_dispersion_d3>`
    * :doc:`dpd (giko) <pair_dpd>`
    * :doc:`dpd/coul/slater/long (g) <pair_dpd_coul_slater_long>`
@@ -150,7 +150,7 @@ parenthesis: g = GPU, i = INTEL, k = KOKKOS, o = OPENMP, t = OPT.
    * :doc:`lj/class2/coul/cut (ko) <pair_class2>`
    * :doc:`lj/class2/coul/cut/soft <pair_fep_soft>`
    * :doc:`lj/class2/coul/long (gko) <pair_class2>`
-   * :doc:`lj/class2/coul/long/cs <pair_cs>`
+   * :doc:`lj/class2/coul/long/cs (o) <pair_cs>`
    * :doc:`lj/class2/coul/long/soft <pair_fep_soft>`
    * :doc:`lj/class2/soft <pair_fep_soft>`
    * :doc:`lj/cubic (gko) <pair_lj_cubic>`
@@ -163,7 +163,7 @@ parenthesis: g = GPU, i = INTEL, k = KOKKOS, o = OPENMP, t = OPT.
    * :doc:`lj/cut/coul/dsf (gko) <pair_lj_cut_coul>`
    * :doc:`lj/cut/coul/esp <pair_lj_cut_coul>`
    * :doc:`lj/cut/coul/long (gikot) <pair_lj_cut_coul>`
-   * :doc:`lj/cut/coul/long/cs <pair_cs>`
+   * :doc:`lj/cut/coul/long/cs (o) <pair_cs>`
    * :doc:`lj/cut/coul/long/dielectric (o) <pair_dielectric>`
    * :doc:`lj/cut/coul/long/soft (go) <pair_fep_soft>`
    * :doc:`lj/cut/coul/msm (go) <pair_lj_cut_coul>`

--- a/doc/src/Commands_pair.rst
+++ b/doc/src/Commands_pair.rst
@@ -170,7 +170,7 @@ parenthesis: g = GPU, i = INTEL, k = KOKKOS, o = OPENMP, t = OPT.
    * :doc:`lj/cut/coul/msm/dielectric <pair_dielectric>`
    * :doc:`lj/cut/coul/wolf (ko) <pair_lj_cut_coul>`
    * :doc:`lj/cut/dipole/cut (gko) <pair_dipole>`
-   * :doc:`lj/cut/dipole/long (g) <pair_dipole>`
+   * :doc:`lj/cut/dipole/long (go) <pair_dipole>`
    * :doc:`lj/cut/dipole/sf (go) <pair_dipole>`
    * :doc:`lj/cut/soft (o) <pair_fep_soft>`
    * :doc:`lj/cut/sphere (ko) <pair_lj_cut_sphere>`

--- a/doc/src/Commands_pair.rst
+++ b/doc/src/Commands_pair.rst
@@ -64,7 +64,7 @@ parenthesis: g = GPU, i = INTEL, k = KOKKOS, o = OPENMP, t = OPT.
    * :doc:`coul/cut/dielectric <pair_dielectric>`
    * :doc:`coul/cut/global (ko) <pair_coul>`
    * :doc:`coul/cut/soft (o) <pair_fep_soft>`
-   * :doc:`coul/cut/soft/gapsys <pair_fep_soft>`
+   * :doc:`coul/cut/soft/gapsys (o) <pair_fep_soft>`
    * :doc:`coul/debye (gko) <pair_coul>`
    * :doc:`coul/diel (ko) <pair_coul_diel>`
    * :doc:`coul/dsf (gko) <pair_coul>`
@@ -148,11 +148,11 @@ parenthesis: g = GPU, i = INTEL, k = KOKKOS, o = OPENMP, t = OPT.
    * :doc:`lj/charmmfsw/coul/long (k) <pair_charmm>`
    * :doc:`lj/class2 (gko) <pair_class2>`
    * :doc:`lj/class2/coul/cut (ko) <pair_class2>`
-   * :doc:`lj/class2/coul/cut/soft <pair_fep_soft>`
+   * :doc:`lj/class2/coul/cut/soft (o) <pair_fep_soft>`
    * :doc:`lj/class2/coul/long (gko) <pair_class2>`
    * :doc:`lj/class2/coul/long/cs (o) <pair_cs>`
-   * :doc:`lj/class2/coul/long/soft <pair_fep_soft>`
-   * :doc:`lj/class2/soft <pair_fep_soft>`
+   * :doc:`lj/class2/coul/long/soft (o) <pair_fep_soft>`
+   * :doc:`lj/class2/soft (o) <pair_fep_soft>`
    * :doc:`lj/cubic (gko) <pair_lj_cubic>`
    * :doc:`lj/cut (gikot) <pair_lj>`
    * :doc:`lj/cut/coul/cut (gko) <pair_lj_cut_coul>`
@@ -219,7 +219,7 @@ parenthesis: g = GPU, i = INTEL, k = KOKKOS, o = OPENMP, t = OPT.
    * :doc:`momb (ko) <pair_momb>`
    * :doc:`morse (gkot) <pair_morse>`
    * :doc:`morse/smooth/linear (ko) <pair_morse>`
-   * :doc:`morse/soft <pair_fep_soft>`
+   * :doc:`morse/soft (o) <pair_fep_soft>`
    * :doc:`multi/lucy <pair_multi_lucy>`
    * :doc:`multi/lucy/rx (k) <pair_multi_lucy_rx>`
    * :doc:`nb3b/harmonic (o) <pair_nb3b>`

--- a/doc/src/Commands_pair.rst
+++ b/doc/src/Commands_pair.rst
@@ -35,7 +35,7 @@ parenthesis: g = GPU, i = INTEL, k = KOKKOS, o = OPENMP, t = OPT.
    * :doc:`body/rounded/polyhedron (o) <pair_body_rounded_polyhedron>`
    * :doc:`bop <pair_bop>`
    * :doc:`born (gko) <pair_born>`
-   * :doc:`born/coul/dsf <pair_born>`
+   * :doc:`born/coul/dsf (o) <pair_born>`
    * :doc:`born/coul/dsf/cs (o) <pair_cs>`
    * :doc:`born/coul/long (gko) <pair_born>`
    * :doc:`born/coul/long/cs (go) <pair_cs>`
@@ -69,14 +69,14 @@ parenthesis: g = GPU, i = INTEL, k = KOKKOS, o = OPENMP, t = OPT.
    * :doc:`coul/diel (ko) <pair_coul_diel>`
    * :doc:`coul/dsf (gko) <pair_coul>`
    * :doc:`coul/esp <pair_coul>`
-   * :doc:`coul/exclude <pair_coul>`
+   * :doc:`coul/exclude (o) <pair_coul>`
    * :doc:`coul/long (gko) <pair_coul>`
    * :doc:`coul/long/cs (go) <pair_cs>`
    * :doc:`coul/long/dielectric <pair_dielectric>`
    * :doc:`coul/long/soft (o) <pair_fep_soft>`
    * :doc:`coul/msm (o) <pair_coul>`
-   * :doc:`coul/slater/cut <pair_coul_slater>`
-   * :doc:`coul/slater/long (gk) <pair_coul_slater>`
+   * :doc:`coul/slater/cut (o) <pair_coul_slater>`
+   * :doc:`coul/slater/long (gko) <pair_coul_slater>`
    * :doc:`coul/shield (ko) <pair_coul_shield>`
    * :doc:`coul/streitz (o) <pair_coul>`
    * :doc:`coul/tt <pair_coul_tt>`
@@ -144,8 +144,8 @@ parenthesis: g = GPU, i = INTEL, k = KOKKOS, o = OPENMP, t = OPT.
    * :doc:`lj/charmm/coul/long (gikot) <pair_charmm>`
    * :doc:`lj/charmm/coul/long/soft (o) <pair_fep_soft>`
    * :doc:`lj/charmm/coul/msm (o) <pair_charmm>`
-   * :doc:`lj/charmmfsw/coul/charmmfsh <pair_charmm>`
-   * :doc:`lj/charmmfsw/coul/long (k) <pair_charmm>`
+   * :doc:`lj/charmmfsw/coul/charmmfsh (o) <pair_charmm>`
+   * :doc:`lj/charmmfsw/coul/long (ko) <pair_charmm>`
    * :doc:`lj/class2 (gko) <pair_class2>`
    * :doc:`lj/class2/coul/cut (ko) <pair_class2>`
    * :doc:`lj/class2/coul/cut/soft (o) <pair_fep_soft>`
@@ -179,7 +179,7 @@ parenthesis: g = GPU, i = INTEL, k = KOKKOS, o = OPENMP, t = OPT.
    * :doc:`lj/cut/tip4p/long (got) <pair_lj_cut_tip4p>`
    * :doc:`lj/cut/tip4p/long/soft (o) <pair_fep_soft>`
    * :doc:`lj/expand (gko) <pair_lj_expand>`
-   * :doc:`lj/expand/coul/long (gk) <pair_lj_expand>`
+   * :doc:`lj/expand/coul/long (gko) <pair_lj_expand>`
    * :doc:`lj/expand/sphere (o) <pair_lj_expand_sphere>`
    * :doc:`lj/gromacs (gko) <pair_gromacs>`
    * :doc:`lj/gromacs/coul/gromacs (ko) <pair_gromacs>`
@@ -227,7 +227,7 @@ parenthesis: g = GPU, i = INTEL, k = KOKKOS, o = OPENMP, t = OPT.
    * :doc:`nm/cut (ko) <pair_nm>`
    * :doc:`nm/cut/coul/cut (ko) <pair_nm>`
    * :doc:`nm/cut/coul/long (ko) <pair_nm>`
-   * :doc:`nm/cut/split <pair_nm>`
+   * :doc:`nm/cut/split (o) <pair_nm>`
    * :doc:`oxdna/coaxstk <pair_oxdna>`
    * :doc:`oxdna/excv <pair_oxdna>`
    * :doc:`oxdna/hbond <pair_oxdna>`

--- a/doc/src/angle_cosine_buck6d.rst
+++ b/doc/src/angle_cosine_buck6d.rst
@@ -1,7 +1,10 @@
 .. index:: angle_style cosine/buck6d
+.. index:: angle_style cosine/buck6d/omp
 
 angle_style cosine/buck6d command
 =================================
+
+Accelerator Variants: *cosine/buck6d/omp*
 
 Syntax
 """"""

--- a/doc/src/angle_cosine_buck6d.rst
+++ b/doc/src/angle_cosine_buck6d.rst
@@ -55,6 +55,12 @@ the :doc:`special_bonds <special_bonds>` 1-3 interactions to be weighted
 
 ----------
 
+----------
+
+.. include:: accel_styles.rst
+
+----------
+
 Restrictions
 """"""""""""
 

--- a/doc/src/angle_cosine_buck6d.rst
+++ b/doc/src/angle_cosine_buck6d.rst
@@ -55,8 +55,6 @@ the :doc:`special_bonds <special_bonds>` 1-3 interactions to be weighted
 
 ----------
 
-----------
-
 .. include:: accel_styles.rst
 
 ----------

--- a/doc/src/compute_ackland_atom.rst
+++ b/doc/src/compute_ackland_atom.rst
@@ -69,6 +69,12 @@ any command that uses per-atom values from a compute as input.  See
 the :doc:`Howto output <Howto_output>` page for an overview of
 LAMMPS output options.
 
+----------
+
+.. include:: accel_styles.rst
+
+----------
+
 Restrictions
 """"""""""""
 

--- a/doc/src/compute_ackland_atom.rst
+++ b/doc/src/compute_ackland_atom.rst
@@ -1,7 +1,10 @@
 .. index:: compute ackland/atom
+.. index:: compute ackland/atom/omp
 
 compute ackland/atom command
 ============================
+
+Accelerator Variants: *ackland/atom/omp*
 
 Syntax
 """"""

--- a/doc/src/compute_ave_sphere_atom.rst
+++ b/doc/src/compute_ave_sphere_atom.rst
@@ -1,10 +1,11 @@
 .. index:: compute ave/sphere/atom
 .. index:: compute ave/sphere/atom/kk
+.. index:: compute ave/sphere/atom/omp
 
 compute ave/sphere/atom command
 ================================
 
-Accelerator Variants: *ave/sphere/atom/kk*
+Accelerator Variants: *ave/sphere/atom/kk*, *ave/sphere/atom/omp*
 
 Syntax
 """"""

--- a/doc/src/compute_centro_atom.rst
+++ b/doc/src/compute_centro_atom.rst
@@ -1,7 +1,10 @@
 .. index:: compute centro/atom
+.. index:: compute centro/atom/omp
 
 compute centro/atom command
 ===========================
+
+Accelerator Variants: *centro/atom/omp*
 
 Syntax
 """"""

--- a/doc/src/compute_centro_atom.rst
+++ b/doc/src/compute_centro_atom.rst
@@ -151,6 +151,12 @@ For BCC materials, the values for dislocation cores and free surfaces
 would be somewhat different, due to their being only 8 neighbors instead
 of 12.
 
+----------
+
+.. include:: accel_styles.rst
+
+----------
+
 Restrictions
 """"""""""""
 none

--- a/doc/src/compute_cna_atom.rst
+++ b/doc/src/compute_cna_atom.rst
@@ -1,7 +1,10 @@
 .. index:: compute cna/atom
+.. index:: compute cna/atom/omp
 
 compute cna/atom command
 ========================
+
+Accelerator Variants: *cna/atom/omp*
 
 Syntax
 """"""

--- a/doc/src/compute_cna_atom.rst
+++ b/doc/src/compute_cna_atom.rst
@@ -95,6 +95,12 @@ LAMMPS output options.
 The per-atom vector values will be a number from 0 to 5, as explained
 above.
 
+----------
+
+.. include:: accel_styles.rst
+
+----------
+
 Restrictions
 """"""""""""
 none

--- a/doc/src/compute_cnp_atom.rst
+++ b/doc/src/compute_cnp_atom.rst
@@ -1,7 +1,10 @@
 .. index:: compute cnp/atom
+.. index:: compute cnp/atom/omp
 
 compute cnp/atom command
 ========================
+
+Accelerator Variants: *cnp/atom/omp*
 
 Syntax
 """"""

--- a/doc/src/compute_cnp_atom.rst
+++ b/doc/src/compute_cnp_atom.rst
@@ -112,6 +112,12 @@ values:
    FCC (100) surface = 26.5
    FCC dislocation core = 11
 
+----------
+
+.. include:: accel_styles.rst
+
+----------
+
 Restrictions
 """"""""""""
 

--- a/doc/src/compute_coord_atom.rst
+++ b/doc/src/compute_coord_atom.rst
@@ -1,10 +1,11 @@
 .. index:: compute coord/atom
 .. index:: compute coord/atom/kk
+.. index:: compute coord/atom/omp
 
 compute coord/atom command
 ==========================
 
-Accelerator Variants: *coord/atom/kk*
+Accelerator Variants: *coord/atom/kk*, *coord/atom/omp*
 
 Syntax
 """"""

--- a/doc/src/compute_entropy_atom.rst
+++ b/doc/src/compute_entropy_atom.rst
@@ -125,6 +125,12 @@ The pair entropy values have units of the Boltzmann constant. They are
 always negative, and lower values (lower entropy) correspond to more
 ordered environments.
 
+----------
+
+.. include:: accel_styles.rst
+
+----------
+
 Restrictions
 """"""""""""
 

--- a/doc/src/compute_entropy_atom.rst
+++ b/doc/src/compute_entropy_atom.rst
@@ -1,7 +1,10 @@
 .. index:: compute entropy/atom
+.. index:: compute entropy/atom/omp
 
 compute entropy/atom command
 ============================
+
+Accelerator Variants: *entropy/atom/omp*
 
 Syntax
 """"""

--- a/doc/src/compute_erotate_sphere_atom.rst
+++ b/doc/src/compute_erotate_sphere_atom.rst
@@ -1,7 +1,10 @@
 .. index:: compute erotate/sphere/atom
+.. index:: compute erotate/sphere/atom/omp
 
 compute erotate/sphere/atom command
 ===================================
+
+Accelerator Variants: *erotate/sphere/atom/omp*
 
 Syntax
 """"""

--- a/doc/src/compute_erotate_sphere_atom.rst
+++ b/doc/src/compute_erotate_sphere_atom.rst
@@ -52,6 +52,12 @@ LAMMPS output options.
 
 The per-atom vector values will be in energy :doc:`units <units>`.
 
+----------
+
+.. include:: accel_styles.rst
+
+----------
+
 Restrictions
 """"""""""""
 none

--- a/doc/src/compute_hexorder_atom.rst
+++ b/doc/src/compute_hexorder_atom.rst
@@ -111,6 +111,12 @@ These values can be accessed by any command that uses per-atom values
 from a compute as input.  See the :doc:`Howto output <Howto_output>` doc
 page for an overview of LAMMPS output options.
 
+----------
+
+.. include:: accel_styles.rst
+
+----------
+
 Restrictions
 """"""""""""
 

--- a/doc/src/compute_hexorder_atom.rst
+++ b/doc/src/compute_hexorder_atom.rst
@@ -1,7 +1,10 @@
 .. index:: compute hexorder/atom
+.. index:: compute hexorder/atom/omp
 
 compute hexorder/atom command
 =============================
+
+Accelerator Variants: *hexorder/atom/omp*
 
 Syntax
 """"""

--- a/doc/src/compute_ke_atom.rst
+++ b/doc/src/compute_ke_atom.rst
@@ -45,6 +45,12 @@ LAMMPS output options.
 
 The per-atom vector values will be in energy :doc:`units <units>`.
 
+----------
+
+.. include:: accel_styles.rst
+
+----------
+
 Restrictions
 """"""""""""
 none

--- a/doc/src/compute_ke_atom.rst
+++ b/doc/src/compute_ke_atom.rst
@@ -1,7 +1,10 @@
 .. index:: compute ke/atom
+.. index:: compute ke/atom/omp
 
 compute ke/atom command
 =======================
+
+Accelerator Variants: *ke/atom/omp*
 
 Syntax
 """"""

--- a/doc/src/compute_orientorder_atom.rst
+++ b/doc/src/compute_orientorder_atom.rst
@@ -1,10 +1,11 @@
 .. index:: compute orientorder/atom
 .. index:: compute orientorder/atom/kk
+.. index:: compute orientorder/atom/omp
 
 compute orientorder/atom command
 ================================
 
-Accelerator Variants: *orientorder/atom/kk*
+Accelerator Variants: *orientorder/atom/kk*, *orientorder/atom/omp*
 
 Syntax
 """"""

--- a/doc/src/compute_rdf.rst
+++ b/doc/src/compute_rdf.rst
@@ -178,6 +178,12 @@ The first column of array values will be in distance
 numbers :math:`\ge 0.0`.  The coordination number columns of array values are
 also numbers :math:`\ge 0.0`.
 
+----------
+
+.. include:: accel_styles.rst
+
+----------
+
 Restrictions
 """"""""""""
 

--- a/doc/src/compute_rdf.rst
+++ b/doc/src/compute_rdf.rst
@@ -1,7 +1,10 @@
 .. index:: compute rdf
+.. index:: compute rdf/omp
 
 compute rdf command
 ===================
+
+Accelerator Variants: *rdf/omp*
 
 Syntax
 """"""

--- a/doc/src/fix_orient.rst
+++ b/doc/src/fix_orient.rst
@@ -1,11 +1,17 @@
 .. index:: fix orient/fcc
+.. index:: fix orient/fcc/omp
 .. index:: fix orient/bcc
+.. index:: fix orient/bcc/omp
 
 fix orient/fcc command
 ======================
 
+Accelerator Variants: *orient/fcc/omp*
+
 fix orient/bcc command
 ======================
+
+Accelerator Variants: *orient/bcc/omp*
 
 Syntax
 """"""
@@ -173,6 +179,16 @@ No parameter of this fix can be used with the *start/stop* keywords of
 the :doc:`run <run>` command.
 
 This fix is not invoked during :doc:`energy minimization <minimize>`.
+
+----------
+
+.. include:: accel_styles.rst
+
+.. versionadded:: TBD
+
+   OpenMP accelerator variants (*orient/fcc/omp*, *orient/bcc/omp*).
+
+----------
 
 Restrictions
 """"""""""""

--- a/doc/src/fix_orient.rst
+++ b/doc/src/fix_orient.rst
@@ -184,10 +184,6 @@ This fix is not invoked during :doc:`energy minimization <minimize>`.
 
 .. include:: accel_styles.rst
 
-.. versionadded:: TBD
-
-   OpenMP accelerator variants (*orient/fcc/omp*, *orient/bcc/omp*).
-
 ----------
 
 Restrictions

--- a/doc/src/fix_orient_eco.rst
+++ b/doc/src/fix_orient_eco.rst
@@ -126,10 +126,6 @@ the run command. This fix is not invoked during energy minimization.
 
 .. include:: accel_styles.rst
 
-.. versionadded:: TBD
-
-   OpenMP accelerator variant (*orient/eco/omp*).
-
 ----------
 
 Restrictions

--- a/doc/src/fix_orient_eco.rst
+++ b/doc/src/fix_orient_eco.rst
@@ -1,7 +1,10 @@
 .. index:: fix orient/eco
+.. index:: fix orient/eco/omp
 
 fix orient/eco command
 ======================
+
+Accelerator Variants: *orient/eco/omp*
 
 
 .. parsed-literal::
@@ -118,6 +121,16 @@ the thermal masking value for each atom.  Both are described above.
 
 No parameter of this fix can be used with the start/stop keywords of
 the run command. This fix is not invoked during energy minimization.
+
+----------
+
+.. include:: accel_styles.rst
+
+.. versionadded:: TBD
+
+   OpenMP accelerator variant (*orient/eco/omp*).
+
+----------
 
 Restrictions
 """"""""""""

--- a/doc/src/fix_qeq.rst
+++ b/doc/src/fix_qeq.rst
@@ -1,27 +1,45 @@
 .. index:: fix qeq/point
+.. index:: fix qeq/point/omp
 .. index:: fix qeq/shielded
+.. index:: fix qeq/shielded/omp
 .. index:: fix qeq/slater
+.. index:: fix qeq/slater/omp
 .. index:: fix qeq/ctip
+.. index:: fix qeq/ctip/omp
 .. index:: fix qeq/dynamic
+.. index:: fix qeq/dynamic/omp
 .. index:: fix qeq/fire
+.. index:: fix qeq/fire/omp
 
 fix qeq/point command
 =====================
 
+Accelerator Variants: *qeq/point/omp*
+
 fix qeq/shielded command
 ========================
+
+Accelerator Variants: *qeq/shielded/omp*
 
 fix qeq/slater command
 ======================
 
+Accelerator Variants: *qeq/slater/omp*
+
 fix qeq/ctip command
 ====================
+
+Accelerator Variants: *qeq/ctip/omp*
 
 fix qeq/dynamic command
 =======================
 
+Accelerator Variants: *qeq/dynamic/omp*
+
 fix qeq/fire command
 ====================
+
+Accelerator Variants: *qeq/fire/omp*
 
 Syntax
 """"""
@@ -283,6 +301,16 @@ stored by these fixes for access by various :doc:`output commands
 *start/stop* keywords of the :doc:`run <run>` command.
 
 Thexe fixes are invoked during :doc:`energy minimization <minimize>`.
+
+----------
+
+.. include:: accel_styles.rst
+
+.. versionadded:: TBD
+
+   OpenMP accelerator variants (*/omp*) of all six qeq fixes.
+
+----------
 
 Restrictions
 """"""""""""

--- a/doc/src/fix_qeq.rst
+++ b/doc/src/fix_qeq.rst
@@ -306,10 +306,6 @@ Thexe fixes are invoked during :doc:`energy minimization <minimize>`.
 
 .. include:: accel_styles.rst
 
-.. versionadded:: TBD
-
-   OpenMP accelerator variants (*/omp*) of all six qeq fixes.
-
 ----------
 
 Restrictions

--- a/doc/src/pair_born.rst
+++ b/doc/src/pair_born.rst
@@ -13,6 +13,7 @@
 .. index:: pair_style born/coul/wolf/kk
 .. index:: pair_style born/coul/wolf/omp
 .. index:: pair_style born/coul/dsf
+.. index:: pair_style born/coul/dsf/omp
 
 pair_style born command
 =======================
@@ -36,6 +37,8 @@ Accelerator Variants: *born/coul/wolf/gpu*, *born/coul/wolf/kk*, *born/coul/wolf
 
 pair_style born/coul/dsf command
 ================================
+
+Accelerator Variants: *born/coul/dsf/omp*
 
 Syntax
 """"""

--- a/doc/src/pair_charmm.rst
+++ b/doc/src/pair_charmm.rst
@@ -15,7 +15,9 @@
 .. index:: pair_style lj/charmm/coul/msm
 .. index:: pair_style lj/charmm/coul/msm/omp
 .. index:: pair_style lj/charmmfsw/coul/charmmfsh
+.. index:: pair_style lj/charmmfsw/coul/charmmfsh/omp
 .. index:: pair_style lj/charmmfsw/coul/long
+.. index:: pair_style lj/charmmfsw/coul/long/omp
 .. index:: pair_style lj/charmmfsw/coul/long/kk
 
 pair_style lj/charmm/coul/charmm command
@@ -41,10 +43,12 @@ Accelerator Variants: *lj/charmm/coul/msm/omp*
 pair_style lj/charmmfsw/coul/charmmfsh command
 ==============================================
 
+Accelerator Variants: *lj/charmmfsw/coul/charmmfsh/omp*
+
 pair_style lj/charmmfsw/coul/long command
 =========================================
 
-Accelerator Variants: *lj/charmmfsw/coul/long/kk*
+Accelerator Variants: *lj/charmmfsw/coul/long/kk*, *lj/charmmfsw/coul/long/omp*
 
 Syntax
 """"""

--- a/doc/src/pair_coul.rst
+++ b/doc/src/pair_coul.rst
@@ -16,6 +16,7 @@
 .. index:: pair_style coul/dsf/omp
 .. index:: pair_style coul/esp
 .. index:: pair_style coul/exclude
+.. index:: pair_style coul/exclude/omp
 .. index:: pair_style coul/long
 .. index:: pair_style coul/long/omp
 .. index:: pair_style coul/long/kk
@@ -57,6 +58,8 @@ Accelerator Variants: *coul/dsf/gpu*, *coul/dsf/kk*, *coul/dsf/omp*
 
 pair_style coul/exclude command
 ===============================
+
+Accelerator Variants: *coul/exclude/omp*
 
 pair_style coul/long command
 ============================

--- a/doc/src/pair_coul_slater.rst
+++ b/doc/src/pair_coul_slater.rst
@@ -1,8 +1,10 @@
 .. index:: pair_style coul/slater
 .. index:: pair_style coul/slater/cut
+.. index:: pair_style coul/slater/cut/omp
 .. index:: pair_style coul/slater/long
 .. index:: pair_style coul/slater/long/gpu
 .. index:: pair_style coul/slater/long/kk
+.. index:: pair_style coul/slater/long/omp
 
 pair_style coul/slater command
 ==============================
@@ -10,10 +12,12 @@ pair_style coul/slater command
 pair_style coul/slater/cut command
 ==================================
 
+Accelerator Variants: *coul/slater/cut/omp*
+
 pair_style coul/slater/long command
 ===================================
 
-Accelerator Variants: *coul/slater/long/gpu*, *coul/slater/long/kk*
+Accelerator Variants: *coul/slater/long/gpu*, *coul/slater/long/kk*, *coul/slater/long/omp*
 
 Syntax
 """"""

--- a/doc/src/pair_cs.rst
+++ b/doc/src/pair_cs.rst
@@ -1,44 +1,62 @@
 .. index:: pair_style born/coul/dsf/cs
+.. index:: pair_style born/coul/dsf/cs/omp
 .. index:: pair_style born/coul/long/cs
 .. index:: pair_style born/coul/long/cs/gpu
+.. index:: pair_style born/coul/long/cs/omp
 .. index:: pair_style born/coul/wolf/cs
 .. index:: pair_style born/coul/wolf/cs/gpu
+.. index:: pair_style born/coul/wolf/cs/omp
 .. index:: pair_style buck/coul/long/cs
+.. index:: pair_style buck/coul/long/cs/omp
 .. index:: pair_style coul/long/cs
 .. index:: pair_style coul/long/cs/gpu
+.. index:: pair_style coul/long/cs/omp
 .. index:: pair_style coul/wolf/cs
+.. index:: pair_style coul/wolf/cs/omp
 .. index:: pair_style lj/cut/coul/long/cs
+.. index:: pair_style lj/cut/coul/long/cs/omp
 .. index:: pair_style lj/class2/coul/long/cs
+.. index:: pair_style lj/class2/coul/long/cs/omp
 
 pair_style born/coul/dsf/cs command
 ===================================
 
+Accelerator Variants: *born/coul/dsf/cs/omp*
+
 pair_style born/coul/long/cs command
 ====================================
 
-Accelerator Variants: *born/coul/long/cs/gpu*
+Accelerator Variants: *born/coul/long/cs/gpu*, *born/coul/long/cs/omp*
 
 pair_style born/coul/wolf/cs command
 ====================================
 
-Accelerator Variants: *born/coul/wolf/cs/gpu*
+Accelerator Variants: *born/coul/wolf/cs/gpu*, *born/coul/wolf/cs/omp*
 
 pair_style buck/coul/long/cs command
 ====================================
 
+Accelerator Variants: *buck/coul/long/cs/omp*
+
 pair_style coul/long/cs command
 ===============================
 
-Accelerator Variants: *coul/long/cs/gpu*
+Accelerator Variants: *coul/long/cs/gpu*, *coul/long/cs/omp*
 
 pair_style coul/wolf/cs command
 ===============================
 
+Accelerator Variants: *coul/wolf/cs/omp*
+
 pair_style lj/cut/coul/long/cs command
 ======================================
 
+Accelerator Variants: *lj/cut/coul/long/cs/omp*
+
 pair_style lj/class2/coul/long/cs command
 =========================================
+
+Accelerator Variants: *lj/class2/coul/long/cs/omp*
 
 Syntax
 """"""

--- a/doc/src/pair_dipole.rst
+++ b/doc/src/pair_dipole.rst
@@ -7,6 +7,7 @@
 .. index:: pair_style lj/sf/dipole/sf/omp
 .. index:: pair_style lj/cut/dipole/long
 .. index:: pair_style lj/cut/dipole/long/gpu
+.. index:: pair_style lj/cut/dipole/long/omp
 .. index:: pair_style lj/long/dipole/long
 
 pair_style lj/cut/dipole/cut command
@@ -22,7 +23,7 @@ Accelerator Variants: *lj/sf/dipole/sf/gpu*, *lj/sf/dipole/sf/omp*
 pair_style lj/cut/dipole/long command
 =====================================
 
-Accelerator Variants: *lj/cut/dipole/long/gpu*
+Accelerator Variants: *lj/cut/dipole/long/gpu*, *lj/cut/dipole/long/omp*
 
 pair_style lj/long/dipole/long command
 ======================================

--- a/doc/src/pair_fep_soft.rst
+++ b/doc/src/pair_fep_soft.rst
@@ -11,16 +11,21 @@
 .. index:: pair_style lj/charmm/coul/long/soft
 .. index:: pair_style lj/charmm/coul/long/soft/omp
 .. index:: pair_style lj/class2/soft
+.. index:: pair_style lj/class2/soft/omp
 .. index:: pair_style lj/class2/coul/cut/soft
+.. index:: pair_style lj/class2/coul/cut/soft/omp
 .. index:: pair_style lj/class2/coul/long/soft
+.. index:: pair_style lj/class2/coul/long/soft/omp
 .. index:: pair_style coul/cut/soft
 .. index:: pair_style coul/cut/soft/omp
 .. index:: pair_style coul/cut/soft/gapsys
+.. index:: pair_style coul/cut/soft/gapsys/omp
 .. index:: pair_style coul/long/soft
 .. index:: pair_style coul/long/soft/omp
 .. index:: pair_style tip4p/long/soft
 .. index:: pair_style tip4p/long/soft/omp
 .. index:: pair_style morse/soft
+.. index:: pair_style morse/soft/omp
 
 pair_style lj/cut/soft command
 ==============================
@@ -50,11 +55,17 @@ Accelerator Variants: *lj/charmm/coul/long/soft/omp*
 pair_style lj/class2/soft command
 =================================
 
+Accelerator Variants: *lj/class2/soft/omp*
+
 pair_style lj/class2/coul/cut/soft command
 ==========================================
 
+Accelerator Variants: *lj/class2/coul/cut/soft/omp*
+
 pair_style lj/class2/coul/long/soft command
 ===========================================
+
+Accelerator Variants: *lj/class2/coul/long/soft/omp*
 
 pair_style coul/cut/soft command
 ================================
@@ -63,6 +74,8 @@ Accelerator Variants: *coul/cut/soft/omp*
 
 pair_style coul/cut/soft/gapsys command
 =======================================
+
+Accelerator Variants: *coul/cut/soft/gapsys/omp*
 
 pair_style coul/long/soft command
 =================================
@@ -76,6 +89,8 @@ Accelerator Variants: *tip4p/long/soft/omp*
 
 pair_style morse/soft command
 =============================
+
+Accelerator Variants: *morse/soft/omp*
 
 Syntax
 """"""

--- a/doc/src/pair_lj_expand.rst
+++ b/doc/src/pair_lj_expand.rst
@@ -5,6 +5,7 @@
 .. index:: pair_style lj/expand/coul/long
 .. index:: pair_style lj/expand/coul/long/kk
 .. index:: pair_style lj/expand/coul/long/gpu
+.. index:: pair_style lj/expand/coul/long/omp
 
 pair_style lj/expand command
 ============================
@@ -14,7 +15,7 @@ Accelerator Variants: *lj/expand/gpu*, *lj/expand/kk*, *lj/expand/omp*
 pair_style lj/expand/coul/long command
 ======================================
 
-Accelerator Variants: *lj/expand/coul/long/kk*, *lj/expand/coul/long/gpu*
+Accelerator Variants: *lj/expand/coul/long/kk*, *lj/expand/coul/long/gpu*, *lj/expand/coul/long/omp*
 
 Syntax
 """"""

--- a/doc/src/pair_nm.rst
+++ b/doc/src/pair_nm.rst
@@ -6,6 +6,7 @@
 .. index:: pair_style nm/cut/coul/long
 .. index:: pair_style nm/cut/coul/long/kk
 .. index:: pair_style nm/cut/omp
+.. index:: pair_style nm/cut/split/omp
 .. index:: pair_style nm/cut/coul/cut/omp
 .. index:: pair_style nm/cut/coul/long/omp
 
@@ -16,6 +17,8 @@ Accelerator Variants: *nm/cut/kk*, *nm/cut/omp*
 
 pair_style nm/cut/split command
 ===============================
+
+Accelerator Variants: *nm/cut/split/omp*
 
 pair_style nm/cut/coul/cut command
 ==================================

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1056,10 +1056,16 @@
 /fix_oneway.h
 /fix_orient_bcc.cpp
 /fix_orient_bcc.h
+/fix_orient_bcc_omp.cpp
+/fix_orient_bcc_omp.h
 /fix_orient_eco.cpp
 /fix_orient_eco.h
+/fix_orient_eco_omp.cpp
+/fix_orient_eco_omp.h
 /fix_orient_fcc.cpp
 /fix_orient_fcc.h
+/fix_orient_fcc_omp.cpp
+/fix_orient_fcc_omp.h
 /fix_oxdna_lrf.cpp
 /fix_oxdna_lrf.h
 /fix_peri_neigh.cpp

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1056,16 +1056,10 @@
 /fix_oneway.h
 /fix_orient_bcc.cpp
 /fix_orient_bcc.h
-/fix_orient_bcc_omp.cpp
-/fix_orient_bcc_omp.h
 /fix_orient_eco.cpp
 /fix_orient_eco.h
-/fix_orient_eco_omp.cpp
-/fix_orient_eco_omp.h
 /fix_orient_fcc.cpp
 /fix_orient_fcc.h
-/fix_orient_fcc_omp.cpp
-/fix_orient_fcc_omp.h
 /fix_oxdna_lrf.cpp
 /fix_oxdna_lrf.h
 /fix_peri_neigh.cpp

--- a/src/EXTRA-COMPUTE/compute_cnp_atom.h
+++ b/src/EXTRA-COMPUTE/compute_cnp_atom.h
@@ -33,7 +33,7 @@ class ComputeCNPAtom : public Compute {
   void compute_peratom() override;
   double memory_usage() override;
 
- private:
+ protected:
   //revise
   int nmax;
   double cutsq;

--- a/src/EXTRA-COMPUTE/compute_entropy_atom.h
+++ b/src/EXTRA-COMPUTE/compute_entropy_atom.h
@@ -33,7 +33,7 @@ class ComputeEntropyAtom : public Compute {
   void compute_peratom() override;
   double memory_usage() override;
 
- private:
+ protected:
   int nmax, maxneigh, nbin;
   class NeighList *list;
   double *pair_entropy, *pair_entropy_avg;

--- a/src/EXTRA-COMPUTE/compute_hexorder_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_hexorder_atom.cpp
@@ -237,7 +237,7 @@ void ComputeHexOrderAtom::compute_peratom()
 
 // calculate order parameter using std::complex::pow function
 
-inline void ComputeHexOrderAtom::calc_qn_complex(double delx, double dely, double &u, double &v) {
+void ComputeHexOrderAtom::calc_qn_complex(double delx, double dely, double &u, double &v) {
   double rinv = 1.0/sqrt(delx*delx+dely*dely);
   double x = delx*rinv;
   double y = dely*rinv;
@@ -250,7 +250,7 @@ inline void ComputeHexOrderAtom::calc_qn_complex(double delx, double dely, doubl
 // calculate order parameter using trig functions
 // this is usually slower, but can be used if <complex> not available
 
-inline void ComputeHexOrderAtom::calc_qn_trig(double delx, double dely, double &u, double &v) {
+void ComputeHexOrderAtom::calc_qn_trig(double delx, double dely, double &u, double &v) {
   double ntheta;
   if (fabs(delx) <= MY_EPSILON) {
     if (dely > 0.0) ntheta = ndegree * MY_PI / 2.0;

--- a/src/OPENMP/angle_cosine_buck6d_omp.cpp
+++ b/src/OPENMP/angle_cosine_buck6d_omp.cpp
@@ -1,0 +1,258 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "angle_cosine_buck6d_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "neighbor.h"
+#include "pair.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+using namespace LAMMPS_NS;
+
+static constexpr double SMALL = 0.001;
+
+/* ---------------------------------------------------------------------- */
+
+AngleCosineBuck6dOMP::AngleCosineBuck6dOMP(LAMMPS *lmp) :
+    AngleCosineBuck6d(lmp), ThrOMP(lmp, THR_ANGLE | THR_CHARMM)
+{
+  suffix_flag |= Suffix::OMP;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void AngleCosineBuck6dOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag, vflag);
+
+  // ensure pair->ev_tally() will use 1-3 virial contribution
+
+  if (vflag_global == VIRIAL_FDOTR)
+    force->pair->vflag_either = force->pair->vflag_global = 1;
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = neighbor->nanglelist;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag, vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, cvatom, thr);
+
+    if (inum > 0) {
+      if (evflag) {
+        if (eflag) {
+          if (force->newton_bond)
+            eval<1, 1, 1>(ifrom, ito, thr);
+          else
+            eval<1, 1, 0>(ifrom, ito, thr);
+        } else {
+          if (force->newton_bond)
+            eval<1, 0, 1>(ifrom, ito, thr);
+          else
+            eval<1, 0, 0>(ifrom, ito, thr);
+        }
+      } else {
+        if (force->newton_bond)
+          eval<0, 0, 1>(ifrom, ito, thr);
+        else
+          eval<0, 0, 0>(ifrom, ito, thr);
+      }
+    }
+    thr->timer(Timer::BOND);
+    reduce_thr(this, eflag, vflag, thr);
+  }    // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+void AngleCosineBuck6dOMP::eval(int nfrom, int nto, ThrData *const thr)
+{
+  int i1, i2, i3, n, type, itype, jtype;
+  double delx1, dely1, delz1, delx2, dely2, delz2;
+  double eangle, f1[3], f3[3];
+  double rsq1, rsq2, r1, r2, c, s, a, a11, a12, a22;
+  double tk;
+
+  // extra lj variables
+  double delx3, dely3, delz3, rsq3, r3;
+  double rexp, r32inv, r36inv, r314inv, forcebuck6d, fpair;
+  double term1, term2, term3, term4, term5, ebuck6d, evdwl;
+  double rcu, rqu, sme, smf;
+
+  eangle = 0.0;
+
+  const double *const *const x = atom->x;
+  double **const f = thr->get_f();
+  const int *const *const anglelist = neighbor->anglelist;
+  const int nlocal = atom->nlocal;
+  const int newton_pair = force->newton_pair;
+  const int *const atomtype = atom->type;
+
+  for (n = nfrom; n < nto; n++) {
+    i1 = anglelist[n][0];
+    i2 = anglelist[n][1];
+    i3 = anglelist[n][2];
+    type = anglelist[n][3];
+
+    // 1st bond
+
+    delx1 = x[i1][0] - x[i2][0];
+    dely1 = x[i1][1] - x[i2][1];
+    delz1 = x[i1][2] - x[i2][2];
+
+    rsq1 = delx1 * delx1 + dely1 * dely1 + delz1 * delz1;
+    r1 = sqrt(rsq1);
+
+    // 2nd bond
+
+    delx2 = x[i3][0] - x[i2][0];
+    dely2 = x[i3][1] - x[i2][1];
+    delz2 = x[i3][2] - x[i2][2];
+
+    rsq2 = delx2 * delx2 + dely2 * dely2 + delz2 * delz2;
+    r2 = sqrt(rsq2);
+
+    // c = cosine of angle
+
+    c = delx1 * delx2 + dely1 * dely2 + delz1 * delz2;
+    c /= r1 * r2;
+    if (c > 1.0) c = 1.0;
+    if (c < -1.0) c = -1.0;
+
+    s = sqrt(1.0 - c * c);
+    if (s < SMALL) s = SMALL;
+    s = 1.0 / s;
+
+    // force & energy
+
+    // explicit lj-contribution
+
+    itype = atomtype[i1];
+    jtype = atomtype[i3];
+
+    delx3 = x[i1][0] - x[i3][0];
+    dely3 = x[i1][1] - x[i3][1];
+    delz3 = x[i1][2] - x[i3][2];
+    rsq3 = delx3 * delx3 + dely3 * dely3 + delz3 * delz3;
+
+    r32inv = 0.0;
+    if (rsq3 < cut_ljsq[itype][jtype]) {
+      r3 = sqrt(rsq3);
+      r32inv = 1.0 / rsq3;
+      r36inv = r32inv * r32inv * r32inv;
+      r314inv = r36inv * r36inv * r32inv;
+      rexp = exp(-r3 * buck6d2[itype][jtype]);
+      term1 = buck6d3[itype][jtype] * r36inv;
+      term2 = buck6d4[itype][jtype] * r314inv;
+      term3 = term2 * term2;
+      term4 = 1.0 / (1.0 + term2);
+      term5 = 1.0 / (1.0 + 2.0 * term2 + term3);
+      forcebuck6d = buck6d1[itype][jtype] * buck6d2[itype][jtype] * r3 * rexp;
+      forcebuck6d -= term1 * (6.0 * term4 - term5 * 14.0 * term2);
+      ebuck6d = buck6d1[itype][jtype] * rexp - term1 * term4;
+
+      // smoothing term
+      if (rsq3 > rsmooth_sq[itype][jtype]) {
+        rcu = r3 * rsq3;
+        rqu = rsq3 * rsq3;
+        sme = c5[itype][jtype] * rqu * r3 + c4[itype][jtype] * rqu + c3[itype][jtype] * rcu +
+            c2[itype][jtype] * rsq3 + c1[itype][jtype] * r3 + c0[itype][jtype];
+        smf = 5.0 * c5[itype][jtype] * rqu + 4.0 * c4[itype][jtype] * rcu +
+            3.0 * c3[itype][jtype] * rsq3 + 2.0 * c2[itype][jtype] * r3 + c1[itype][jtype];
+        forcebuck6d = forcebuck6d * sme + ebuck6d * smf;
+        ebuck6d *= sme;
+      }
+    } else
+      forcebuck6d = 0.0;
+
+    // add forces of additional LJ interaction
+
+    fpair = forcebuck6d * r32inv;
+    if (newton_pair || i1 < nlocal) {
+      f[i1][0] += delx3 * fpair;
+      f[i1][1] += dely3 * fpair;
+      f[i1][2] += delz3 * fpair;
+    }
+    if (newton_pair || i3 < nlocal) {
+      f[i3][0] -= delx3 * fpair;
+      f[i3][1] -= dely3 * fpair;
+      f[i3][2] -= delz3 * fpair;
+    }
+
+    evdwl = 0.0;
+    if (EFLAG) {
+      if (rsq3 < cut_ljsq[itype][jtype]) { evdwl = ebuck6d - offset[itype][jtype]; }
+    }
+
+    // update pair energy and virial via per-thread pair accumulators
+
+    if (EVFLAG)
+      ev_tally_thr(force->pair, i1, i3, nlocal, newton_pair, evdwl, 0.0, fpair, delx3, dely3, delz3,
+                   thr);
+
+    tk = multiplicity[type] * acos(c) - th0[type];
+
+    if (EFLAG) eangle = k[type] * (1.0 + cos(tk));
+
+    a = k[type] * multiplicity[type] * sin(tk) * s;
+
+    a11 = a * c / rsq1;
+    a12 = -a / (r1 * r2);
+    a22 = a * c / rsq2;
+
+    f1[0] = a11 * delx1 + a12 * delx2;
+    f1[1] = a11 * dely1 + a12 * dely2;
+    f1[2] = a11 * delz1 + a12 * delz2;
+    f3[0] = a22 * delx2 + a12 * delx1;
+    f3[1] = a22 * dely2 + a12 * dely1;
+    f3[2] = a22 * delz2 + a12 * delz1;
+
+    // apply force to each of 3 atoms
+
+    if (NEWTON_BOND || i1 < nlocal) {
+      f[i1][0] += f1[0];
+      f[i1][1] += f1[1];
+      f[i1][2] += f1[2];
+    }
+
+    if (NEWTON_BOND || i2 < nlocal) {
+      f[i2][0] -= f1[0] + f3[0];
+      f[i2][1] -= f1[1] + f3[1];
+      f[i2][2] -= f1[2] + f3[2];
+    }
+
+    if (NEWTON_BOND || i3 < nlocal) {
+      f[i3][0] += f3[0];
+      f[i3][1] += f3[1];
+      f[i3][2] += f3[2];
+    }
+
+    if (EVFLAG)
+      ev_tally_thr(this, i1, i2, i3, nlocal, NEWTON_BOND, eangle, f1, f3, delx1, dely1, delz1, delx2,
+                   dely2, delz2, thr);
+  }
+}

--- a/src/OPENMP/angle_cosine_buck6d_omp.h
+++ b/src/OPENMP/angle_cosine_buck6d_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef ANGLE_CLASS
+// clang-format off
+AngleStyle(cosine/buck6d/omp,AngleCosineBuck6dOMP);
+// clang-format on
+#else
+
+#ifndef LMP_ANGLE_COSINE_BUCK6D_OMP_H
+#define LMP_ANGLE_COSINE_BUCK6D_OMP_H
+
+#include "angle_cosine_buck6d.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class AngleCosineBuck6dOMP : public AngleCosineBuck6d, public ThrOMP {
+ public:
+  AngleCosineBuck6dOMP(class LAMMPS *lmp);
+  void compute(int, int) override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_BOND>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/compute_ackland_atom_omp.cpp
+++ b/src/OPENMP/compute_ackland_atom_omp.cpp
@@ -1,0 +1,296 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "compute_ackland_atom_omp.h"
+
+#include "atom.h"
+#include "force.h"
+#include "memory.h"
+#include "neigh_list.h"
+#include "neighbor.h"
+#include "pair.h"
+#include "update.h"
+
+#include <cmath>
+
+using namespace LAMMPS_NS;
+
+// this mirrors the file-static enum in compute_ackland_atom.cpp
+
+enum { UNKNOWN, BCC, FCC, HCP, ICO };
+
+/* ---------------------------------------------------------------------- */
+
+ComputeAcklandAtomOMP::ComputeAcklandAtomOMP(LAMMPS *lmp, int narg, char **arg) :
+    ComputeAcklandAtom(lmp, narg, arg)
+{
+}
+
+/* ----------------------------------------------------------------------
+   threaded variant of ComputeAcklandAtom::compute_peratom().  The per-atom
+   neighbor scratch (distsq/nearest/nearest_n0/nearest_n1) is allocated
+   thread-locally inside the parallel region, sized to the largest neighbor
+   count over the looped atoms; the chi[] histogram is per-iteration local.
+   select2() is reentrant given thread-private scratch, and each atom writes
+   only its own output structure[i], so the result is bit-identical to the
+   serial compute.
+------------------------------------------------------------------------- */
+
+void ComputeAcklandAtomOMP::compute_peratom()
+{
+  invoked_peratom = update->ntimestep;
+
+  // grow structure array if necessary
+
+  if (atom->nmax > nmax) {
+    memory->destroy(structure);
+    nmax = atom->nmax;
+    memory->create(structure, nmax, "compute/ackland/atom:ackland");
+    vector_atom = structure;
+  }
+
+  // invoke full neighbor list (will copy or build if necessary)
+
+  neighbor->build_one(list);
+
+  const int inum = list->inum;
+  const int *const ilist = list->ilist;
+  const int *const numneigh = list->numneigh;
+  const int *const *const firstneigh = list->firstneigh;
+
+  // compute structure parameter for each atom in group
+  // use full neighbor list
+
+  const double *const *const x = atom->x;
+  const int *const mask = atom->mask;
+  const double cutsq = force->pair->cutforce * force->pair->cutforce;
+
+  // largest neighbor count over the looped atoms, for sizing thread scratch
+
+  int maxn = 1;
+  for (int ii = 0; ii < inum; ii++) {
+    const int jnum = numneigh[ilist[ii]];
+    if (jnum > maxn) maxn = jnum;
+  }
+
+#if defined(_OPENMP)
+#pragma omp parallel
+#endif
+  {
+    auto *const t_distsq = new double[maxn];
+    auto *const t_nearest = new int[maxn];
+    auto *const t_nearest_n0 = new int[maxn];
+    auto *const t_nearest_n1 = new int[maxn];
+
+#if defined(_OPENMP)
+#pragma omp for schedule(dynamic)
+#endif
+    for (int ii = 0; ii < inum; ii++) {
+      const int i = ilist[ii];
+      if (mask[i] & groupbit) {
+        const double xtmp = x[i][0];
+        const double ytmp = x[i][1];
+        const double ztmp = x[i][2];
+        const int *const jlist = firstneigh[i];
+        const int jnum = numneigh[i];
+
+        // loop over list of all neighbors within force cutoff
+        // t_distsq[] = distance sq to each
+        // t_nearest[] = atom indices of neighbors
+
+        int n = 0;
+        for (int jj = 0; jj < jnum; jj++) {
+          const int j = jlist[jj] & NEIGHMASK;
+          const double delx = xtmp - x[j][0];
+          const double dely = ytmp - x[j][1];
+          const double delz = ztmp - x[j][2];
+          const double rsq = delx * delx + dely * dely + delz * delz;
+          if (rsq < cutsq) {
+            t_distsq[n] = rsq;
+            t_nearest[n++] = j;
+          }
+        }
+
+        // Select 6 nearest neighbors
+
+        select2(6, n, t_distsq, t_nearest);
+
+        // Mean squared separation
+
+        double r0_sq = 0.;
+        for (int j = 0; j < 6; j++) r0_sq += t_distsq[j];
+        r0_sq /= 6.;
+
+        // n0 near neighbors with: distsq<1.45*r0_sq
+        // n1 near neighbors with: distsq<1.55*r0_sq
+
+        double n0_dist_sq = 1.45 * r0_sq, n1_dist_sq = 1.55 * r0_sq;
+        int n0 = 0, n1 = 0;
+        for (int j = 0; j < n; j++) {
+          if (t_distsq[j] < n1_dist_sq) {
+            t_nearest_n1[n1++] = t_nearest[j];
+            if (t_distsq[j] < n0_dist_sq) { t_nearest_n0[n0++] = t_nearest[j]; }
+          }
+        }
+
+        // Evaluate all angles <(r_ij,rik) forall n0 particles with:
+        // distsq < 1.45*r0_sq
+
+        int chi[8];
+        chi[0] = chi[1] = chi[2] = chi[3] = chi[4] = chi[5] = chi[6] = chi[7] = 0;
+        for (int j = 0; j < n0; j++) {
+          const double x_ij = x[i][0] - x[t_nearest_n0[j]][0];
+          const double y_ij = x[i][1] - x[t_nearest_n0[j]][1];
+          const double z_ij = x[i][2] - x[t_nearest_n0[j]][2];
+          const double norm_j = sqrt(x_ij * x_ij + y_ij * y_ij + z_ij * z_ij);
+          if (norm_j <= 0.) continue;
+          for (int k = j + 1; k < n0; k++) {
+            const double x_ik = x[i][0] - x[t_nearest_n0[k]][0];
+            const double y_ik = x[i][1] - x[t_nearest_n0[k]][1];
+            const double z_ik = x[i][2] - x[t_nearest_n0[k]][2];
+            const double norm_k = sqrt(x_ik * x_ik + y_ik * y_ik + z_ik * z_ik);
+            if (norm_k <= 0.) continue;
+
+            const double bond_angle =
+                (x_ij * x_ik + y_ij * y_ik + z_ij * z_ik) / (norm_j * norm_k);
+
+            // Histogram for identifying the relevant peaks
+
+            if (bond_angle < -0.945)
+              chi[0]++;
+            else if (bond_angle < -0.915)
+              chi[1]++;
+            else if (bond_angle < -0.755)
+              chi[2]++;
+            else if (bond_angle < -0.195)
+              chi[3]++;
+            else if (bond_angle < 0.195)
+              chi[4]++;
+            else if (bond_angle < 0.245)
+              chi[5]++;
+            else if (bond_angle < 0.795)
+              chi[6]++;
+            else
+              chi[7]++;
+          }
+        }
+
+        if (legacy) {
+
+          // This is the original implementation by Gerolf Ziegenhain
+          // Deviations from the different lattice structures
+
+          double delta_bcc = 0.35 * chi[4] / (double) (chi[5] + chi[6] - chi[4]);
+          double delta_cp = fabs(1. - (double) chi[6] / 24.);
+          double delta_fcc = 0.61 * (fabs((double) (chi[0] + chi[1] - 6.)) + (double) chi[2]) / 6.0;
+          double delta_hcp = (fabs((double) chi[0] - 3.) +
+                              fabs((double) chi[0] + (double) chi[1] + (double) chi[2] +
+                                   (double) chi[3] - 9.0)) /
+              12.0;
+
+          // Identification of the local structure according to the reference
+
+          if (chi[0] == 7) {
+            delta_bcc = 0.;
+          } else if (chi[0] == 6) {
+            delta_fcc = 0.;
+          } else if (chi[0] <= 3) {
+            delta_hcp = 0.;
+          }
+
+          if (chi[7] > 0.)
+            structure[i] = UNKNOWN;
+          else if (chi[4] < 3.) {
+            if (n1 > 13 || n1 < 11)
+              structure[i] = UNKNOWN;
+            else
+              structure[i] = ICO;
+          } else if (delta_bcc <= delta_cp) {
+            if (n1 < 11)
+              structure[i] = UNKNOWN;
+            else
+              structure[i] = BCC;
+          } else if (n1 > 12 || n1 < 11)
+            structure[i] = UNKNOWN;
+          else if (delta_fcc < delta_hcp)
+            structure[i] = FCC;
+          else
+            structure[i] = HCP;
+
+        } else {
+
+          // This is the updated implementation by Brian Barnes
+
+          if (chi[7] > 0 || n0 < 11)
+            structure[i] = UNKNOWN;
+          else if (chi[0] == 7)
+            structure[i] = BCC;
+          else if (chi[0] == 6)
+            structure[i] = FCC;
+          else if (chi[0] == 3)
+            structure[i] = HCP;
+          else {
+            // Deviations from the different lattice structures
+
+            double delta_cp = fabs(1. - (double) chi[6] / 24.);
+
+            // ensure we do not get divide by zero
+            // and if we will, make delta_bcc irrelevant
+            double delta_bcc = delta_cp + 1.0;
+            int chi56m4 = chi[5] + chi[6] - chi[4];
+
+            // note that chi[7] presumed zero
+            if (chi56m4 != 0) delta_bcc = 0.35 * chi[4] / (double) chi56m4;
+
+            double delta_fcc = 0.61 * (fabs((double) (chi[0] + chi[1] - 6)) + (double) chi[2]) / 6.0;
+
+            double delta_hcp = (fabs((double) chi[0] - 3.) +
+                                fabs((double) chi[0] + (double) chi[1] + (double) chi[2] +
+                                     (double) chi[3] - 9.0)) /
+                12.0;
+
+            // Identification of the local structure according to the reference
+
+            if (delta_bcc >= 0.1 && delta_cp >= 0.1 && delta_fcc >= 0.1 && delta_hcp >= 0.1)
+              structure[i] = UNKNOWN;
+
+            // not part of Ackland-Jones 2006; included for backward compatibility
+            if (chi[4] < 3. && n1 == 12)
+              structure[i] = ICO;
+
+            else {
+              if (delta_bcc <= delta_cp && n1 > 10 && n1 < 13)
+                structure[i] = BCC;
+              else {
+                if (n0 > 12)
+                  structure[i] = UNKNOWN;
+                else {
+                  if (delta_fcc < delta_hcp)
+                    structure[i] = FCC;
+                  else
+                    structure[i] = HCP;
+                }
+              }
+            }
+          }
+        }
+      } else
+        structure[i] = 0.0;
+    }
+
+    delete[] t_distsq;
+    delete[] t_nearest;
+    delete[] t_nearest_n0;
+    delete[] t_nearest_n1;
+  }
+}

--- a/src/OPENMP/compute_ackland_atom_omp.h
+++ b/src/OPENMP/compute_ackland_atom_omp.h
@@ -13,35 +13,21 @@
 
 #ifdef COMPUTE_CLASS
 // clang-format off
-ComputeStyle(ackland/atom,ComputeAcklandAtom);
+ComputeStyle(ackland/atom/omp,ComputeAcklandAtomOMP);
 // clang-format on
 #else
 
-#ifndef LMP_COMPUTE_ACKLAND_ATOM_H
-#define LMP_COMPUTE_ACKLAND_ATOM_H
+#ifndef LMP_COMPUTE_ACKLAND_ATOM_OMP_H
+#define LMP_COMPUTE_ACKLAND_ATOM_OMP_H
 
-#include "compute.h"
+#include "compute_ackland_atom.h"
 
 namespace LAMMPS_NS {
 
-class ComputeAcklandAtom : public Compute {
+class ComputeAcklandAtomOMP : public ComputeAcklandAtom {
  public:
-  ComputeAcklandAtom(class LAMMPS *, int, char **);
-  ~ComputeAcklandAtom() override;
-  void init() override;
-  void init_list(int, class NeighList *) override;
+  ComputeAcklandAtomOMP(class LAMMPS *, int, char **);
   void compute_peratom() override;
-  double memory_usage() override;
-
- protected:
-  int nmax, maxneigh, legacy;
-  double *distsq;
-  int *nearest, *nearest_n0, *nearest_n1;
-  double *structure;
-  class NeighList *list;
-
-  void select(int, int, double *);
-  void select2(int, int, double *, int *);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/OPENMP/compute_ave_sphere_atom_omp.cpp
+++ b/src/OPENMP/compute_ave_sphere_atom_omp.cpp
@@ -1,0 +1,158 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "compute_ave_sphere_atom_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "domain.h"
+#include "force.h"
+#include "memory.h"
+#include "neigh_list.h"
+#include "neighbor.h"
+#include "update.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+ComputeAveSphereAtomOMP::ComputeAveSphereAtomOMP(LAMMPS *lmp, int narg, char **arg) :
+    ComputeAveSphereAtom(lmp, narg, arg)
+{
+}
+
+/* ----------------------------------------------------------------------
+   threaded variant of ComputeAveSphereAtom::compute_peratom().  All per-atom
+   scratch (p/vcom/vnet/count) is stack-local per iteration; ghost velocities
+   are forward-communicated (serial) before the threaded loop.  Each atom
+   writes only its own output row result[i], so the result is bit-identical
+   to the serial compute.
+------------------------------------------------------------------------- */
+
+void ComputeAveSphereAtomOMP::compute_peratom()
+{
+  invoked_peratom = update->ntimestep;
+
+  // grow result array if necessary
+
+  if (atom->nmax > nmax) {
+    memory->destroy(result);
+    nmax = atom->nmax;
+    memory->create(result, nmax, 2, "ave/sphere/atom:result");
+    array_atom = result;
+  }
+
+  // need velocities of ghost atoms
+
+  comm->forward_comm(this);
+
+  // invoke full neighbor list (will copy or build if necessary)
+
+  neighbor->build_one(list);
+
+  const int inum = list->inum;
+  const int *const ilist = list->ilist;
+  const int *const numneigh = list->numneigh;
+  const int *const *const firstneigh = list->firstneigh;
+
+  // compute properties for each atom in group
+  // use full neighbor list to count atoms less than cutoff
+
+  const double *const *const x = atom->x;
+  const double *const *const v = atom->v;
+  const double *const mass = atom->mass;
+  const double *const rmass = atom->rmass;
+  const int *const type = atom->type;
+  const int *const mask = atom->mask;
+
+  const double adof = domain->dimension;
+  const double mvv2e = force->mvv2e;
+  const double mv2d = force->mv2d;
+  const double boltz = force->boltz;
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(dynamic)
+#endif
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+
+    if (mask[i] & groupbit) {
+      const double massone_i = rmass ? rmass[i] : mass[type[i]];
+
+      const double xtmp = x[i][0];
+      const double ytmp = x[i][1];
+      const double ztmp = x[i][2];
+      const int *const jlist = firstneigh[i];
+      const int jnum = numneigh[i];
+
+      // i atom contribution
+
+      int count = 1;
+      double totalmass = massone_i;
+      double p[3];
+      p[0] = v[i][0] * massone_i;
+      p[1] = v[i][1] * massone_i;
+      p[2] = v[i][2] * massone_i;
+
+      for (int jj = 0; jj < jnum; jj++) {
+        const int j = jlist[jj] & NEIGHMASK;
+        const double massone_j = rmass ? rmass[j] : mass[type[j]];
+
+        const double delx = xtmp - x[j][0];
+        const double dely = ytmp - x[j][1];
+        const double delz = ztmp - x[j][2];
+        const double rsq = delx * delx + dely * dely + delz * delz;
+        if (rsq < cutsq) {
+          count++;
+          totalmass += massone_j;
+          p[0] += v[j][0] * massone_j;
+          p[1] += v[j][1] * massone_j;
+          p[2] += v[j][2] * massone_j;
+        }
+      }
+
+      double vcom[3];
+      vcom[0] = p[0] / totalmass;
+      vcom[1] = p[1] / totalmass;
+      vcom[2] = p[2] / totalmass;
+
+      // i atom contribution
+
+      double vnet[3];
+      vnet[0] = v[i][0] - vcom[0];
+      vnet[1] = v[i][1] - vcom[1];
+      vnet[2] = v[i][2] - vcom[2];
+      double ke_sum = massone_i * (vnet[0] * vnet[0] + vnet[1] * vnet[1] + vnet[2] * vnet[2]);
+
+      for (int jj = 0; jj < jnum; jj++) {
+        const int j = jlist[jj] & NEIGHMASK;
+        const double massone_j = rmass ? rmass[j] : mass[type[j]];
+
+        const double delx = xtmp - x[j][0];
+        const double dely = ytmp - x[j][1];
+        const double delz = ztmp - x[j][2];
+        const double rsq = delx * delx + dely * dely + delz * delz;
+        if (rsq < cutsq) {
+          vnet[0] = v[j][0] - vcom[0];
+          vnet[1] = v[j][1] - vcom[1];
+          vnet[2] = v[j][2] - vcom[2];
+          ke_sum += massone_j * (vnet[0] * vnet[0] + vnet[1] * vnet[1] + vnet[2] * vnet[2]);
+        }
+      }
+      const double density = mv2d * totalmass / volume;
+      const double temp = mvv2e * ke_sum / (adof * count * boltz);
+      result[i][0] = density;
+      result[i][1] = temp;
+    }
+  }
+}

--- a/src/OPENMP/compute_ave_sphere_atom_omp.h
+++ b/src/OPENMP/compute_ave_sphere_atom_omp.h
@@ -13,35 +13,21 @@
 
 #ifdef COMPUTE_CLASS
 // clang-format off
-ComputeStyle(ackland/atom,ComputeAcklandAtom);
+ComputeStyle(ave/sphere/atom/omp,ComputeAveSphereAtomOMP);
 // clang-format on
 #else
 
-#ifndef LMP_COMPUTE_ACKLAND_ATOM_H
-#define LMP_COMPUTE_ACKLAND_ATOM_H
+#ifndef LMP_COMPUTE_AVE_SPHERE_ATOM_OMP_H
+#define LMP_COMPUTE_AVE_SPHERE_ATOM_OMP_H
 
-#include "compute.h"
+#include "compute_ave_sphere_atom.h"
 
 namespace LAMMPS_NS {
 
-class ComputeAcklandAtom : public Compute {
+class ComputeAveSphereAtomOMP : public ComputeAveSphereAtom {
  public:
-  ComputeAcklandAtom(class LAMMPS *, int, char **);
-  ~ComputeAcklandAtom() override;
-  void init() override;
-  void init_list(int, class NeighList *) override;
+  ComputeAveSphereAtomOMP(class LAMMPS *, int, char **);
   void compute_peratom() override;
-  double memory_usage() override;
-
- protected:
-  int nmax, maxneigh, legacy;
-  double *distsq;
-  int *nearest, *nearest_n0, *nearest_n1;
-  double *structure;
-  class NeighList *list;
-
-  void select(int, int, double *);
-  void select2(int, int, double *, int *);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/OPENMP/compute_centro_atom_omp.cpp
+++ b/src/OPENMP/compute_centro_atom_omp.cpp
@@ -1,0 +1,248 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "compute_centro_atom_omp.h"
+
+#include "atom.h"
+#include "force.h"
+#include "math_extra.h"
+#include "memory.h"
+#include "neigh_list.h"
+#include "neighbor.h"
+#include "pair.h"
+#include "update.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+ComputeCentroAtomOMP::ComputeCentroAtomOMP(LAMMPS *lmp, int narg, char **arg) :
+    ComputeCentroAtom(lmp, narg, arg)
+{
+}
+
+/* ----------------------------------------------------------------------
+   threaded variant of ComputeCentroAtom::compute_peratom().  The per-atom
+   neighbor scratch (distsq/nearest) and the pair-distance scratch (pairs)
+   are allocated thread-locally inside the parallel region, sized to the
+   largest neighbor count over the looped atoms.  The base select()/select2()
+   helpers are reentrant given thread-private scratch, and each atom writes
+   only its own output (centro[i] / array_atom[i]), so the result is
+   bit-identical to the serial compute.
+------------------------------------------------------------------------- */
+
+void ComputeCentroAtomOMP::compute_peratom()
+{
+  invoked_peratom = update->ntimestep;
+
+  // grow centro array if necessary
+  // grow array_atom array if axes_flag set
+
+  if (atom->nmax > nmax) {
+    if (!axes_flag) {
+      memory->destroy(centro);
+      nmax = atom->nmax;
+      memory->create(centro, nmax, "centro/atom:centro");
+      vector_atom = centro;
+    } else {
+      memory->destroy(centro);
+      memory->destroy(array_atom);
+      nmax = atom->nmax;
+      memory->create(centro, nmax, "centro/atom:centro");
+      memory->create(array_atom, nmax, size_peratom_cols, "centro/atom:array_atom");
+    }
+  }
+
+  // invoke full neighbor list (will copy or build if necessary)
+
+  neighbor->build_one(list);
+
+  const int inum = list->inum;
+  const int *const ilist = list->ilist;
+  const int *const numneigh = list->numneigh;
+  const int *const *const firstneigh = list->firstneigh;
+
+  // nhalf = number of pairs to sum, npairs = number of unique pairs
+
+  const int nhalf = nnn / 2;
+  const int npairs = nnn * (nnn - 1) / 2;
+
+  // compute centro-symmetry parameter for each atom in group
+  // use full neighbor list
+
+  const double *const *const x = atom->x;
+  const int *const mask = atom->mask;
+  const double cutsq = force->pair->cutforce * force->pair->cutforce;
+
+  // largest neighbor count over the looped atoms, for sizing thread scratch
+
+  int maxn = 1;
+  for (int ii = 0; ii < inum; ii++) {
+    const int jnum = numneigh[ilist[ii]];
+    if (jnum > maxn) maxn = jnum;
+  }
+
+#if defined(_OPENMP)
+#pragma omp parallel
+#endif
+  {
+    auto *const t_distsq = new double[maxn];
+    auto *const t_nearest = new int[maxn];
+    auto *const t_pairs = new double[npairs > 0 ? npairs : 1];
+
+#if defined(_OPENMP)
+#pragma omp for schedule(dynamic)
+#endif
+    for (int ii = 0; ii < inum; ii++) {
+      const int i = ilist[ii];
+      if (mask[i] & groupbit) {
+        const double xtmp = x[i][0];
+        const double ytmp = x[i][1];
+        const double ztmp = x[i][2];
+        const int *const jlist = firstneigh[i];
+        const int jnum = numneigh[i];
+
+        // loop over list of all neighbors within force cutoff
+        // t_distsq[] = distance sq to each
+        // t_nearest[] = atom indices of neighbors
+
+        int n = 0;
+        for (int jj = 0; jj < jnum; jj++) {
+          const int j = jlist[jj] & NEIGHMASK;
+          const double delx = xtmp - x[j][0];
+          const double dely = ytmp - x[j][1];
+          const double delz = ztmp - x[j][2];
+          const double rsq = delx * delx + dely * dely + delz * delz;
+          if (rsq < cutsq) {
+            t_distsq[n] = rsq;
+            t_nearest[n++] = j;
+          }
+        }
+
+        // check whether to include local crystal symmetry axes
+
+        if (!axes_flag) {
+
+          // if not nnn neighbors, centro = 0.0
+
+          if (n < nnn) {
+            centro[i] = 0.0;
+            continue;
+          }
+
+          // store nnn nearest neighs in 1st nnn locations of distsq and nearest
+
+          select2(nnn, n, t_distsq, t_nearest);
+
+          // R = Ri + Rj for each of npairs i,j pairs among nnn neighbors
+          // pairs = squared length of each R
+
+          int m = 0;
+          for (int j = 0; j < nnn; j++) {
+            const int jj = t_nearest[j];
+            for (int k = j + 1; k < nnn; k++) {
+              const int kk = t_nearest[k];
+              const double delx = x[jj][0] + x[kk][0] - 2.0 * xtmp;
+              const double dely = x[jj][1] + x[kk][1] - 2.0 * ytmp;
+              const double delz = x[jj][2] + x[kk][2] - 2.0 * ztmp;
+              t_pairs[m++] = delx * delx + dely * dely + delz * delz;
+            }
+          }
+
+        } else {
+
+          // calculate local crystal symmetry axes
+          // rsq1, rsq2 are two smallest values of R^2
+          // R1, R2 are corresponding vectors Ri - Rj
+          // R3 is normal to R1, R2
+
+          double *r1 = &array_atom[i][1];
+          double *r2 = &array_atom[i][4];
+          double *r3 = &array_atom[i][7];
+
+          if (n < nnn) {
+            centro[i] = 0.0;
+            MathExtra::zero3(r1);
+            MathExtra::zero3(r2);
+            MathExtra::zero3(r3);
+            continue;
+          }
+
+          // store nnn nearest neighs in 1st nnn locations of distsq and nearest
+
+          select2(nnn, n, t_distsq, t_nearest);
+
+          int m = 0;
+          double rsq1, rsq2;
+          rsq1 = rsq2 = cutsq;
+          for (int j = 0; j < nnn; j++) {
+            const int jj = t_nearest[j];
+            for (int k = j + 1; k < nnn; k++) {
+              const int kk = t_nearest[k];
+              const double delx = x[jj][0] + x[kk][0] - 2.0 * xtmp;
+              const double dely = x[jj][1] + x[kk][1] - 2.0 * ytmp;
+              const double delz = x[jj][2] + x[kk][2] - 2.0 * ztmp;
+              const double rsq = delx * delx + dely * dely + delz * delz;
+              t_pairs[m++] = rsq;
+
+              if (rsq < rsq2) {
+                if (rsq < rsq1) {
+                  rsq2 = rsq1;
+                  MathExtra::copy3(r1, r2);
+                  rsq1 = rsq;
+                  MathExtra::sub3(x[jj], x[kk], r1);
+                } else {
+                  rsq2 = rsq;
+                  MathExtra::sub3(x[jj], x[kk], r2);
+                }
+              }
+            }
+          }
+
+          MathExtra::cross3(r1, r2, r3);
+          MathExtra::norm3(r1);
+          MathExtra::norm3(r2);
+          MathExtra::norm3(r3);
+        }
+
+        // store nhalf smallest pair distances in 1st nhalf locations of pairs
+
+        select(nhalf, npairs, t_pairs);
+
+        // centrosymmetry = sum of nhalf smallest squared values
+
+        double value = 0.0;
+        for (int j = 0; j < nhalf; j++) value += t_pairs[j];
+        centro[i] = value;
+
+      } else {
+        centro[i] = 0.0;
+        if (axes_flag) {
+          MathExtra::zero3(&array_atom[i][1]);
+          MathExtra::zero3(&array_atom[i][4]);
+          MathExtra::zero3(&array_atom[i][7]);
+        }
+      }
+    }
+
+    delete[] t_distsq;
+    delete[] t_nearest;
+    delete[] t_pairs;
+  }
+
+  if (axes_flag)
+    for (int ii = 0; ii < inum; ii++) {
+      const int i = ilist[ii];
+      if (mask[i] & groupbit) array_atom[i][0] = centro[i];
+    }
+}

--- a/src/OPENMP/compute_centro_atom_omp.h
+++ b/src/OPENMP/compute_centro_atom_omp.h
@@ -13,38 +13,21 @@
 
 #ifdef COMPUTE_CLASS
 // clang-format off
-ComputeStyle(hexorder/atom,ComputeHexOrderAtom);
+ComputeStyle(centro/atom/omp,ComputeCentroAtomOMP);
 // clang-format on
 #else
 
-#ifndef LMP_COMPUTE_HEXORDER_ATOM_H
-#define LMP_COMPUTE_HEXORDER_ATOM_H
+#ifndef LMP_COMPUTE_CENTRO_ATOM_OMP_H
+#define LMP_COMPUTE_CENTRO_ATOM_OMP_H
 
-#include "compute.h"
+#include "compute_centro_atom.h"
 
 namespace LAMMPS_NS {
 
-class ComputeHexOrderAtom : public Compute {
+class ComputeCentroAtomOMP : public ComputeCentroAtom {
  public:
-  ComputeHexOrderAtom(class LAMMPS *, int, char **);
-  ~ComputeHexOrderAtom() override;
-  void init() override;
-  void init_list(int, class NeighList *) override;
+  ComputeCentroAtomOMP(class LAMMPS *, int, char **);
   void compute_peratom() override;
-  double memory_usage() override;
-
- protected:
-  int nmax, maxneigh, ncol, nnn, ndegree;
-  double cutsq;
-  class NeighList *list;
-  double *distsq;
-  int *nearest;
-
-  double **qnarray;
-
-  void calc_qn_complex(double, double, double &, double &);
-  void calc_qn_trig(double, double, double &, double &);
-  void select2(int, int, double *, int *);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/OPENMP/compute_cna_atom_omp.cpp
+++ b/src/OPENMP/compute_cna_atom_omp.cpp
@@ -1,0 +1,307 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "compute_cna_atom_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "error.h"
+#include "memory.h"
+#include "neigh_list.h"
+#include "neighbor.h"
+#include "update.h"
+
+using namespace LAMMPS_NS;
+
+// these mirror the file-static constants in compute_cna_atom.cpp
+
+static constexpr int MAXNEAR = 16;
+static constexpr int MAXCOMMON = 8;
+
+enum { UNKNOWN, FCC, HCP, BCC, ICOS, OTHER };
+enum { NCOMMON, NBOND, MAXBOND, MINBOND };
+
+/* ---------------------------------------------------------------------- */
+
+ComputeCNAAtomOMP::ComputeCNAAtomOMP(LAMMPS *lmp, int narg, char **arg) :
+    ComputeCNAAtom(lmp, narg, arg)
+{
+}
+
+/* ----------------------------------------------------------------------
+   threaded variant of ComputeCNAAtom::compute_peratom().  Two threaded
+   phases: phase 1 fills the per-atom nearest[]/nnearest[] lists (each atom
+   writes only its own row), phase 2 classifies each atom reading its
+   neighbors' rows.  The implicit barrier between the two omp-for regions
+   guarantees all rows are built before classification.  The classification
+   scratch (cna/onenearest/common/bonds) is thread-private.  Each atom writes
+   only its own pattern[i], so the result is bit-identical to the serial
+   compute.  The two "too many neighbors" counters are summed across threads
+   and then MPI-reduced (collective calls stay outside the parallel region).
+------------------------------------------------------------------------- */
+
+void ComputeCNAAtomOMP::compute_peratom()
+{
+  invoked_peratom = update->ntimestep;
+
+  // grow arrays if necessary
+
+  if (atom->nmax > nmax) {
+    memory->destroy(nearest);
+    memory->destroy(nnearest);
+    memory->destroy(pattern);
+    nmax = atom->nmax;
+
+    memory->create(nearest, nmax, MAXNEAR, "cna:nearest");
+    memory->create(nnearest, nmax, "cna:nnearest");
+    memory->create(pattern, nmax, "cna:cna_pattern");
+    vector_atom = pattern;
+  }
+
+  // invoke full neighbor list (will copy or build if necessary)
+
+  neighbor->build_one(list);
+
+  const int inum = list->inum;
+  const int *const ilist = list->ilist;
+  const int *const numneigh = list->numneigh;
+  const int *const *const firstneigh = list->firstneigh;
+
+  // find the neighbors of each atom within cutoff using full neighbor list
+  // nearest[] = atom indices of nearest neighbors, up to MAXNEAR
+  // do this for all atoms, not just compute group
+  // since CNA calculation requires neighbors of neighbors
+
+  const double *const *const x = atom->x;
+  const int *const mask = atom->mask;
+  const int nlocal = atom->nlocal;
+
+  int nerror = 0;
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(dynamic) reduction(+ : nerror)
+#endif
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    const double xtmp = x[i][0];
+    const double ytmp = x[i][1];
+    const double ztmp = x[i][2];
+    const int *const jlist = firstneigh[i];
+    const int jnum = numneigh[i];
+
+    int n = 0;
+    for (int jj = 0; jj < jnum; jj++) {
+      const int j = jlist[jj] & NEIGHMASK;
+      const double delx = xtmp - x[j][0];
+      const double dely = ytmp - x[j][1];
+      const double delz = ztmp - x[j][2];
+      const double rsq = delx * delx + dely * dely + delz * delz;
+      if (rsq < cutsq) {
+        if (n < MAXNEAR)
+          nearest[i][n++] = j;
+        else {
+          nerror++;
+          break;
+        }
+      }
+    }
+    nnearest[i] = n;
+  }
+
+  // warning message
+
+  int nerrorall;
+  MPI_Allreduce(&nerror, &nerrorall, 1, MPI_INT, MPI_SUM, world);
+  if (nerrorall && comm->me == 0)
+    error->warning(FLERR, "Too many neighbors in CNA for {} atoms", nerrorall);
+
+  // compute CNA for each atom in group
+  // only performed if # of nearest neighbors = 12 or 14 (fcc,hcp)
+
+  nerror = 0;
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(dynamic) reduction(+ : nerror)
+#endif
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+
+    if (!(mask[i] & groupbit)) {
+      pattern[i] = UNKNOWN;
+      continue;
+    }
+
+    if (nnearest[i] != 12 && nnearest[i] != 14) {
+      pattern[i] = OTHER;
+      continue;
+    }
+
+    // per-thread scratch
+
+    int cna[MAXNEAR][4], onenearest[MAXNEAR];
+    int common[MAXCOMMON], bonds[MAXCOMMON];
+
+    // loop over near neighbors of I to build cna data structure
+    // cna[k][NCOMMON] = # of common neighbors of I with each of its neighs
+    // cna[k][NBONDS] = # of bonds between those common neighbors
+    // cna[k][MAXBOND] = max # of bonds of any common neighbor
+    // cna[k][MINBOND] = min # of bonds of any common neighbor
+
+    for (int m = 0; m < nnearest[i]; m++) {
+      const int jatom = nearest[i][m];
+
+      // common = list of neighbors common to atom I and atom J
+      // if J is an owned atom, use its near neighbor list to find them
+      // if J is a ghost atom, use full neighbor list of I to find them
+      // in latter case, must exclude J from I's neighbor list
+
+      int firstflag, ncommon;
+      if (jatom < nlocal) {
+        firstflag = 1;
+        ncommon = 0;
+        for (int inear = 0; inear < nnearest[i]; inear++)
+          for (int jnear = 0; jnear < nnearest[jatom]; jnear++)
+            if (nearest[i][inear] == nearest[jatom][jnear]) {
+              if (ncommon < MAXCOMMON)
+                common[ncommon++] = nearest[i][inear];
+              else if (firstflag) {
+                nerror++;
+                firstflag = 0;
+              }
+            }
+
+      } else {
+        const double xtmp = x[jatom][0];
+        const double ytmp = x[jatom][1];
+        const double ztmp = x[jatom][2];
+        const int *const jlist = firstneigh[i];
+        const int jnum = numneigh[i];
+
+        int n = 0;
+        for (int kk = 0; kk < jnum; kk++) {
+          const int k = jlist[kk] & NEIGHMASK;
+          if (k == jatom) continue;
+
+          const double delx = xtmp - x[k][0];
+          const double dely = ytmp - x[k][1];
+          const double delz = ztmp - x[k][2];
+          const double rsq = delx * delx + dely * dely + delz * delz;
+          if (rsq < cutsq) {
+            if (n < MAXNEAR)
+              onenearest[n++] = k;
+            else
+              break;
+          }
+        }
+
+        firstflag = 1;
+        ncommon = 0;
+        for (int inear = 0; inear < nnearest[i]; inear++)
+          for (int jnear = 0; (jnear < n) && (n < MAXNEAR); jnear++)
+            if (nearest[i][inear] == onenearest[jnear]) {
+              if (ncommon < MAXCOMMON)
+                common[ncommon++] = nearest[i][inear];
+              else if (firstflag) {
+                nerror++;
+                firstflag = 0;
+              }
+            }
+      }
+
+      cna[m][NCOMMON] = ncommon;
+
+      // calculate total # of bonds between common neighbor atoms
+      // also max and min # of common atoms any common atom is bonded to
+      // bond = pair of atoms within cutoff
+
+      for (int n = 0; n < ncommon; n++) bonds[n] = 0;
+
+      int nbonds = 0;
+      for (int jj = 0; jj < ncommon - 1; jj++) {
+        const int j = common[jj];
+        const double xtmp = x[j][0];
+        const double ytmp = x[j][1];
+        const double ztmp = x[j][2];
+        for (int kk = jj + 1; kk < ncommon; kk++) {
+          const int k = common[kk];
+          const double delx = xtmp - x[k][0];
+          const double dely = ytmp - x[k][1];
+          const double delz = ztmp - x[k][2];
+          const double rsq = delx * delx + dely * dely + delz * delz;
+          if (rsq < cutsq) {
+            nbonds++;
+            bonds[jj]++;
+            bonds[kk]++;
+          }
+        }
+      }
+
+      cna[m][NBOND] = nbonds;
+
+      int maxbonds = 0;
+      int minbonds = MAXCOMMON;
+      for (int n = 0; n < ncommon; n++) {
+        maxbonds = MAX(bonds[n], maxbonds);
+        minbonds = MIN(bonds[n], minbonds);
+      }
+      cna[m][MAXBOND] = maxbonds;
+      cna[m][MINBOND] = minbonds;
+    }
+
+    // detect CNA pattern of the atom
+
+    int nfcc, nhcp, nbcc4, nbcc6, nico;
+    nfcc = nhcp = nbcc4 = nbcc6 = nico = 0;
+    pattern[i] = OTHER;
+
+    if (nnearest[i] == 12) {
+      for (int inear = 0; inear < 12; inear++) {
+        const int cj = cna[inear][NCOMMON];
+        const int ck = cna[inear][NBOND];
+        const int cl = cna[inear][MAXBOND];
+        const int cm = cna[inear][MINBOND];
+        if (cj == 4 && ck == 2 && cl == 1 && cm == 1)
+          nfcc++;
+        else if (cj == 4 && ck == 2 && cl == 2 && cm == 0)
+          nhcp++;
+        else if (cj == 5 && ck == 5 && cl == 2 && cm == 2)
+          nico++;
+      }
+      if (nfcc == 12)
+        pattern[i] = FCC;
+      else if (nfcc == 6 && nhcp == 6)
+        pattern[i] = HCP;
+      else if (nico == 12)
+        pattern[i] = ICOS;
+
+    } else if (nnearest[i] == 14) {
+      for (int inear = 0; inear < 14; inear++) {
+        const int cj = cna[inear][NCOMMON];
+        const int ck = cna[inear][NBOND];
+        const int cl = cna[inear][MAXBOND];
+        const int cm = cna[inear][MINBOND];
+        if (cj == 4 && ck == 4 && cl == 2 && cm == 2)
+          nbcc4++;
+        else if (cj == 6 && ck == 6 && cl == 2 && cm == 2)
+          nbcc6++;
+      }
+      if (nbcc4 == 6 && nbcc6 == 8) pattern[i] = BCC;
+    }
+  }
+
+  // warning message
+
+  MPI_Allreduce(&nerror, &nerrorall, 1, MPI_INT, MPI_SUM, world);
+  if (nerrorall && comm->me == 0)
+    error->warning(FLERR, "Too many common neighbors in CNA: {}x", nerrorall);
+}

--- a/src/OPENMP/compute_cna_atom_omp.h
+++ b/src/OPENMP/compute_cna_atom_omp.h
@@ -13,38 +13,21 @@
 
 #ifdef COMPUTE_CLASS
 // clang-format off
-ComputeStyle(hexorder/atom,ComputeHexOrderAtom);
+ComputeStyle(cna/atom/omp,ComputeCNAAtomOMP);
 // clang-format on
 #else
 
-#ifndef LMP_COMPUTE_HEXORDER_ATOM_H
-#define LMP_COMPUTE_HEXORDER_ATOM_H
+#ifndef LMP_COMPUTE_CNA_ATOM_OMP_H
+#define LMP_COMPUTE_CNA_ATOM_OMP_H
 
-#include "compute.h"
+#include "compute_cna_atom.h"
 
 namespace LAMMPS_NS {
 
-class ComputeHexOrderAtom : public Compute {
+class ComputeCNAAtomOMP : public ComputeCNAAtom {
  public:
-  ComputeHexOrderAtom(class LAMMPS *, int, char **);
-  ~ComputeHexOrderAtom() override;
-  void init() override;
-  void init_list(int, class NeighList *) override;
+  ComputeCNAAtomOMP(class LAMMPS *, int, char **);
   void compute_peratom() override;
-  double memory_usage() override;
-
- protected:
-  int nmax, maxneigh, ncol, nnn, ndegree;
-  double cutsq;
-  class NeighList *list;
-  double *distsq;
-  int *nearest;
-
-  double **qnarray;
-
-  void calc_qn_complex(double, double, double &, double &);
-  void calc_qn_trig(double, double, double &, double &);
-  void select2(int, int, double *, int *);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/OPENMP/compute_cnp_atom_omp.cpp
+++ b/src/OPENMP/compute_cnp_atom_omp.cpp
@@ -1,0 +1,237 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "compute_cnp_atom_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "error.h"
+#include "memory.h"
+#include "neigh_list.h"
+#include "neighbor.h"
+#include "update.h"
+
+using namespace LAMMPS_NS;
+
+// these mirror the file-static constants in compute_cnp_atom.cpp
+
+static constexpr int MAXNEAR = 24;
+static constexpr int MAXCOMMON = 12;
+
+/* ---------------------------------------------------------------------- */
+
+ComputeCNPAtomOMP::ComputeCNPAtomOMP(LAMMPS *lmp, int narg, char **arg) :
+    ComputeCNPAtom(lmp, narg, arg)
+{
+}
+
+/* ----------------------------------------------------------------------
+   threaded variant of ComputeCNPAtom::compute_peratom().  Two threaded
+   phases with an implicit barrier between them: phase 1 fills the per-atom
+   nearest[]/nnearest[] lists, phase 2 computes cnpv[i] reading neighbors'
+   rows with thread-private common[]/onenearest[] scratch.  Each atom writes
+   only its own cnpv[i], so the result is bit-identical to the serial
+   compute; the "too many neighbors" counters use omp reductions and the
+   MPI_Allreduce calls stay collective outside the parallel regions.
+------------------------------------------------------------------------- */
+
+void ComputeCNPAtomOMP::compute_peratom()
+{
+  invoked_peratom = update->ntimestep;
+
+  // grow arrays if necessary
+
+  if (atom->nmax > nmax) {
+    memory->destroy(nearest);
+    memory->destroy(nnearest);
+    memory->destroy(cnpv);
+    nmax = atom->nmax;
+    memory->create(nearest, nmax, MAXNEAR, "cnp:nearest");
+    memory->create(nnearest, nmax, "cnp:nnearest");
+    memory->create(cnpv, nmax, "cnp:cnp_cnpv");
+    vector_atom = cnpv;
+  }
+
+  // invoke full neighbor list (will copy or build if necessary)
+
+  neighbor->build_one(list);
+
+  const int inum = list->inum;
+  const int *const ilist = list->ilist;
+  const int *const numneigh = list->numneigh;
+  const int *const *const firstneigh = list->firstneigh;
+
+  // find the neighbors of each atom within cutoff using full neighbor list
+  // nearest[] = atom indices of nearest neighbors, up to MAXNEAR
+  // do this for all atoms, not just compute group
+  // since CNP calculation requires neighbors of neighbors
+
+  const double *const *const x = atom->x;
+  const int *const mask = atom->mask;
+  const int nlocal = atom->nlocal;
+
+  int nerror = 0;
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(dynamic) reduction(+ : nerror)
+#endif
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    const double xtmp = x[i][0];
+    const double ytmp = x[i][1];
+    const double ztmp = x[i][2];
+    const int *const jlist = firstneigh[i];
+    const int jnum = numneigh[i];
+
+    int n = 0;
+    for (int jj = 0; jj < jnum; jj++) {
+      const int j = jlist[jj] & NEIGHMASK;
+      const double delx = xtmp - x[j][0];
+      const double dely = ytmp - x[j][1];
+      const double delz = ztmp - x[j][2];
+      const double rsq = delx * delx + dely * dely + delz * delz;
+      if (rsq < cutsq) {
+        if (n < MAXNEAR)
+          nearest[i][n++] = j;
+        else {
+          nerror++;
+          break;
+        }
+      }
+    }
+    nnearest[i] = n;
+  }
+
+  // warning message
+
+  int nerrorall;
+  MPI_Allreduce(&nerror, &nerrorall, 1, MPI_INT, MPI_SUM, world);
+  if (nerrorall && comm->me == 0)
+    error->warning(FLERR, "Too many neighbors in CNP for {} atoms", nerrorall);
+
+  // compute CNP value for each atom in group
+
+  nerror = 0;
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(dynamic) reduction(+ : nerror)
+#endif
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    const double xtmp = x[i][0];
+    const double ytmp = x[i][1];
+    const double ztmp = x[i][2];
+    // reset cnpv
+    cnpv[i] = 0.0;
+
+    // skip computation of cnpv for atoms outside the compute group
+
+    if (!(mask[i] & groupbit)) continue;
+
+    int onenearest[MAXNEAR];
+    int common[MAXCOMMON];
+
+    // loop over nearest neighbors of I to build cnp data structure
+    //  cnp[k][NCOMMON] = # of common neighbors of I with each of its neighbors
+
+    for (int m = 0; m < nnearest[i]; m++) {
+      const int jatom = nearest[i][m];
+      const double xjtmp = x[jatom][0];
+      const double yjtmp = x[jatom][1];
+      const double zjtmp = x[jatom][2];
+
+      // common = list of neighbors common to atom I and atom J
+      // if J is an owned atom, use its near neighbor list to find them
+      // if J is a ghost atom, use full neighbor list of I to find them
+      // in latter case, must exclude J from I's neighbor list
+
+      int firstflag, ncommon;
+
+      // find common neighbors of i and j using near neighbor list
+      if (jatom < nlocal) {
+        firstflag = 1;
+        ncommon = 0;
+        for (int inear = 0; inear < nnearest[i]; inear++)
+          for (int jnear = 0; jnear < nnearest[jatom]; jnear++)
+            if (nearest[i][inear] == nearest[jatom][jnear]) {
+              if (ncommon < MAXCOMMON)
+                common[ncommon++] = nearest[i][inear];
+              else if (firstflag) {
+                nerror++;
+                firstflag = 0;
+              }
+            }
+
+        // find common neighbors of i and j using full neighbor list
+      } else {
+        const int *const jlist = firstneigh[i];
+        const int jnum = numneigh[i];
+
+        int n = 0;
+        for (int kk = 0; kk < jnum; kk++) {
+          const int k = jlist[kk] & NEIGHMASK;
+          if (k == jatom) continue;
+
+          const double delx = xjtmp - x[k][0];
+          const double dely = yjtmp - x[k][1];
+          const double delz = zjtmp - x[k][2];
+          const double rsq = delx * delx + dely * dely + delz * delz;
+          if (rsq < cutsq) {
+            if (n < MAXNEAR)
+              onenearest[n++] = k;
+            else
+              break;
+          }
+        }
+
+        firstflag = 1;
+        ncommon = 0;
+        for (int inear = 0; inear < nnearest[i]; inear++)
+          for (int jnear = 0; (jnear < n) && (n < MAXNEAR); jnear++)
+            if (nearest[i][inear] == onenearest[jnear]) {
+              if (ncommon < MAXCOMMON)
+                common[ncommon++] = nearest[i][inear];
+              else if (firstflag) {
+                nerror++;
+                firstflag = 0;
+              }
+            }
+      }
+
+      // Calculate and update sum |Rik+Rjk|^2
+      double rjkx = 0.0;
+      double rjky = 0.0;
+      double rjkz = 0.0;
+      for (int kk = 0; kk < ncommon; kk++) {
+        const int k = common[kk];
+        rjkx += 2.0 * x[k][0] - xjtmp - xtmp;
+        rjky += 2.0 * x[k][1] - yjtmp - ytmp;
+        rjkz += 2.0 * x[k][2] - zjtmp - ztmp;
+      }
+      // update cnpv with summed (valuejk)
+      cnpv[i] += rjkx * rjkx + rjky * rjky + rjkz * rjkz;
+
+      // end of loop over j atoms
+    }
+
+    // normalize cnp by the number of nearest neighbors
+    cnpv[i] = cnpv[i] / nnearest[i];
+
+    // end of loop over i atoms
+  }
+
+  // warning message
+  MPI_Allreduce(&nerror, &nerrorall, 1, MPI_INT, MPI_SUM, world);
+  if (nerrorall && comm->me == 0)
+    error->warning(FLERR, "Too many common neighbors in CNP {} times", nerrorall);
+}

--- a/src/OPENMP/compute_cnp_atom_omp.h
+++ b/src/OPENMP/compute_cnp_atom_omp.h
@@ -13,35 +13,21 @@
 
 #ifdef COMPUTE_CLASS
 // clang-format off
-ComputeStyle(ackland/atom,ComputeAcklandAtom);
+ComputeStyle(cnp/atom/omp,ComputeCNPAtomOMP);
 // clang-format on
 #else
 
-#ifndef LMP_COMPUTE_ACKLAND_ATOM_H
-#define LMP_COMPUTE_ACKLAND_ATOM_H
+#ifndef LMP_COMPUTE_CNP_ATOM_OMP_H
+#define LMP_COMPUTE_CNP_ATOM_OMP_H
 
-#include "compute.h"
+#include "compute_cnp_atom.h"
 
 namespace LAMMPS_NS {
 
-class ComputeAcklandAtom : public Compute {
+class ComputeCNPAtomOMP : public ComputeCNPAtom {
  public:
-  ComputeAcklandAtom(class LAMMPS *, int, char **);
-  ~ComputeAcklandAtom() override;
-  void init() override;
-  void init_list(int, class NeighList *) override;
+  ComputeCNPAtomOMP(class LAMMPS *, int, char **);
   void compute_peratom() override;
-  double memory_usage() override;
-
- protected:
-  int nmax, maxneigh, legacy;
-  double *distsq;
-  int *nearest, *nearest_n0, *nearest_n1;
-  double *structure;
-  class NeighList *list;
-
-  void select(int, int, double *);
-  void select2(int, int, double *, int *);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/OPENMP/compute_coord_atom_omp.cpp
+++ b/src/OPENMP/compute_coord_atom_omp.cpp
@@ -1,0 +1,195 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "compute_coord_atom_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "compute_orientorder_atom.h"
+#include "memory.h"
+#include "neigh_list.h"
+#include "neighbor.h"
+#include "update.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+ComputeCoordAtomOMP::ComputeCoordAtomOMP(LAMMPS *lmp, int narg, char **arg) :
+    ComputeCoordAtom(lmp, narg, arg)
+{
+}
+
+/* ----------------------------------------------------------------------
+   threaded variant of ComputeCoordAtom::compute_peratom().  The serial
+   setup (array (re)allocation, dependent orientorder/atom invocation,
+   forward communication and neighbor-list build) is unchanged; only the
+   per-atom loops are threaded.  Each atom writes solely to its own output
+   slot (cvec[i] / carray[i]), so the result is bit-identical to the serial
+   compute regardless of thread count or schedule.
+------------------------------------------------------------------------- */
+
+void ComputeCoordAtomOMP::compute_peratom()
+{
+  invoked_peratom = update->ntimestep;
+
+  // grow coordination array if necessary
+
+  if (atom->nmax > nmax) {
+    if (ncol == 1) {
+      memory->destroy(cvec);
+      nmax = atom->nmax;
+      memory->create(cvec, nmax, "coord/atom:cvec");
+      vector_atom = cvec;
+    } else {
+      memory->destroy(carray);
+      nmax = atom->nmax;
+      memory->create(carray, nmax, ncol, "coord/atom:carray");
+      array_atom = carray;
+    }
+  }
+
+  if (cstyle == ORIENT) {
+    if (!(c_orientorder->invoked_flag & Compute::INVOKED_PERATOM)) {
+      c_orientorder->compute_peratom();
+      c_orientorder->invoked_flag |= Compute::INVOKED_PERATOM;
+    }
+    nqlist = c_orientorder->nqlist;
+    normv = c_orientorder->array_atom;
+    comm->forward_comm(this);
+  }
+
+  // invoke full neighbor list (will copy or build if necessary)
+
+  neighbor->build_one(list);
+
+  const int inum = list->inum;
+  const int *const ilist = list->ilist;
+  const int *const numneigh = list->numneigh;
+  const int *const *const firstneigh = list->firstneigh;
+
+  // compute coordination number(s) for each atom in group
+  // use full neighbor list to count atoms less than cutoff
+
+  const double *const *const x = atom->x;
+  const int *const type = atom->type;
+  const int *const mask = atom->mask;
+
+  if (cstyle == CUTOFF) {
+
+    if (ncol == 1) {
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(static)
+#endif
+      for (int ii = 0; ii < inum; ii++) {
+        const int i = ilist[ii];
+        if (mask[i] & groupbit) {
+          const double xtmp = x[i][0];
+          const double ytmp = x[i][1];
+          const double ztmp = x[i][2];
+          const int *const jlist = firstneigh[i];
+          const int jnum = numneigh[i];
+
+          int n = 0;
+          for (int jj = 0; jj < jnum; jj++) {
+            const int j = jlist[jj] & NEIGHMASK;
+
+            if (mask[j] & jgroupbit) {
+              const int jtype = type[j];
+              const double delx = xtmp - x[j][0];
+              const double dely = ytmp - x[j][1];
+              const double delz = ztmp - x[j][2];
+              const double rsq = delx * delx + dely * dely + delz * delz;
+              if (rsq < cutsq && jtype >= typelo[0] && jtype <= typehi[0]) n++;
+            }
+          }
+
+          cvec[i] = n;
+        } else
+          cvec[i] = 0.0;
+      }
+
+    } else {
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(static)
+#endif
+      for (int ii = 0; ii < inum; ii++) {
+        const int i = ilist[ii];
+        double *const count = carray[i];
+        for (int m = 0; m < ncol; m++) count[m] = 0.0;
+
+        if (mask[i] & groupbit) {
+          const double xtmp = x[i][0];
+          const double ytmp = x[i][1];
+          const double ztmp = x[i][2];
+          const int *const jlist = firstneigh[i];
+          const int jnum = numneigh[i];
+
+          for (int jj = 0; jj < jnum; jj++) {
+            const int j = jlist[jj] & NEIGHMASK;
+
+            if (mask[j] & jgroupbit) {
+              const int jtype = type[j];
+              const double delx = xtmp - x[j][0];
+              const double dely = ytmp - x[j][1];
+              const double delz = ztmp - x[j][2];
+              const double rsq = delx * delx + dely * dely + delz * delz;
+              if (rsq < cutsq) {
+                for (int m = 0; m < ncol; m++)
+                  if (jtype >= typelo[m] && jtype <= typehi[m]) count[m] += 1.0;
+              }
+            }
+          }
+        }
+      }
+    }
+
+  } else if (cstyle == ORIENT) {
+
+    const int ncomp = 2 * (2 * l + 1);
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(static)
+#endif
+    for (int ii = 0; ii < inum; ii++) {
+      const int i = ilist[ii];
+      if (mask[i] & groupbit) {
+        const double xtmp = x[i][0];
+        const double ytmp = x[i][1];
+        const double ztmp = x[i][2];
+        const int *const jlist = firstneigh[i];
+        const int jnum = numneigh[i];
+
+        int n = 0;
+        for (int jj = 0; jj < jnum; jj++) {
+          const int j = jlist[jj] & NEIGHMASK;
+          const double delx = xtmp - x[j][0];
+          const double dely = ytmp - x[j][1];
+          const double delz = ztmp - x[j][2];
+          const double rsq = delx * delx + dely * dely + delz * delz;
+          if (rsq < cutsq) {
+            double dot_product = 0.0;
+            for (int m = 0; m < ncomp; m++) {
+              dot_product += normv[i][nqlist + m] * normv[j][nqlist + m];
+            }
+            if (dot_product > threshold) n++;
+          }
+        }
+        cvec[i] = n;
+      } else
+        cvec[i] = 0.0;
+    }
+  }
+}

--- a/src/OPENMP/compute_coord_atom_omp.h
+++ b/src/OPENMP/compute_coord_atom_omp.h
@@ -1,0 +1,36 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef COMPUTE_CLASS
+// clang-format off
+ComputeStyle(coord/atom/omp,ComputeCoordAtomOMP);
+// clang-format on
+#else
+
+#ifndef LMP_COMPUTE_COORD_ATOM_OMP_H
+#define LMP_COMPUTE_COORD_ATOM_OMP_H
+
+#include "compute_coord_atom.h"
+
+namespace LAMMPS_NS {
+
+class ComputeCoordAtomOMP : public ComputeCoordAtom {
+ public:
+  ComputeCoordAtomOMP(class LAMMPS *, int, char **);
+  void compute_peratom() override;
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/compute_entropy_atom_omp.cpp
+++ b/src/OPENMP/compute_entropy_atom_omp.cpp
@@ -1,0 +1,226 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "compute_entropy_atom_omp.h"
+
+#include "atom.h"
+#include "domain.h"
+#include "force.h"
+#include "math_const.h"
+#include "memory.h"
+#include "neigh_list.h"
+#include "neighbor.h"
+#include "pair.h"
+#include "update.h"
+
+#include <cmath>
+
+using namespace LAMMPS_NS;
+using namespace MathConst;
+
+/* ---------------------------------------------------------------------- */
+
+ComputeEntropyAtomOMP::ComputeEntropyAtomOMP(LAMMPS *lmp, int narg, char **arg) :
+    ComputeEntropyAtom(lmp, narg, arg)
+{
+}
+
+/* ----------------------------------------------------------------------
+   threaded variant of ComputeEntropyAtom::compute_peratom().  The per-atom
+   g(r) scratch (gofr/integrand) is allocated thread-locally; the read-only
+   rbin/rbinsq tables are shared.  When avg_flag is set the averaging pass
+   reads neighbors' pair_entropy[j] (including ghost atoms, which is why the
+   first loop spans inum+gnum), so it runs as a second omp-for region whose
+   implicit barrier guarantees all pair_entropy[] are filled first.  Each
+   atom writes only its own output, so the result is bit-identical to the
+   serial compute.
+------------------------------------------------------------------------- */
+
+void ComputeEntropyAtomOMP::compute_peratom()
+{
+  invoked_peratom = update->ntimestep;
+
+  // read-only distance-bin tables (shared across threads)
+
+  auto *const rbin = new double[nbin];
+  auto *const rbinsq = new double[nbin];
+  for (int i = 0; i < nbin; i++) {
+    rbin[i] = i * deltar;
+    rbinsq[i] = rbin[i] * rbin[i];
+  }
+
+  // grow pair_entropy and pair_entropy_avg array if necessary
+
+  if (atom->nmax > nmax) {
+    if (!avg_flag) {
+      memory->destroy(pair_entropy);
+      nmax = atom->nmax;
+      memory->create(pair_entropy, nmax, "entropy/atom:pair_entropy");
+      vector_atom = pair_entropy;
+    } else {
+      memory->destroy(pair_entropy);
+      memory->destroy(pair_entropy_avg);
+      nmax = atom->nmax;
+      memory->create(pair_entropy, nmax, "entropy/atom:pair_entropy");
+      memory->create(pair_entropy_avg, nmax, "entropy/atom:pair_entropy_avg");
+      vector_atom = pair_entropy_avg;
+    }
+  }
+
+  // invoke occasional neighbor list build (if not perpetual)
+
+  if (!avg_flag) neighbor->build_one(list);
+
+  const int inum = list->inum + list->gnum;
+  const int *const ilist = list->ilist;
+  const int *const numneigh = list->numneigh;
+  const int *const *const firstneigh = list->firstneigh;
+
+  // Compute some constants
+
+  const double sigmasq2 = 2 * sigma * sigma;
+  const double volume = domain->xprd * domain->yprd * domain->zprd;
+  const double global_density = atom->natoms / volume;
+
+  // compute pair entropy for each atom in group
+  // use full neighbor list
+
+  const double *const *const x = atom->x;
+  const int *const mask = atom->mask;
+
+#if defined(_OPENMP)
+#pragma omp parallel
+#endif
+  {
+    auto *const gofr = new double[nbin];
+    auto *const integrand = new double[nbin];
+
+#if defined(_OPENMP)
+#pragma omp for schedule(dynamic)
+#endif
+    for (int ii = 0; ii < inum; ii++) {
+      const int i = ilist[ii];
+      if (mask[i] & groupbit) {
+        const double xtmp = x[i][0];
+        const double ytmp = x[i][1];
+        const double ztmp = x[i][2];
+        const int *const jlist = firstneigh[i];
+        const int jnum = numneigh[i];
+
+        // If local density is used, calculate it
+
+        double density = global_density;
+        if (local_flag) {
+          const double neigh_cutoff = force->pair->cutforce + neighbor->skin;
+          const double vol = (4. / 3.) * MY_PI * neigh_cutoff * neigh_cutoff * neigh_cutoff;
+          density = jnum / vol;
+        }
+
+        // calculate kernel normalization
+        // Normalization of g(r)
+        double normConstantBase = 4 * MY_PI * density;
+        // Normalization of gaussian
+        normConstantBase *= sqrt(2. * MY_PI) * sigma;
+        const double invNormConstantBase = 1. / normConstantBase;
+
+        // loop over list of all neighbors within force cutoff
+        // initialize gofr
+
+        for (int k = 0; k < nbin; ++k) gofr[k] = 0.;
+
+        for (int jj = 0; jj < jnum; jj++) {
+          const int j = jlist[jj] & NEIGHMASK;
+          const double delx = xtmp - x[j][0];
+          const double dely = ytmp - x[j][1];
+          const double delz = ztmp - x[j][2];
+          const double rsq = delx * delx + dely * dely + delz * delz;
+          if (rsq < cutsq) {
+            // contribute to gofr
+            const double r = sqrt(rsq);
+            const int bin = floor(r / deltar);    // NOLINT
+            int minbin, maxbin;
+            minbin = bin - deltabin;
+            if (minbin < 0) minbin = 0;
+            if (minbin > (nbin - 1)) minbin = nbin - 1;
+            maxbin = bin + deltabin;
+            if (maxbin > (nbin - 1)) maxbin = nbin - 1;
+            for (int k = minbin; k < maxbin + 1; k++) {
+              const double invNormKernel = invNormConstantBase / rbinsq[k];
+              const double distance = r - rbin[k];
+              gofr[k] += invNormKernel * exp(-distance * distance / sigmasq2);
+            }
+          }
+        }
+
+        // Calculate integrand
+
+        for (int k = 0; k < nbin; ++k) {
+          if (gofr[k] < 1.e-10) {
+            integrand[k] = rbinsq[k];
+          } else {
+            integrand[k] = (gofr[k] * log(gofr[k]) - gofr[k] + 1) * rbinsq[k];
+          }
+        }
+
+        // Integrate with trapezoid rule
+
+        double value = 0.;
+        for (int k = 1; k < nbin - 1; ++k) { value += integrand[k]; }
+        value += 0.5 * integrand[0];
+        value += 0.5 * integrand[nbin - 1];
+        value *= deltar;
+
+        pair_entropy[i] = -2 * MY_PI * density * value;
+      }
+    }
+
+    delete[] gofr;
+    delete[] integrand;
+  }
+
+  if (avg_flag) {
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(dynamic)
+#endif
+    for (int ii = 0; ii < inum; ii++) {
+      const int i = ilist[ii];
+      if (mask[i] & groupbit) {
+        const double xtmp = x[i][0];
+        const double ytmp = x[i][1];
+        const double ztmp = x[i][2];
+        const int *const jlist = firstneigh[i];
+        const int jnum = numneigh[i];
+
+        pair_entropy_avg[i] = pair_entropy[i];
+        double counter = 1;
+
+        // loop over list of all neighbors within force cutoff
+        for (int jj = 0; jj < jnum; jj++) {
+          const int j = jlist[jj] & NEIGHMASK;
+          const double delx = xtmp - x[j][0];
+          const double dely = ytmp - x[j][1];
+          const double delz = ztmp - x[j][2];
+          const double rsq = delx * delx + dely * dely + delz * delz;
+          if (rsq < cutsq2) {
+            pair_entropy_avg[i] += pair_entropy[j];
+            counter += 1;
+          }
+        }
+        pair_entropy_avg[i] /= counter;
+      }
+    }
+  }
+
+  delete[] rbin;
+  delete[] rbinsq;
+}

--- a/src/OPENMP/compute_entropy_atom_omp.h
+++ b/src/OPENMP/compute_entropy_atom_omp.h
@@ -13,35 +13,21 @@
 
 #ifdef COMPUTE_CLASS
 // clang-format off
-ComputeStyle(ackland/atom,ComputeAcklandAtom);
+ComputeStyle(entropy/atom/omp,ComputeEntropyAtomOMP);
 // clang-format on
 #else
 
-#ifndef LMP_COMPUTE_ACKLAND_ATOM_H
-#define LMP_COMPUTE_ACKLAND_ATOM_H
+#ifndef LMP_COMPUTE_ENTROPY_ATOM_OMP_H
+#define LMP_COMPUTE_ENTROPY_ATOM_OMP_H
 
-#include "compute.h"
+#include "compute_entropy_atom.h"
 
 namespace LAMMPS_NS {
 
-class ComputeAcklandAtom : public Compute {
+class ComputeEntropyAtomOMP : public ComputeEntropyAtom {
  public:
-  ComputeAcklandAtom(class LAMMPS *, int, char **);
-  ~ComputeAcklandAtom() override;
-  void init() override;
-  void init_list(int, class NeighList *) override;
+  ComputeEntropyAtomOMP(class LAMMPS *, int, char **);
   void compute_peratom() override;
-  double memory_usage() override;
-
- protected:
-  int nmax, maxneigh, legacy;
-  double *distsq;
-  int *nearest, *nearest_n0, *nearest_n1;
-  double *structure;
-  class NeighList *list;
-
-  void select(int, int, double *);
-  void select2(int, int, double *, int *);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/OPENMP/compute_erotate_sphere_atom_omp.cpp
+++ b/src/OPENMP/compute_erotate_sphere_atom_omp.cpp
@@ -1,0 +1,65 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "compute_erotate_sphere_atom_omp.h"
+
+#include "atom.h"
+#include "memory.h"
+#include "update.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+ComputeErotateSphereAtomOMP::ComputeErotateSphereAtomOMP(LAMMPS *lmp, int narg, char **arg) :
+    ComputeErotateSphereAtom(lmp, narg, arg)
+{
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeErotateSphereAtomOMP::compute_peratom()
+{
+  invoked_peratom = update->ntimestep;
+
+  // grow erot array if necessary
+
+  if (atom->nmax > nmax) {
+    memory->destroy(erot);
+    nmax = atom->nmax;
+    memory->create(erot, nmax, "erotate/sphere/atom:erot");
+    vector_atom = erot;
+  }
+
+  // compute rotational kinetic energy for each atom in group
+  // point particles will have erot = 0.0, due to radius = 0.0
+
+  const double *const *const omega = atom->omega;
+  const double *const radius = atom->radius;
+  const double *const rmass = atom->rmass;
+  const int *const mask = atom->mask;
+  const int nlocal = atom->nlocal;
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(static)
+#endif
+  for (int i = 0; i < nlocal; i++) {
+    if (mask[i] & groupbit) {
+      erot[i] =
+          (omega[i][0] * omega[i][0] + omega[i][1] * omega[i][1] + omega[i][2] * omega[i][2]) *
+          radius[i] * radius[i] * rmass[i];
+      erot[i] *= pfactor;
+    } else
+      erot[i] = 0.0;
+  }
+}

--- a/src/OPENMP/compute_erotate_sphere_atom_omp.h
+++ b/src/OPENMP/compute_erotate_sphere_atom_omp.h
@@ -13,28 +13,21 @@
 
 #ifdef COMPUTE_CLASS
 // clang-format off
-ComputeStyle(ke/atom,ComputeKEAtom);
+ComputeStyle(erotate/sphere/atom/omp,ComputeErotateSphereAtomOMP);
 // clang-format on
 #else
 
-#ifndef LMP_COMPUTE_KE_ATOM_H
-#define LMP_COMPUTE_KE_ATOM_H
+#ifndef LMP_COMPUTE_EROTATE_SPHERE_ATOM_OMP_H
+#define LMP_COMPUTE_EROTATE_SPHERE_ATOM_OMP_H
 
-#include "compute.h"
+#include "compute_erotate_sphere_atom.h"
 
 namespace LAMMPS_NS {
 
-class ComputeKEAtom : public Compute {
+class ComputeErotateSphereAtomOMP : public ComputeErotateSphereAtom {
  public:
-  ComputeKEAtom(class LAMMPS *, int, char **);
-  ~ComputeKEAtom() override;
-  void init() override;
+  ComputeErotateSphereAtomOMP(class LAMMPS *, int, char **);
   void compute_peratom() override;
-  double memory_usage() override;
-
- protected:
-  int nmax;
-  double *ke;
 };
 
 }    // namespace LAMMPS_NS

--- a/src/OPENMP/compute_hexorder_atom_omp.cpp
+++ b/src/OPENMP/compute_hexorder_atom_omp.cpp
@@ -1,0 +1,148 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "compute_hexorder_atom_omp.h"
+
+#include "atom.h"
+#include "memory.h"
+#include "neigh_list.h"
+#include "neighbor.h"
+#include "update.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+ComputeHexOrderAtomOMP::ComputeHexOrderAtomOMP(LAMMPS *lmp, int narg, char **arg) :
+    ComputeHexOrderAtom(lmp, narg, arg)
+{
+}
+
+/* ----------------------------------------------------------------------
+   threaded variant of ComputeHexOrderAtom::compute_peratom().  The per-atom
+   neighbor scratch (distsq/nearest) is allocated thread-locally inside the
+   parallel region, sized to the largest neighbor count over the looped
+   atoms.  select2()/calc_qn_complex() are reentrant given thread-private
+   scratch, and each atom writes only its own output row qnarray[i], so the
+   result is bit-identical to the serial compute.
+------------------------------------------------------------------------- */
+
+void ComputeHexOrderAtomOMP::compute_peratom()
+{
+  invoked_peratom = update->ntimestep;
+
+  // grow order parameter array if necessary
+
+  if (atom->nmax > nmax) {
+    memory->destroy(qnarray);
+    nmax = atom->nmax;
+    memory->create(qnarray, nmax, ncol, "hexorder/atom:qnarray");
+    array_atom = qnarray;
+  }
+
+  // invoke full neighbor list (will copy or build if necessary)
+
+  neighbor->build_one(list);
+
+  const int inum = list->inum;
+  const int *const ilist = list->ilist;
+  const int *const numneigh = list->numneigh;
+  const int *const *const firstneigh = list->firstneigh;
+
+  // compute order parameter for each atom in group
+  // use full neighbor list to count atoms less than cutoff
+
+  const double *const *const x = atom->x;
+  const int *const mask = atom->mask;
+
+  // largest neighbor count over the looped atoms, for sizing thread scratch
+
+  int maxn = 1;
+  for (int ii = 0; ii < inum; ii++) {
+    const int jnum = numneigh[ilist[ii]];
+    if (jnum > maxn) maxn = jnum;
+  }
+
+#if defined(_OPENMP)
+#pragma omp parallel
+#endif
+  {
+    auto *const t_distsq = new double[maxn];
+    auto *const t_nearest = new int[maxn];
+
+#if defined(_OPENMP)
+#pragma omp for schedule(dynamic)
+#endif
+    for (int ii = 0; ii < inum; ii++) {
+      const int i = ilist[ii];
+      double *const qn = qnarray[i];
+      if (mask[i] & groupbit) {
+        const double xtmp = x[i][0];
+        const double ytmp = x[i][1];
+        const double ztmp = x[i][2];
+        const int *const jlist = firstneigh[i];
+        const int jnum = numneigh[i];
+
+        // loop over list of all neighbors within force cutoff
+        // t_distsq[] = distance sq to each
+        // t_nearest[] = atom indices of neighbors
+
+        int ncount = 0;
+        for (int jj = 0; jj < jnum; jj++) {
+          const int j = jlist[jj] & NEIGHMASK;
+          const double delx = xtmp - x[j][0];
+          const double dely = ytmp - x[j][1];
+          const double delz = ztmp - x[j][2];
+          const double rsq = delx * delx + dely * dely + delz * delz;
+          if (rsq < cutsq) {
+            t_distsq[ncount] = rsq;
+            t_nearest[ncount++] = j;
+          }
+        }
+
+        // if not nnn neighbors, order parameter = 0;
+
+        if (ncount < nnn) {
+          qn[0] = qn[1] = 0.0;
+          continue;
+        }
+
+        // if nnn > 0, use only nearest nnn neighbors
+
+        if (nnn > 0) {
+          select2(nnn, ncount, t_distsq, t_nearest);
+          ncount = nnn;
+        }
+
+        double usum = 0.0;
+        double vsum = 0.0;
+
+        for (int jj = 0; jj < ncount; jj++) {
+          const int j = t_nearest[jj] & NEIGHMASK;
+          const double delx = xtmp - x[j][0];
+          const double dely = ytmp - x[j][1];
+          double u, v;
+          calc_qn_complex(delx, dely, u, v);
+          usum += u;
+          vsum += v;
+        }
+        qn[0] = usum / nnn;
+        qn[1] = vsum / nnn;
+      } else
+        qn[0] = qn[1] = 0.0;
+    }
+
+    delete[] t_distsq;
+    delete[] t_nearest;
+  }
+}

--- a/src/OPENMP/compute_hexorder_atom_omp.h
+++ b/src/OPENMP/compute_hexorder_atom_omp.h
@@ -13,38 +13,21 @@
 
 #ifdef COMPUTE_CLASS
 // clang-format off
-ComputeStyle(hexorder/atom,ComputeHexOrderAtom);
+ComputeStyle(hexorder/atom/omp,ComputeHexOrderAtomOMP);
 // clang-format on
 #else
 
-#ifndef LMP_COMPUTE_HEXORDER_ATOM_H
-#define LMP_COMPUTE_HEXORDER_ATOM_H
+#ifndef LMP_COMPUTE_HEXORDER_ATOM_OMP_H
+#define LMP_COMPUTE_HEXORDER_ATOM_OMP_H
 
-#include "compute.h"
+#include "compute_hexorder_atom.h"
 
 namespace LAMMPS_NS {
 
-class ComputeHexOrderAtom : public Compute {
+class ComputeHexOrderAtomOMP : public ComputeHexOrderAtom {
  public:
-  ComputeHexOrderAtom(class LAMMPS *, int, char **);
-  ~ComputeHexOrderAtom() override;
-  void init() override;
-  void init_list(int, class NeighList *) override;
+  ComputeHexOrderAtomOMP(class LAMMPS *, int, char **);
   void compute_peratom() override;
-  double memory_usage() override;
-
- protected:
-  int nmax, maxneigh, ncol, nnn, ndegree;
-  double cutsq;
-  class NeighList *list;
-  double *distsq;
-  int *nearest;
-
-  double **qnarray;
-
-  void calc_qn_complex(double, double, double &, double &);
-  void calc_qn_trig(double, double, double &, double &);
-  void select2(int, int, double *, int *);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/OPENMP/compute_ke_atom_omp.cpp
+++ b/src/OPENMP/compute_ke_atom_omp.cpp
@@ -1,0 +1,79 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "compute_ke_atom_omp.h"
+
+#include "atom.h"
+#include "force.h"
+#include "memory.h"
+#include "update.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+ComputeKEAtomOMP::ComputeKEAtomOMP(LAMMPS *lmp, int narg, char **arg) :
+    ComputeKEAtom(lmp, narg, arg)
+{
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeKEAtomOMP::compute_peratom()
+{
+  invoked_peratom = update->ntimestep;
+
+  // grow ke array if necessary
+
+  if (atom->nmax > nmax) {
+    memory->destroy(ke);
+    nmax = atom->nmax;
+    memory->create(ke, nmax, "ke/atom:ke");
+    vector_atom = ke;
+  }
+
+  // compute kinetic energy for each atom in group
+
+  const double mvv2e = force->mvv2e;
+  const double *const *const v = atom->v;
+  const double *const mass = atom->mass;
+  const double *const rmass = atom->rmass;
+  const int *const mask = atom->mask;
+  const int *const type = atom->type;
+  const int nlocal = atom->nlocal;
+
+  if (rmass) {
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(static)
+#endif
+    for (int i = 0; i < nlocal; i++) {
+      if (mask[i] & groupbit) {
+        ke[i] =
+            0.5 * mvv2e * rmass[i] * (v[i][0] * v[i][0] + v[i][1] * v[i][1] + v[i][2] * v[i][2]);
+      } else
+        ke[i] = 0.0;
+    }
+
+  } else {
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(static)
+#endif
+    for (int i = 0; i < nlocal; i++) {
+      if (mask[i] & groupbit) {
+        ke[i] = 0.5 * mvv2e * mass[type[i]] *
+            (v[i][0] * v[i][0] + v[i][1] * v[i][1] + v[i][2] * v[i][2]);
+      } else
+        ke[i] = 0.0;
+    }
+  }
+}

--- a/src/OPENMP/compute_ke_atom_omp.h
+++ b/src/OPENMP/compute_ke_atom_omp.h
@@ -13,28 +13,21 @@
 
 #ifdef COMPUTE_CLASS
 // clang-format off
-ComputeStyle(ke/atom,ComputeKEAtom);
+ComputeStyle(ke/atom/omp,ComputeKEAtomOMP);
 // clang-format on
 #else
 
-#ifndef LMP_COMPUTE_KE_ATOM_H
-#define LMP_COMPUTE_KE_ATOM_H
+#ifndef LMP_COMPUTE_KE_ATOM_OMP_H
+#define LMP_COMPUTE_KE_ATOM_OMP_H
 
-#include "compute.h"
+#include "compute_ke_atom.h"
 
 namespace LAMMPS_NS {
 
-class ComputeKEAtom : public Compute {
+class ComputeKEAtomOMP : public ComputeKEAtom {
  public:
-  ComputeKEAtom(class LAMMPS *, int, char **);
-  ~ComputeKEAtom() override;
-  void init() override;
+  ComputeKEAtomOMP(class LAMMPS *, int, char **);
   void compute_peratom() override;
-  double memory_usage() override;
-
- protected:
-  int nmax;
-  double *ke;
 };
 
 }    // namespace LAMMPS_NS

--- a/src/OPENMP/compute_orientorder_atom_omp.cpp
+++ b/src/OPENMP/compute_orientorder_atom_omp.cpp
@@ -1,0 +1,211 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "compute_orientorder_atom_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "memory.h"
+#include "neigh_list.h"
+#include "neighbor.h"
+#include "update.h"
+
+#include <cstring>
+
+#if defined(_OPENMP)
+#include <omp.h>
+#endif
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+ComputeOrientOrderAtomOMP::ComputeOrientOrderAtomOMP(LAMMPS *lmp, int narg, char **arg) :
+    ComputeOrientOrderAtom(lmp, narg, arg), nthreads_alloc(0), maxneigh_thr(0), distsq_thr(nullptr),
+    nearest_thr(nullptr), rlist_thr(nullptr), qnm_r_thr(nullptr), qnm_i_thr(nullptr)
+{
+}
+
+/* ---------------------------------------------------------------------- */
+
+ComputeOrientOrderAtomOMP::~ComputeOrientOrderAtomOMP()
+{
+  free_thr_arrays();
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeOrientOrderAtomOMP::free_thr_arrays()
+{
+  memory->destroy(distsq_thr);
+  memory->destroy(nearest_thr);
+  memory->destroy(rlist_thr);
+  memory->destroy(qnm_r_thr);
+  memory->destroy(qnm_i_thr);
+  distsq_thr = nullptr;
+  nearest_thr = nullptr;
+  rlist_thr = nullptr;
+  qnm_r_thr = nullptr;
+  qnm_i_thr = nullptr;
+}
+
+/* ----------------------------------------------------------------------
+   threaded variant of ComputeOrientOrderAtom::compute_peratom().  The
+   per-atom scratch arrays (distsq/nearest/rlist) and the boop accumulators
+   (qnm_r/qnm_i) are replicated per thread and sized once, before the
+   threaded region, to the largest neighbor count over the looped atoms.
+   The base select3()/calc_boop() helpers are reentrant given thread-private
+   scratch, so each atom is processed independently and the result is
+   bit-identical to the serial compute.
+------------------------------------------------------------------------- */
+
+void ComputeOrientOrderAtomOMP::compute_peratom()
+{
+  invoked_peratom = update->ntimestep;
+
+  // grow order parameter array if necessary
+
+  if (atom->nmax > nmax) {
+    memory->destroy(qnarray);
+    nmax = atom->nmax;
+    memory->create(qnarray, nmax, ncol, "orientorder/atom:qnarray");
+    array_atom = qnarray;
+  }
+
+  // invoke full neighbor list (will copy or build if necessary)
+
+  neighbor->build_one(list);
+
+  const int inum = list->inum;
+  const int *const ilist = list->ilist;
+  const int *const numneigh = list->numneigh;
+  const int *const *const firstneigh = list->firstneigh;
+
+  double **x = atom->x;
+  const int *const mask = atom->mask;
+  memset(&qnarray[0][0], 0, sizeof(double) * nmax * ncol);
+
+  // (re)allocate per-thread boop accumulators when the thread count changes
+
+  const int nthreads = comm->nthreads;
+  if (nthreads != nthreads_alloc) {
+    free_thr_arrays();
+    nthreads_alloc = nthreads;
+    maxneigh_thr = 0;
+    memory->create(qnm_r_thr, nthreads_alloc, nqlist, qmax + 1, "orientorder/atom:qnm_r_thr");
+    memory->create(qnm_i_thr, nthreads_alloc, nqlist, qmax + 1, "orientorder/atom:qnm_i_thr");
+  }
+
+  // size the per-thread neighbor scratch once, to the largest neighbor count
+  // (clamp to >= 1 so the buffers are never null when the region runs)
+
+  int maxn = 1;
+  for (int ii = 0; ii < inum; ii++) {
+    const int jnum = numneigh[ilist[ii]];
+    if (jnum > maxn) maxn = jnum;
+  }
+  if (maxn > maxneigh_thr) {
+    memory->destroy(distsq_thr);
+    memory->destroy(nearest_thr);
+    memory->destroy(rlist_thr);
+    maxneigh_thr = maxn;
+    memory->create(distsq_thr, nthreads_alloc, maxneigh_thr, "orientorder/atom:distsq_thr");
+    memory->create(nearest_thr, nthreads_alloc, maxneigh_thr, "orientorder/atom:nearest_thr");
+    memory->create(rlist_thr, nthreads_alloc, maxneigh_thr, 3, "orientorder/atom:rlist_thr");
+  }
+
+  // compute order parameter for each atom in group
+  // use full neighbor list to count atoms less than cutoff
+
+#if defined(_OPENMP)
+#pragma omp parallel
+#endif
+  {
+    int tid = 0;
+#if defined(_OPENMP)
+    tid = omp_get_thread_num();
+#endif
+    double *const t_distsq = distsq_thr[tid];
+    int *const t_nearest = nearest_thr[tid];
+    double **const t_rlist = rlist_thr[tid];
+    double **const t_qnm_r = qnm_r_thr[tid];
+    double **const t_qnm_i = qnm_i_thr[tid];
+
+#if defined(_OPENMP)
+#pragma omp for schedule(dynamic)
+#endif
+    for (int ii = 0; ii < inum; ii++) {
+      const int i = ilist[ii];
+      double *const qn = qnarray[i];
+      if (mask[i] & groupbit) {
+        const double xtmp = x[i][0];
+        const double ytmp = x[i][1];
+        const double ztmp = x[i][2];
+        const int *const jlist = firstneigh[i];
+        const int jnum = numneigh[i];
+
+        // loop over list of all neighbors within force cutoff
+        // t_distsq[] = distance sq to each
+        // t_rlist[] = distance vector to each
+        // t_nearest[] = atom indices of neighbors
+
+        int ncount = 0;
+        for (int jj = 0; jj < jnum; jj++) {
+          const int j = jlist[jj] & NEIGHMASK;
+
+          const double delx = xtmp - x[j][0];
+          const double dely = ytmp - x[j][1];
+          const double delz = ztmp - x[j][2];
+          const double rsq = delx * delx + dely * dely + delz * delz;
+          if (rsq < cutsq) {
+            t_distsq[ncount] = rsq;
+            t_rlist[ncount][0] = delx;
+            t_rlist[ncount][1] = dely;
+            t_rlist[ncount][2] = delz;
+            t_nearest[ncount++] = j;
+          }
+        }
+
+        // if not nnn neighbors, order parameter = 0;
+
+        if ((ncount == 0) || (ncount < nnn)) {
+          for (int jj = 0; jj < ncol; jj++) qn[jj] = 0.0;
+          continue;
+        }
+
+        // if nnn > 0, use only nearest nnn neighbors
+
+        if (nnn > 0) {
+          select3(nnn, ncount, t_distsq, t_nearest, t_rlist);
+          ncount = nnn;
+        }
+
+        calc_boop(t_rlist, ncount, qn, qlist, nqlist, t_qnm_r, t_qnm_i);
+      }
+    }
+  }
+}
+
+/* ----------------------------------------------------------------------
+   memory usage of local atom-based array plus per-thread scratch
+------------------------------------------------------------------------- */
+
+double ComputeOrientOrderAtomOMP::memory_usage()
+{
+  double bytes = ComputeOrientOrderAtom::memory_usage();
+  if (nthreads_alloc > 0) {
+    bytes += (double) nthreads_alloc * maxneigh_thr * (4 * sizeof(double) + sizeof(int));
+    bytes += (double) nthreads_alloc * nqlist * (qmax + 1) * 2 * sizeof(double);
+  }
+  return bytes;
+}

--- a/src/OPENMP/compute_orientorder_atom_omp.h
+++ b/src/OPENMP/compute_orientorder_atom_omp.h
@@ -1,0 +1,49 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef COMPUTE_CLASS
+// clang-format off
+ComputeStyle(orientorder/atom/omp,ComputeOrientOrderAtomOMP);
+// clang-format on
+#else
+
+#ifndef LMP_COMPUTE_ORIENTORDER_ATOM_OMP_H
+#define LMP_COMPUTE_ORIENTORDER_ATOM_OMP_H
+
+#include "compute_orientorder_atom.h"
+
+namespace LAMMPS_NS {
+
+class ComputeOrientOrderAtomOMP : public ComputeOrientOrderAtom {
+ public:
+  ComputeOrientOrderAtomOMP(class LAMMPS *, int, char **);
+  ~ComputeOrientOrderAtomOMP() override;
+  void compute_peratom() override;
+  double memory_usage() override;
+
+ private:
+  int nthreads_alloc;    // number of per-thread scratch slots allocated
+  int maxneigh_thr;      // per-thread neighbor scratch capacity
+  double **distsq_thr;   // [nthreads][maxneigh_thr]
+  int **nearest_thr;     // [nthreads][maxneigh_thr]
+  double ***rlist_thr;   // [nthreads][maxneigh_thr][3]
+  double ***qnm_r_thr;   // [nthreads][nqlist][qmax+1]
+  double ***qnm_i_thr;   // [nthreads][nqlist][qmax+1]
+
+  void free_thr_arrays();
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/compute_rdf_omp.cpp
+++ b/src/OPENMP/compute_rdf_omp.cpp
@@ -1,0 +1,233 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "compute_rdf_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "domain.h"
+#include "force.h"
+#include "math_const.h"
+#include "neigh_list.h"
+#include "neighbor.h"
+#include "update.h"
+
+#include <cmath>
+
+#if defined(_OPENMP)
+#include <omp.h>
+#endif
+
+using namespace LAMMPS_NS;
+using namespace MathConst;
+
+/* ---------------------------------------------------------------------- */
+
+ComputeRDFOMP::ComputeRDFOMP(LAMMPS *lmp, int narg, char **arg) : ComputeRDF(lmp, narg, arg) {}
+
+/* ----------------------------------------------------------------------
+   threaded variant of ComputeRDF::compute_array().  Only the histogram
+   tally loop is threaded: each thread accumulates into a private partial
+   histogram, then the partials are summed into hist[] before the
+   MPI_Allreduce.  Every tally is an increment of 1.0, so the per-thread
+   sums are exact integers and the reduced result is bit-identical to the
+   serial compute regardless of thread count.  Setup, normalization and the
+   collective MPI_Allreduce remain serial/collective.
+------------------------------------------------------------------------- */
+
+void ComputeRDFOMP::compute_array()
+{
+  if (natoms_old != atom->natoms) {
+    dynamic = 1;
+    natoms_old = atom->natoms;
+  }
+
+  // if the number of atoms has changed or we have a dynamic group
+  // or dynamic updates are requested (e.g. when changing atom types)
+  // we need to recompute some normalization parameters
+
+  if (dynamic) init_norm();
+
+  invoked_array = update->ntimestep;
+
+  // invoke half neighbor list (will copy or build if necessary)
+
+  neighbor->build_one(list);
+
+  const int inum = list->inum;
+  const int *const ilist = list->ilist;
+  const int *const numneigh = list->numneigh;
+  const int *const *const firstneigh = list->firstneigh;
+
+  // tally the RDF
+  // both atom i and j must be in fix group
+  // itype,jtype must have been specified by user
+  // consider I,J as one interaction even if neighbor pair is stored on 2 procs
+  // tally I,J pair each time I is central atom, and each time J is central
+
+  const double *const *const x = atom->x;
+  const int *const type = atom->type;
+  const int *const mask = atom->mask;
+  const int nlocal = atom->nlocal;
+
+  const double *const special_coul = force->special_coul;
+  const double *const special_lj = force->special_lj;
+  const int newton_pair = force->newton_pair;
+
+  // per-thread partial histograms; tallies are exact integer increments,
+  // so summing the partials reproduces the serial histogram bit-for-bit
+
+  const int nthreads = comm->nthreads;
+  const int ntot = npairs * nbin;
+  auto *const hist_thr = new double[(std::size_t) nthreads * ntot];
+
+#if defined(_OPENMP)
+#pragma omp parallel
+#endif
+  {
+    int tid = 0;
+#if defined(_OPENMP)
+    tid = omp_get_thread_num();
+#endif
+    double *const myhist = hist_thr + (std::size_t) tid * ntot;
+    for (int k = 0; k < ntot; k++) myhist[k] = 0.0;
+
+#if defined(_OPENMP)
+#pragma omp for schedule(dynamic)
+#endif
+    for (int ii = 0; ii < inum; ii++) {
+      const int i = ilist[ii];
+      if (!(mask[i] & groupbit)) continue;
+      const double xtmp = x[i][0];
+      const double ytmp = x[i][1];
+      const double ztmp = x[i][2];
+      const int itype = type[i];
+      const int *const jlist = firstneigh[i];
+      const int jnum = numneigh[i];
+
+      for (int jj = 0; jj < jnum; jj++) {
+        int j = jlist[jj];
+        const double factor_lj = special_lj[sbmask(j)];
+        const double factor_coul = special_coul[sbmask(j)];
+        j &= NEIGHMASK;
+
+        // if both weighting factors are 0, skip this pair
+        // could be 0 and still be in neigh list for long-range Coulombics
+        // want consistency with non-charged pairs which wouldn't be in list
+
+        if (factor_lj == 0.0 && factor_coul == 0.0) continue;
+
+        if (!(mask[j] & groupbit)) continue;
+        const int jtype = type[j];
+        const int ipair = nrdfpair[itype][jtype];
+        const int jpair = nrdfpair[jtype][itype];
+        if (!ipair && !jpair) continue;
+
+        const double delx = xtmp - x[j][0];
+        const double dely = ytmp - x[j][1];
+        const double delz = ztmp - x[j][2];
+        const double r = sqrt(delx * delx + dely * dely + delz * delz);
+        const int ibin = static_cast<int>(r * delrinv);
+        if (ibin >= nbin) continue;
+
+        for (int ihisto = 0; ihisto < ipair; ihisto++) {
+          const int m = rdfpair[ihisto][itype][jtype];
+          myhist[m * nbin + ibin] += 1.0;
+        }
+        if (newton_pair || j < nlocal) {
+          for (int ihisto = 0; ihisto < jpair; ihisto++) {
+            const int m = rdfpair[ihisto][jtype][itype];
+            myhist[m * nbin + ibin] += 1.0;
+          }
+        }
+      }
+    }
+  }
+
+  // reduce per-thread partial histograms into hist[] (hist[0] is contiguous)
+
+  double *const hist_flat = hist[0];
+  for (int k = 0; k < ntot; k++) {
+    double sum = 0.0;
+    for (int t = 0; t < nthreads; t++) sum += hist_thr[(std::size_t) t * ntot + k];
+    hist_flat[k] = sum;
+  }
+  delete[] hist_thr;
+
+  // sum histograms across procs
+
+  MPI_Allreduce(hist[0], histall[0], npairs * nbin, MPI_DOUBLE, MPI_SUM, world);
+
+  // convert counts to g(r) and coord(r) and copy into output array
+  // vfrac = fraction of volume in shell m
+  // npairs = number of pairs, corrected for duplicates
+  // duplicates = pairs in which both atoms are the same
+
+  double constant, vfrac, gr, ncoord, rlower, rupper, normfac;
+
+  if (domain->dimension == 3) {
+    constant = 4.0 * MY_PI / (3.0 * domain->xprd * domain->yprd * domain->zprd);
+
+    for (int m = 0; m < npairs; m++) {
+      if (rev[m]) {    // swap i and j because they were entered in different order
+        normfac = (jcount[m] > 0)
+            ? static_cast<double>(icount[m]) - static_cast<double>(duplicates[m]) / jcount[m]
+            : 0.0;
+      } else {
+        normfac = (icount[m] > 0)
+            ? static_cast<double>(jcount[m]) - static_cast<double>(duplicates[m]) / icount[m]
+            : 0.0;
+      }
+      ncoord = 0.0;
+      for (int ibin = 0; ibin < nbin; ibin++) {
+        rlower = ibin * delr;
+        rupper = (ibin + 1) * delr;
+        vfrac = constant * (rupper * rupper * rupper - rlower * rlower * rlower);
+        gr = 0.0;
+        if (vfrac * normfac != 0.0) {
+          if (rev[m]) {    // swap i and j because they were entered in different order
+            gr = histall[m][ibin] / (vfrac * normfac * jcount[m]);
+            if (jcount[m] != 0) ncoord += gr * vfrac * normfac;
+          } else {
+            gr = histall[m][ibin] / (vfrac * normfac * icount[m]);
+            if (icount[m] != 0) ncoord += gr * vfrac * normfac;
+          }
+        }
+        array[ibin][1 + 2 * m] = gr;
+        array[ibin][2 + 2 * m] = ncoord;
+      }
+    }
+
+  } else {
+    constant = MY_PI / (domain->xprd * domain->yprd);
+
+    for (int m = 0; m < npairs; m++) {
+      ncoord = 0.0;
+      normfac = (icount[m] > 0)
+          ? static_cast<double>(jcount[m]) - static_cast<double>(duplicates[m]) / icount[m]
+          : 0.0;
+      for (int ibin = 0; ibin < nbin; ibin++) {
+        rlower = ibin * delr;
+        rupper = (ibin + 1) * delr;
+        vfrac = constant * (rupper * rupper - rlower * rlower);
+        if (vfrac * normfac != 0.0)
+          gr = histall[m][ibin] / (vfrac * normfac * icount[m]);
+        else
+          gr = 0.0;
+        if (icount[m] != 0) ncoord += gr * vfrac * normfac;
+        array[ibin][1 + 2 * m] = gr;
+        array[ibin][2 + 2 * m] = ncoord;
+      }
+    }
+  }
+}

--- a/src/OPENMP/compute_rdf_omp.h
+++ b/src/OPENMP/compute_rdf_omp.h
@@ -1,0 +1,36 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef COMPUTE_CLASS
+// clang-format off
+ComputeStyle(rdf/omp,ComputeRDFOMP);
+// clang-format on
+#else
+
+#ifndef LMP_COMPUTE_RDF_OMP_H
+#define LMP_COMPUTE_RDF_OMP_H
+
+#include "compute_rdf.h"
+
+namespace LAMMPS_NS {
+
+class ComputeRDFOMP : public ComputeRDF {
+ public:
+  ComputeRDFOMP(class LAMMPS *, int, char **);
+  void compute_array() override;
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/fix_orient_bcc_omp.cpp
+++ b/src/OPENMP/fix_orient_bcc_omp.cpp
@@ -1,0 +1,279 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "fix_orient_bcc_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "error.h"
+#include "math_const.h"
+#include "memory.h"
+#include "neigh_list.h"
+#include "update.h"
+
+#include <cmath>
+#include <cstdlib>
+
+#if defined(_OPENMP)
+#include <omp.h>
+#endif
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+using namespace MathConst;
+
+static constexpr int BIG = 1000000000;
+
+/* ---------------------------------------------------------------------- */
+
+FixOrientBCCOMP::FixOrientBCCOMP(LAMMPS *lmp, int narg, char **arg) :
+  FixOrientBCC(lmp, narg, arg)
+{
+}
+
+/* ----------------------------------------------------------------------
+   threaded version of FixOrientBCC::post_force(); see fix_orient_fcc_omp.cpp
+   for the threading rationale (phase 1 per-atom build with per-thread sort
+   scratch + reductions; phase 2 writes only f[i], so it is race-free).
+------------------------------------------------------------------------- */
+
+void FixOrientBCCOMP::post_force(int /*vflag*/)
+{
+  // set local ptrs
+
+  double **x = atom->x;
+  double **f = atom->f;
+  int *mask = atom->mask;
+  tagint *tag = atom->tag;
+  const int nlocal = atom->nlocal;
+  const int nall = atom->nlocal + atom->nghost;
+
+  const int inum = list->inum;
+  int *ilist = list->ilist;
+  int *numneigh = list->numneigh;
+  int **firstneigh = list->firstneigh;
+
+  // ensure nbr and order data structures are adequate size
+
+  if (nall > nmax) {
+    nmax = nall;
+    memory->destroy(nbr);
+    memory->destroy(order);
+    nbr = (Nbr *) memory->smalloc(nmax*sizeof(Nbr),"orient/bcc:nbr");
+    memory->create(order,nmax,2,"orient/bcc:order");
+    array_atom = order;
+  }
+
+  added_energy = 0.0;
+  int count = 0;
+  int mincount = BIG;
+  int maxcount = 0;
+
+  // loop over owned atoms and build Nbr data structure of neighbors
+  // use full neighbor list
+
+#if defined(_OPENMP)
+#pragma omp parallel default(shared)
+#endif
+  {
+    Sort *sort = nullptr;
+    int sortmax = 0;
+    double e_thr = 0.0;
+    int count_thr = 0, minc_thr = BIG, maxc_thr = 0;
+
+#if defined(_OPENMP)
+#pragma omp for schedule(dynamic)
+#endif
+    for (int ii = 0; ii < inum; ii++) {
+      const int i = ilist[ii];
+      int *jlist = firstneigh[i];
+      const int jnum = numneigh[i];
+
+      if (jnum < minc_thr) minc_thr = jnum;
+      if (jnum > maxc_thr) maxc_thr = jnum;
+      if (jnum > sortmax) {
+        delete [] sort;
+        sortmax = jnum;
+        sort = new Sort[sortmax];
+      }
+
+      // loop over all neighbors of atom i
+      // for those within cutsq, build sort data structure
+
+      int nsort = 0;
+      for (int jj = 0; jj < jnum; jj++) {
+        int j = jlist[jj];
+        j &= NEIGHMASK;
+        count_thr++;
+
+        const double dx = x[i][0] - x[j][0];
+        const double dy = x[i][1] - x[j][1];
+        const double dz = x[i][2] - x[j][2];
+        const double rsq = dx*dx + dy*dy + dz*dz;
+
+        if (rsq < cutsq) {
+          sort[nsort].id = j;
+          sort[nsort].rsq = rsq;
+          sort[nsort].delta[0] = dx;
+          sort[nsort].delta[1] = dy;
+          sort[nsort].delta[2] = dz;
+          if (use_xismooth) {
+            const double xismooth = (xicutoffsq - 2.0*rsq/(a*a)) / (xicutoffsq - 1.0);
+            sort[nsort].xismooth = 1.0 - fabs(1.0-xismooth);
+          }
+          nsort++;
+        }
+      }
+
+      // sort neighbors by rsq distance
+      // no need to sort if nsort <= 8
+
+      if (nsort > 8) qsort(sort,nsort,sizeof(Sort),compare);
+
+      // copy up to 8 nearest neighbors into nbr data structure
+      // operate on delta vector via find_best_ref() to compute dxi
+
+      const int n = MIN(8,nsort);
+      nbr[i].n = n;
+      if (n == 0) continue;
+
+      double xi_total = 0.0;
+      double xi_sq, dxi[3];
+      for (int j = 0; j < n; j++) {
+        find_best_ref(sort[j].delta,0,xi_sq,dxi);
+        xi_total += sqrt(xi_sq);
+        nbr[i].id[j] = sort[j].id;
+        nbr[i].dxi[j][0] = dxi[0]/n;
+        nbr[i].dxi[j][1] = dxi[1]/n;
+        nbr[i].dxi[j][2] = dxi[2]/n;
+        if (use_xismooth) nbr[i].xismooth[j] = sort[j].xismooth;
+      }
+      xi_total /= n;
+      order[i][0] = xi_total;
+
+      // compute potential derivative to xi
+
+      double edelta;
+      if (xi_total < xi0) {
+        nbr[i].duxi = 0.0;
+        edelta = 0.0;
+        order[i][1] = 0.0;
+      } else if (xi_total > xi1) {
+        nbr[i].duxi = 0.0;
+        edelta = Vxi;
+        order[i][1] = 1.0;
+      } else {
+        const double omega = MY_PI2*(xi_total-xi0) / (xi1-xi0);
+        nbr[i].duxi = MY_PI*Vxi*sin(2.0*omega) / (2.0*(xi1-xi0));
+        edelta = Vxi*(1 - cos(2.0*omega)) / 2.0;
+        order[i][1] = omega / MY_PI2;
+      }
+      e_thr += edelta;
+    }
+
+    delete [] sort;
+
+#if defined(_OPENMP)
+#pragma omp critical
+#endif
+    {
+      added_energy += e_thr;
+      count += count_thr;
+      if (minc_thr < mincount) mincount = minc_thr;
+      if (maxc_thr > maxcount) maxcount = maxc_thr;
+    }
+  }
+
+  // communicate to acquire nbr data for ghost atoms
+
+  comm->forward_comm(this);
+
+  // compute grain boundary force on each owned atom
+  // skip atoms not in group
+  // only f[i] is written, so the per-atom partition is race-free
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(dynamic) default(shared)
+#endif
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    if (!(mask[i] & groupbit)) continue;
+    const int n = nbr[i].n;
+    const double duxi = nbr[i].duxi;
+
+    for (int j = 0; j < n; j++) {
+      double *dxiptr = &nbr[i].dxi[j][0];
+      if (use_xismooth) {
+        const double xismooth = nbr[i].xismooth[j];
+        f[i][0] += duxi * dxiptr[0] * xismooth;
+        f[i][1] += duxi * dxiptr[1] * xismooth;
+        f[i][2] += duxi * dxiptr[2] * xismooth;
+      } else {
+        f[i][0] += duxi * dxiptr[0];
+        f[i][1] += duxi * dxiptr[1];
+        f[i][2] += duxi * dxiptr[2];
+      }
+
+      // m = local index of neighbor
+      // id_self = ID for atom I in atom M's neighbor list
+      // if M is local atom, id_self will be local ID of atom I
+      // if M is ghost atom, id_self will be global ID of atom I
+
+      const int m = nbr[i].id[j];
+      tagint id_self;
+      if (m < nlocal) id_self = i;
+      else id_self = tag[i];
+      bool found_myself = false;
+      const int nn = nbr[m].n;
+
+      for (int k = 0; k < nn; k++) {
+        if (id_self == nbr[m].id[k]) {
+          if (found_myself) error->one(FLERR,"Fix orient/bcc found self twice");
+          found_myself = true;
+          const double duxi_other = nbr[m].duxi;
+          dxiptr = &nbr[m].dxi[k][0];
+          if (use_xismooth) {
+            const double xismooth = nbr[m].xismooth[k];
+            f[i][0] -= duxi_other * dxiptr[0] * xismooth;
+            f[i][1] -= duxi_other * dxiptr[1] * xismooth;
+            f[i][2] -= duxi_other * dxiptr[2] * xismooth;
+          } else {
+            f[i][0] -= duxi_other * dxiptr[0];
+            f[i][1] -= duxi_other * dxiptr[1];
+            f[i][2] -= duxi_other * dxiptr[2];
+          }
+        }
+      }
+    }
+  }
+
+  // print statistics every nstats timesteps
+
+  if (nstats && update->ntimestep % nstats == 0) {
+    int total;
+    MPI_Allreduce(&count,&total,1,MPI_INT,MPI_SUM,world);
+    double ave = static_cast<double>(total)/atom->natoms;
+
+    int min,max;
+    MPI_Allreduce(&mincount,&min,1,MPI_INT,MPI_MIN,world);
+    MPI_Allreduce(&maxcount,&max,1,MPI_INT,MPI_MAX,world);
+
+    if (me == 0) {
+      std::string mesg = fmt::format("orient step {}: {} atoms have {} "
+                                     "neighbors\n", update->ntimestep,
+                                     atom->natoms,total);
+      mesg += fmt::format("  neighs: min = {}, max ={}, ave = {}\n",
+                          min,max,ave);
+      utils::logmesg(lmp,mesg);
+    }
+  }
+}

--- a/src/OPENMP/fix_orient_bcc_omp.h
+++ b/src/OPENMP/fix_orient_bcc_omp.h
@@ -1,0 +1,33 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef FIX_CLASS
+// clang-format off
+FixStyle(orient/bcc/omp,FixOrientBCCOMP);
+// clang-format on
+#else
+
+#ifndef LMP_FIX_ORIENT_BCC_OMP_H
+#define LMP_FIX_ORIENT_BCC_OMP_H
+
+#include "fix_orient_bcc.h"
+
+namespace LAMMPS_NS {
+
+class FixOrientBCCOMP : public FixOrientBCC {
+ public:
+  FixOrientBCCOMP(class LAMMPS *, int, char **);
+  void post_force(int) override;
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/fix_orient_eco_omp.cpp
+++ b/src/OPENMP/fix_orient_eco_omp.cpp
@@ -1,0 +1,250 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "fix_orient_eco_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "math_const.h"
+#include "memory.h"
+#include "neigh_list.h"
+
+#include <cmath>
+
+#if defined(_OPENMP)
+#include <omp.h>
+#endif
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+using namespace MathConst;
+
+/* ---------------------------------------------------------------------- */
+
+FixOrientECOOMP::FixOrientECOOMP(LAMMPS *lmp, int narg, char **arg) :
+  FixOrientECO(lmp, narg, arg)
+{
+}
+
+/* ----------------------------------------------------------------------
+   threaded version of FixOrientECO::post_force().
+
+   Phase 1 (order parameter + wave-function terms) writes only the owning
+   atom's nbr[i]/order[i] slots and reduces added_energy across threads.
+   Phase 2 (force) writes ONLY f[i] -- it reads neighbor data nbr[j]
+   (acquired for ghosts via the forward_comm) but never writes f[j].  All
+   per-atom scratch is declared inside the loop bodies so it is thread
+   private.  Bit-for-bit identical to the serial result per atom.
+------------------------------------------------------------------------- */
+
+void FixOrientECOOMP::post_force(int /* vflag */)
+{
+  const double omega_pre = MY_PI2 * inv_eta;
+  const double duchi_pre = half_u * MY_PI * inv_eta * inv_norm_fac;
+
+  added_energy = 0.0;
+
+  double **x = atom->x;
+  double **f = atom->f;
+  int *mask = atom->mask;
+  const int nall = atom->nlocal + atom->nghost;
+
+  const int inum = list->inum;
+  int *ilist = list->ilist;
+  int *numneigh = list->numneigh;
+  int **firstneigh = list->firstneigh;
+
+  // ensure nbr and order data structures are adequate size
+
+  if (nall > nmax) {
+    nmax = nall;
+    memory->destroy(nbr);
+    memory->destroy(order);
+    nbr = (Nbr *) memory->smalloc(nmax * sizeof(Nbr), "orient/eco:nbr");
+    memory->create(order, nmax, 2, "orient/eco:order");
+    array_atom = order;
+  }
+
+  // loop over owned atoms and compute order parameter
+
+  double e_acc = 0.0;
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(dynamic) default(shared) reduction(+:e_acc)
+#endif
+  for (int ii = 0; ii < inum; ++ii) {
+    const int i = ilist[ii];
+    int *jlist = firstneigh[i];
+    const int jnum = numneigh[i];
+
+    // initializations
+    double chi = 0.0;
+    for (int k = 0; k < 3; ++k) {
+      nbr[i].real_phi[0][k] = nbr[i].real_phi[1][k] = 0.0;
+      nbr[i].imag_phi[0][k] = nbr[i].imag_phi[1][k] = 0.0;
+    }
+
+    // loop over all neighbors of atom i
+    for (int jj = 0; jj < jnum; ++jj) {
+      int j = jlist[jj];
+      j &= NEIGHMASK;
+
+      const double dx = x[i][0] - x[j][0];
+      const double dy = x[i][1] - x[j][1];
+      const double dz = x[i][2] - x[j][2];
+      double squared_distance = dx * dx + dy * dy + dz * dz;
+
+      if (squared_distance < squared_cutoff) {
+        squared_distance *= inv_squared_cutoff;
+        const double weight = squared_distance * (squared_distance - 2.0) + 1.0;
+
+        for (int lambda = 0; lambda < 2; ++lambda) {
+          for (int k = 0; k < 3; ++k) {
+            const double scalar_product = reciprocal_vectors[lambda][k][0] * dx +
+              reciprocal_vectors[lambda][k][1] * dy + reciprocal_vectors[lambda][k][2] * dz;
+            nbr[i].real_phi[lambda][k] += weight * cos(scalar_product);
+            nbr[i].imag_phi[lambda][k] += weight * sin(scalar_product);
+          }
+        }
+      }
+    }
+
+    // collect contributions
+    for (int k = 0; k < 3; ++k) {
+      chi += (nbr[i].real_phi[0][k] * nbr[i].real_phi[0][k] + nbr[i].imag_phi[0][k] * nbr[i].imag_phi[0][k] -
+                nbr[i].real_phi[1][k] * nbr[i].real_phi[1][k] - nbr[i].imag_phi[1][k] * nbr[i].imag_phi[1][k]);
+    }
+    chi *= inv_norm_fac;
+    order[i][0] = chi;
+
+    // compute normalized order parameter
+    // and potential energy
+    if (chi > eta) {
+      e_acc += half_u;
+      nbr[i].duchi = 0.0;
+      order[i][1] = sign;
+    } else if (chi < -eta) {
+      e_acc -= half_u;
+      nbr[i].duchi = 0.0;
+      order[i][1] = -sign;
+    } else {
+      const double omega = omega_pre * chi;
+      const double sin_om = sin(omega);
+
+      e_acc += half_u * sin_om;
+      nbr[i].duchi = duchi_pre * cos(omega);
+      order[i][1] = sign * sin_om;
+    }
+
+    // compute product with potential derivative
+    for (int k = 0; k < 3; ++k) {
+      for (int lambda = 0; lambda < 2; ++lambda) {
+        nbr[i].real_phi[lambda][k] *= nbr[i].duchi;
+        nbr[i].imag_phi[lambda][k] *= nbr[i].duchi;
+      }
+    }
+  }
+
+  added_energy = e_acc;
+
+  // compute force only if synthetic potential is not zero
+
+  if (u_0 != 0.0) {
+    // communicate to acquire nbr data for ghost atoms
+    comm->forward_comm(this);
+
+    // loop over all atoms; only f[i] is written -> race-free partition
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(dynamic) default(shared)
+#endif
+    for (int ii = 0; ii < inum; ++ii) {
+      const int i = ilist[ii];
+
+      // skip atoms not in group
+      if (!(mask[i] & groupbit)) continue;
+
+      int *jlist = firstneigh[i];
+      const int jnum = numneigh[i];
+      const bool no_boundary_atom = (nbr[i].duchi == 0.0);
+
+      // per-atom scratch (thread private)
+      double gradient_ii_cos[2][3][3];
+      double gradient_ii_sin[2][3][3];
+      double gradient_ij_vec[2][3][3];
+      double gradient_ij_sca[2][3];
+
+      for (int k = 0; k < 3; ++k) {
+        for (int lambda = 0; lambda < 2; ++lambda) {
+          for (int dim = 0; dim < 3; ++dim) {
+            gradient_ii_cos[lambda][k][dim] = 0.0;
+            gradient_ii_sin[lambda][k][dim] = 0.0;
+            gradient_ij_vec[lambda][k][dim] = 0.0;
+          }
+          gradient_ij_sca[lambda][k] = 0.0;
+        }
+      }
+
+      // loop over all neighbors of atom i
+      // for those within squared_cutoff, compute force
+      for (int jj = 0; jj < jnum; ++jj) {
+        int j = jlist[jj];
+        j &= NEIGHMASK;
+
+        // do not compute force on atom i if it is far from boundary
+        if ((nbr[j].duchi == 0.0) && no_boundary_atom) continue;
+
+        const double dx = x[i][0] - x[j][0];
+        const double dy = x[i][1] - x[j][1];
+        const double dz = x[i][2] - x[j][2];
+        double squared_distance = dx * dx + dy * dy + dz * dz;
+
+        if (squared_distance < squared_cutoff) {
+          squared_distance *= inv_squared_cutoff;
+          const double weight = squared_distance * (squared_distance - 2.0) + 1.0;
+          const double weight_gradient_prefactor = 4.0 * (squared_distance - 1.0) * inv_squared_cutoff;
+          double weight_gradient[3];
+          weight_gradient[0] = weight_gradient_prefactor * dx;
+          weight_gradient[1] = weight_gradient_prefactor * dy;
+          weight_gradient[2] = weight_gradient_prefactor * dz;
+
+          for (int lambda = 0; lambda < 2; ++lambda) {
+            for (int k = 0; k < 3; ++k) {
+              const double scalar_product = reciprocal_vectors[lambda][k][0] * dx +
+                reciprocal_vectors[lambda][k][1] * dy + reciprocal_vectors[lambda][k][2] * dz;
+              const double cos_scalar_product = cos(scalar_product);
+              const double sin_scalar_product = sin(scalar_product);
+              for (int dim = 0; dim < 3; ++dim) {
+                const double gcos_scalar_product = weight_gradient[dim] * cos_scalar_product;
+                const double gsin_scalar_product = weight_gradient[dim] * sin_scalar_product;
+                gradient_ii_cos[lambda][k][dim] += gcos_scalar_product;
+                gradient_ii_sin[lambda][k][dim] += gsin_scalar_product;
+                gradient_ij_vec[lambda][k][dim] += (nbr[j].real_phi[lambda][k] * gcos_scalar_product -
+                                                    nbr[j].imag_phi[lambda][k] * gsin_scalar_product);
+              }
+              gradient_ij_sca[lambda][k] += weight * (nbr[j].real_phi[lambda][k] * sin_scalar_product +
+                                                      nbr[j].imag_phi[lambda][k] * cos_scalar_product);
+            }
+          }
+        }
+      }
+
+      // sum contributions
+      for (int k = 0; k < 3; ++k) {
+        for (int dim = 0; dim < 3; ++dim) {
+          f[i][dim] -= (nbr[i].real_phi[0][k] * gradient_ii_cos[0][k][dim] + nbr[i].imag_phi[0][k] * gradient_ii_sin[0][k][dim] + gradient_ij_vec[0][k][dim] + reciprocal_vectors[1][k][dim] * gradient_ij_sca[1][k]);
+          f[i][dim] += (nbr[i].real_phi[1][k] * gradient_ii_cos[1][k][dim] + nbr[i].imag_phi[1][k] * gradient_ii_sin[1][k][dim] + gradient_ij_vec[1][k][dim] + reciprocal_vectors[0][k][dim] * gradient_ij_sca[0][k]);
+        }
+      }
+    }
+  }
+}

--- a/src/OPENMP/fix_orient_eco_omp.h
+++ b/src/OPENMP/fix_orient_eco_omp.h
@@ -1,0 +1,33 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef FIX_CLASS
+// clang-format off
+FixStyle(orient/eco/omp,FixOrientECOOMP);
+// clang-format on
+#else
+
+#ifndef LMP_FIX_ORIENT_ECO_OMP_H
+#define LMP_FIX_ORIENT_ECO_OMP_H
+
+#include "fix_orient_eco.h"
+
+namespace LAMMPS_NS {
+
+class FixOrientECOOMP : public FixOrientECO {
+ public:
+  FixOrientECOOMP(class LAMMPS *, int, char **);
+  void post_force(int) override;
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/fix_orient_fcc_omp.cpp
+++ b/src/OPENMP/fix_orient_fcc_omp.cpp
@@ -1,0 +1,288 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "fix_orient_fcc_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "error.h"
+#include "math_const.h"
+#include "memory.h"
+#include "neigh_list.h"
+#include "update.h"
+
+#include <cmath>
+#include <cstdlib>
+
+#if defined(_OPENMP)
+#include <omp.h>
+#endif
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+using namespace MathConst;
+
+static constexpr int BIG = 1000000000;
+
+/* ---------------------------------------------------------------------- */
+
+FixOrientFCCOMP::FixOrientFCCOMP(LAMMPS *lmp, int narg, char **arg) :
+  FixOrientFCC(lmp, narg, arg)
+{
+}
+
+/* ----------------------------------------------------------------------
+   threaded version of FixOrientFCC::post_force().
+
+   Phase 1 (build per-atom Nbr structure + order parameter) is
+   embarrassingly parallel over owned atoms: each atom writes only its own
+   nbr[i]/order[i] slots.  The shared sort scratch of the serial version is
+   replaced by a per-thread buffer, and added_energy / neighbor-count
+   statistics are reduced across threads.
+
+   Phase 2 (apply grain-boundary force) writes ONLY f[i] for the owned
+   atom i -- it reads the neighbor data nbr[m] (acquired for ghosts via the
+   forward_comm between phases) but never writes f[m]/f[j].  Hence it is
+   race-free over a per-atom partition and needs no per-thread force buffer.
+------------------------------------------------------------------------- */
+
+void FixOrientFCCOMP::post_force(int /*vflag*/)
+{
+  // set local ptrs
+
+  double **x = atom->x;
+  double **f = atom->f;
+  int *mask = atom->mask;
+  tagint *tag = atom->tag;
+  const int nlocal = atom->nlocal;
+  const int nall = atom->nlocal + atom->nghost;
+
+  const int inum = list->inum;
+  int *ilist = list->ilist;
+  int *numneigh = list->numneigh;
+  int **firstneigh = list->firstneigh;
+
+  // ensure nbr and order data structures are adequate size
+
+  if (nall > nmax) {
+    nmax = nall;
+    memory->destroy(nbr);
+    memory->destroy(order);
+    nbr = (Nbr *) memory->smalloc(nmax*sizeof(Nbr),"orient/fcc:nbr");
+    memory->create(order,nmax,2,"orient/fcc:order");
+    array_atom = order;
+  }
+
+  added_energy = 0.0;
+  int count = 0;
+  int mincount = BIG;
+  int maxcount = 0;
+
+  // loop over owned atoms and build Nbr data structure of neighbors
+  // use full neighbor list
+
+#if defined(_OPENMP)
+#pragma omp parallel default(shared)
+#endif
+  {
+    Sort *sort = nullptr;
+    int sortmax = 0;
+    double e_thr = 0.0;
+    int count_thr = 0, minc_thr = BIG, maxc_thr = 0;
+
+#if defined(_OPENMP)
+#pragma omp for schedule(dynamic)
+#endif
+    for (int ii = 0; ii < inum; ii++) {
+      const int i = ilist[ii];
+      int *jlist = firstneigh[i];
+      const int jnum = numneigh[i];
+
+      if (jnum < minc_thr) minc_thr = jnum;
+      if (jnum > maxc_thr) maxc_thr = jnum;
+      if (jnum > sortmax) {
+        delete [] sort;
+        sortmax = jnum;
+        sort = new Sort[sortmax];
+      }
+
+      // loop over all neighbors of atom i
+      // for those within cutsq, build sort data structure
+
+      int nsort = 0;
+      for (int jj = 0; jj < jnum; jj++) {
+        int j = jlist[jj];
+        j &= NEIGHMASK;
+        count_thr++;
+
+        const double dx = x[i][0] - x[j][0];
+        const double dy = x[i][1] - x[j][1];
+        const double dz = x[i][2] - x[j][2];
+        const double rsq = dx*dx + dy*dy + dz*dz;
+
+        if (rsq < cutsq) {
+          sort[nsort].id = j;
+          sort[nsort].rsq = rsq;
+          sort[nsort].delta[0] = dx;
+          sort[nsort].delta[1] = dy;
+          sort[nsort].delta[2] = dz;
+          if (use_xismooth) {
+            const double xismooth = (xicutoffsq - 2.0*rsq/(a*a)) / (xicutoffsq - 1.0);
+            sort[nsort].xismooth = 1.0 - fabs(1.0-xismooth);
+          }
+          nsort++;
+        }
+      }
+
+      // sort neighbors by rsq distance
+      // no need to sort if nsort <= 12
+
+      if (nsort > 12) qsort(sort,nsort,sizeof(Sort),compare);
+
+      // copy up to 12 nearest neighbors into nbr data structure
+      // operate on delta vector via find_best_ref() to compute dxi
+
+      const int n = MIN(12,nsort);
+      nbr[i].n = n;
+      if (n == 0) continue;
+
+      double xi_total = 0.0;
+      double xi_sq, dxi[3];
+      for (int j = 0; j < n; j++) {
+        find_best_ref(sort[j].delta,0,xi_sq,dxi);
+        xi_total += sqrt(xi_sq);
+        nbr[i].id[j] = sort[j].id;
+        nbr[i].dxi[j][0] = dxi[0]/n;
+        nbr[i].dxi[j][1] = dxi[1]/n;
+        nbr[i].dxi[j][2] = dxi[2]/n;
+        if (use_xismooth) nbr[i].xismooth[j] = sort[j].xismooth;
+      }
+      xi_total /= n;
+      order[i][0] = xi_total;
+
+      // compute potential derivative to xi
+
+      double edelta;
+      if (xi_total < xi0) {
+        nbr[i].duxi = 0.0;
+        edelta = 0.0;
+        order[i][1] = 0.0;
+      } else if (xi_total > xi1) {
+        nbr[i].duxi = 0.0;
+        edelta = Vxi;
+        order[i][1] = 1.0;
+      } else {
+        const double omega = MY_PI2*(xi_total-xi0) / (xi1-xi0);
+        nbr[i].duxi = MY_PI*Vxi*sin(2.0*omega) / (2.0*(xi1-xi0));
+        edelta = Vxi*(1 - cos(2.0*omega)) / 2.0;
+        order[i][1] = omega / MY_PI2;
+      }
+      e_thr += edelta;
+    }
+
+    delete [] sort;
+
+#if defined(_OPENMP)
+#pragma omp critical
+#endif
+    {
+      added_energy += e_thr;
+      count += count_thr;
+      if (minc_thr < mincount) mincount = minc_thr;
+      if (maxc_thr > maxcount) maxcount = maxc_thr;
+    }
+  }
+
+  // communicate to acquire nbr data for ghost atoms
+
+  comm->forward_comm(this);
+
+  // compute grain boundary force on each owned atom
+  // skip atoms not in group
+  // only f[i] is written, so the per-atom partition is race-free
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(dynamic) default(shared)
+#endif
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    if (!(mask[i] & groupbit)) continue;
+    const int n = nbr[i].n;
+    const double duxi = nbr[i].duxi;
+
+    for (int j = 0; j < n; j++) {
+      double *dxiptr = &nbr[i].dxi[j][0];
+      if (use_xismooth) {
+        const double xismooth = nbr[i].xismooth[j];
+        f[i][0] += duxi * dxiptr[0] * xismooth;
+        f[i][1] += duxi * dxiptr[1] * xismooth;
+        f[i][2] += duxi * dxiptr[2] * xismooth;
+      } else {
+        f[i][0] += duxi * dxiptr[0];
+        f[i][1] += duxi * dxiptr[1];
+        f[i][2] += duxi * dxiptr[2];
+      }
+
+      // m = local index of neighbor
+      // id_self = ID for atom I in atom M's neighbor list
+      // if M is local atom, id_self will be local ID of atom I
+      // if M is ghost atom, id_self will be global ID of atom I
+
+      const int m = nbr[i].id[j];
+      tagint id_self;
+      if (m < nlocal) id_self = i;
+      else id_self = tag[i];
+      bool found_myself = false;
+      const int nn = nbr[m].n;
+
+      for (int k = 0; k < nn; k++) {
+        if (id_self == nbr[m].id[k]) {
+          if (found_myself) error->one(FLERR,"Fix orient/fcc found self twice");
+          found_myself = true;
+          const double duxi_other = nbr[m].duxi;
+          dxiptr = &nbr[m].dxi[k][0];
+          if (use_xismooth) {
+            const double xismooth = nbr[m].xismooth[k];
+            f[i][0] -= duxi_other * dxiptr[0] * xismooth;
+            f[i][1] -= duxi_other * dxiptr[1] * xismooth;
+            f[i][2] -= duxi_other * dxiptr[2] * xismooth;
+          } else {
+            f[i][0] -= duxi_other * dxiptr[0];
+            f[i][1] -= duxi_other * dxiptr[1];
+            f[i][2] -= duxi_other * dxiptr[2];
+          }
+        }
+      }
+    }
+  }
+
+  // print statistics every nstats timesteps
+
+  if (nstats && update->ntimestep % nstats == 0) {
+    int total;
+    MPI_Allreduce(&count,&total,1,MPI_INT,MPI_SUM,world);
+    double ave = static_cast<double>(total)/atom->natoms;
+
+    int min,max;
+    MPI_Allreduce(&mincount,&min,1,MPI_INT,MPI_MIN,world);
+    MPI_Allreduce(&maxcount,&max,1,MPI_INT,MPI_MAX,world);
+
+    if (me == 0) {
+      std::string mesg = fmt::format("orient step {}: {} atoms have {} "
+                                     "neighbors\n", update->ntimestep,
+                                     atom->natoms,total);
+      mesg += fmt::format("  neighs: min = {}, max ={}, ave = {}\n",
+                          min,max,ave);
+      utils::logmesg(lmp,mesg);
+    }
+  }
+}

--- a/src/OPENMP/fix_orient_fcc_omp.h
+++ b/src/OPENMP/fix_orient_fcc_omp.h
@@ -1,0 +1,33 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef FIX_CLASS
+// clang-format off
+FixStyle(orient/fcc/omp,FixOrientFCCOMP);
+// clang-format on
+#else
+
+#ifndef LMP_FIX_ORIENT_FCC_OMP_H
+#define LMP_FIX_ORIENT_FCC_OMP_H
+
+#include "fix_orient_fcc.h"
+
+namespace LAMMPS_NS {
+
+class FixOrientFCCOMP : public FixOrientFCC {
+ public:
+  FixOrientFCCOMP(class LAMMPS *, int, char **);
+  void post_force(int) override;
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/fix_qeq_ctip_omp.cpp
+++ b/src/OPENMP/fix_qeq_ctip_omp.cpp
@@ -1,0 +1,292 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "fix_qeq_ctip_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "error.h"
+#include "ewald_const.h"
+#include "force.h"
+#include "kspace.h"
+#include "math_const.h"
+#include "memory.h"
+#include "neigh_list.h"
+#include "neighbor.h"
+#include "update.h"
+
+#include <cmath>
+
+#if defined(_OPENMP)
+#include <omp.h>
+#endif
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+using namespace EwaldConst;
+using namespace MathConst;
+
+static constexpr double DANGER_ZONE = 0.95;
+
+/* ---------------------------------------------------------------------- */
+
+FixQEqCTIPOMP::FixQEqCTIPOMP(LAMMPS *lmp, int narg, char **arg) :
+  FixQEqCTIP(lmp, narg, arg), b_temp(nullptr), nmax_btmp(0)
+{
+}
+
+/* ---------------------------------------------------------------------- */
+
+FixQEqCTIPOMP::~FixQEqCTIPOMP()
+{
+  memory->destroy(b_temp);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixQEqCTIPOMP::pre_force(int /*vflag*/)
+{
+  int i, n, nout;
+
+  if (update->ntimestep % nevery) return;
+
+  nlocal = atom->nlocal;
+
+  if (atom->nmax > nmax) reallocate_storage();
+
+  if (nlocal > n_cap*DANGER_ZONE || m_fill > m_cap*DANGER_ZONE)
+    reallocate_matrix();
+
+  const int nthreads = comm->nthreads;
+  if (atom->nmax > nmax_btmp) {
+    memory->destroy(b_temp);
+    nmax_btmp = atom->nmax;
+    memory->create(b_temp, nthreads, nmax_btmp, "qeq/ctip/omp:b_temp");
+  }
+
+  for (i = 1; i <= maxrepeat; i++) {
+    init_matvec();
+    matvecs = CG(b_s, s);
+    matvecs += CG(b_t, t);
+    matvecs /= 2;
+    n = calculate_check_Q();
+    MPI_Allreduce(&n, &nout, 1, MPI_INT, MPI_SUM, world);
+    if (nout == 0) break;
+  }
+
+  if (i > maxrepeat && comm->me == 0)
+    error->all(FLERR, Error::NOLASTLINE, "Fix qeq some charges not bound within the domain");
+
+  if (force->kspace) force->kspace->qsum_qsq();
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixQEqCTIPOMP::init_matvec()
+{
+  compute_H();
+
+  int inum, ii, i;
+  int *ilist;
+  double *q = atom->q, qi;
+  int *type = atom->type;
+
+  inum = list->inum;
+  ilist = list->ilist;
+
+  for (ii = 0; ii < inum; ++ii) {
+    i = ilist[ii];
+    if (atom->mask[i] & groupbit) {
+
+      qi = q[i];
+      if (qi < qmin[type[i]]) {
+        Hdia_inv[i] = 1. / (eta[type[i]]+2*omega[type[i]]-s2d_self[type[i]-1]);
+        b_s[i]      = -((chi[type[i]]-2*qmin[type[i]]*omega[type[i]]) + chizj[i]);
+      } else if (qi < qmax[type[i]]) {
+        Hdia_inv[i] = 1. / (eta[type[i]]-s2d_self[type[i]-1]);
+        b_s[i]      = -(chi[type[i]] + chizj[i]);
+      } else {
+        Hdia_inv[i] = 1. / (eta[type[i]]+2*omega[type[i]]-s2d_self[type[i]-1]);
+        b_s[i]      = -((chi[type[i]]-2*qmax[type[i]]*omega[type[i]]) + chizj[i]);
+      }
+
+      b_t[i]      = -1.0;
+      t[i] = t_hist[i][2] + 3 * (t_hist[i][0] - t_hist[i][1]);
+      s[i] = 4*(s_hist[i][0]+s_hist[i][2])-(6*s_hist[i][1]+s_hist[i][3]);
+    }
+  }
+
+  pack_flag = 2;
+  comm->forward_comm(this); //Dist_vector(s);
+  pack_flag = 3;
+  comm->forward_comm(this); //Dist_vector(t);
+}
+
+/* ----------------------------------------------------------------------
+   threaded build of the ctip H matrix (full neighbor list).  Two-pass
+   (count -> serial sum-scan offsets -> fill) reproduces the serial
+   FixQEqCTIP::compute_H() packed CSR layout.
+------------------------------------------------------------------------- */
+
+void FixQEqCTIPOMP::compute_H()
+{
+  int *ilist, *numneigh, **firstneigh;
+  double **x = atom->x;
+  int *mask = atom->mask;
+  int *type = atom->type;
+
+  const int inum = list->inum;
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // pass 1: count neighbors within cutoff for each atom
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(dynamic,50) default(shared)
+#endif
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    if (mask[i] & groupbit) {
+      const int *jlist = firstneigh[i];
+      const int jnum = numneigh[i];
+      int cnt = 0;
+      for (int jj = 0; jj < jnum; jj++) {
+        const int j = jlist[jj] & NEIGHMASK;
+        const double dx = x[j][0] - x[i][0];
+        const double dy = x[j][1] - x[i][1];
+        const double dz = x[j][2] - x[i][2];
+        if (dx*dx + dy*dy + dz*dz <= cutoff_sq) cnt++;
+      }
+      H.numnbrs[i] = cnt;
+    }
+  }
+
+  // serial sum-scan: assign contiguous CSR offsets in ilist order
+
+  m_fill = 0;
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    if (mask[i] & groupbit) {
+      H.firstnbr[i] = m_fill;
+      m_fill += H.numnbrs[i];
+    }
+  }
+
+  // pass 2: fill each atom's contiguous block (race-free)
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(dynamic,50) default(shared)
+#endif
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    if (mask[i] & groupbit) {
+      const int *jlist = firstneigh[i];
+      const int jnum = numneigh[i];
+      const int itype = type[i];
+      int mfill = H.firstnbr[i];
+      for (int jj = 0; jj < jnum; jj++) {
+        const int j = jlist[jj] & NEIGHMASK;
+        const double dx = x[j][0] - x[i][0];
+        const double dy = x[j][1] - x[i][1];
+        const double dz = x[j][2] - x[i][2];
+        const double r_sqr = dx*dx + dy*dy + dz*dz;
+        if (r_sqr <= cutoff_sq) {
+          const int jtype = type[j];
+          const double r = sqrt(r_sqr);
+          const double reff = cbrt(r_sqr * r + 1 / shieldcu[itype-1][jtype-1]);
+          const double erfcd = exp(-cdamp * cdamp * r_sqr);
+          const double tt = 1.0 / (1.0 + EWALD_P * cdamp * r);
+          const double erfcc = tt * (A1 + tt * (A2 + tt * (A3 + tt * (A4 + tt * A5)))) * erfcd;
+          H.jlist[mfill] = j;
+          H.val[mfill] = 0.5*force->qqr2e*(erfcc/r+1/reff-1/r-e_shift[itype-1][jtype-1]
+                          +f_shift[itype-1][jtype-1]*(r-cutoff)
+                          -s2d_shift[itype-1][jtype-1]*0.5*(r-cutoff)*(r-cutoff));
+          mfill++;
+        }
+      }
+    }
+  }
+
+  if (m_fill >= H.m)
+    error->all(FLERR, Error::NOLASTLINE,
+               "Fix qeq/ctip/omp has insufficient H matrix size: m_fill={} H.m={}\n",m_fill, H.m);
+}
+
+/* ----------------------------------------------------------------------
+   threaded sparse matrix-vector product (ctip qmin/qmax diagonal)
+------------------------------------------------------------------------- */
+
+void FixQEqCTIPOMP::sparse_matvec(sparse_matrix *A, double *x, double *b)
+{
+  const int nthreads = comm->nthreads;
+  double *q = atom->q;
+  int *type = atom->type;
+
+#if defined(_OPENMP)
+#pragma omp parallel default(shared)
+#endif
+  {
+    int tid = 0;
+#if defined(_OPENMP)
+    tid = omp_get_thread_num();
+#endif
+    const int nloc = atom->nlocal;
+    const int na = atom->nlocal + atom->nghost;
+    double *b_t = b_temp[tid];
+
+#if defined(_OPENMP)
+#pragma omp for schedule(dynamic,50)
+#endif
+    for (int i = 0; i < nloc; ++i) {
+      if (atom->mask[i] & groupbit) {
+        const double qi = q[i];
+        if (qi < qmin[type[i]]) {
+          b[i] = (eta[type[i]]+2*omega[type[i]]-s2d_self[type[i]-1])*x[i];
+        } else if (qi < qmax[type[i]]) {
+          b[i] = (eta[type[i]]-s2d_self[type[i]-1]) * x[i];
+        } else {
+          b[i] = (eta[type[i]]+2*omega[type[i]]-s2d_self[type[i]-1])*x[i];
+        }
+      }
+    }
+
+#if defined(_OPENMP)
+#pragma omp for schedule(dynamic,50)
+#endif
+    for (int i = nloc; i < na; ++i)
+      if (atom->mask[i] & groupbit) b[i] = 0.0;
+
+    for (int i = 0; i < na; ++i) b_t[i] = 0.0;
+
+#if defined(_OPENMP)
+#pragma omp barrier
+#pragma omp for schedule(dynamic,50)
+#endif
+    for (int i = 0; i < nloc; ++i) {
+      if (atom->mask[i] & groupbit) {
+        for (int itr_j = A->firstnbr[i]; itr_j < A->firstnbr[i]+A->numnbrs[i]; itr_j++) {
+          int j = A->jlist[itr_j];
+          b[i] += A->val[itr_j] * x[j];
+          b_t[j] += A->val[itr_j] * x[i];
+        }
+      }
+    }
+
+#if defined(_OPENMP)
+#pragma omp barrier
+#pragma omp for schedule(dynamic,50)
+#endif
+    for (int i = 0; i < na; ++i)
+      for (int t = 0; t < nthreads; ++t) b[i] += b_temp[t][i];
+  }
+}

--- a/src/OPENMP/fix_qeq_ctip_omp.h
+++ b/src/OPENMP/fix_qeq_ctip_omp.h
@@ -3,41 +3,40 @@
    https://www.lammps.org/, Sandia National Laboratories
    LAMMPS development team: developers@lammps.org
 
-   Copyright (2003) Sandia Corporation.  Under the terms of Contract
-   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
-   certain rights in this software.  This software is distributed under
-   the GNU General Public License.
+   This software is distributed under the GNU General Public License.
 
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
 #ifdef FIX_CLASS
 // clang-format off
-FixStyle(qeq/shielded,FixQEqShielded);
+FixStyle(qeq/ctip/omp,FixQEqCTIPOMP);
 // clang-format on
 #else
 
-#ifndef LMP_FIX_QEQ_SHIELDED_H
-#define LMP_FIX_QEQ_SHIELDED_H
+#ifndef LMP_FIX_QEQ_CTIP_OMP_H
+#define LMP_FIX_QEQ_CTIP_OMP_H
 
-#include "fix_qeq.h"
+#include "fix_qeq_ctip.h"
 
 namespace LAMMPS_NS {
 
-class FixQEqShielded : public FixQEq {
+class FixQEqCTIPOMP : public FixQEqCTIP {
  public:
-  FixQEqShielded(class LAMMPS *, int, char **);
-
-  void init() override;
+  FixQEqCTIPOMP(class LAMMPS *, int, char **);
+  ~FixQEqCTIPOMP() override;
   void pre_force(int) override;
 
  protected:
-  void extract_reax();
-  void init_shielding();
   void init_matvec();
   void compute_H();
-  double calculate_H(double, double);
+  void sparse_matvec(sparse_matrix *, double *, double *) override;
+
+  double **b_temp;
+  int nmax_btmp;
 };
+
 }    // namespace LAMMPS_NS
+
 #endif
 #endif

--- a/src/OPENMP/fix_qeq_dynamic_omp.cpp
+++ b/src/OPENMP/fix_qeq_dynamic_omp.cpp
@@ -1,0 +1,141 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "fix_qeq_dynamic_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "memory.h"
+#include "neigh_list.h"
+
+#include <cmath>
+
+#if defined(_OPENMP)
+#include <omp.h>
+#endif
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+FixQEqDynamicOMP::FixQEqDynamicOMP(LAMMPS *lmp, int narg, char **arg) :
+  FixQEqDynamic(lmp, narg, arg), b_temp(nullptr), nmax_btmp(0)
+{
+}
+
+/* ---------------------------------------------------------------------- */
+
+FixQEqDynamicOMP::~FixQEqDynamicOMP()
+{
+  memory->destroy(b_temp);
+}
+
+/* ----------------------------------------------------------------------
+   threaded matrix-free charge-force evaluation.  The forward/reverse
+   communication (which zeroes ghost qf and sums ghost contributions back
+   to their owners) stays serial; only the O(N*neigh) accumulation loop is
+   threaded.  The qf[j] cross-write is deferred to per-thread b_temp and
+   reduced, reproducing the serial FixQEqDynamic::compute_eneg().
+------------------------------------------------------------------------- */
+
+double FixQEqDynamicOMP::compute_eneg()
+{
+  int *ilist, *numneigh, **firstneigh;
+  int *type = atom->type;
+  int *mask = atom->mask;
+  double *q = atom->q;
+  double **x = atom->x;
+
+  const int inum = list->inum;
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  const int nthreads = comm->nthreads;
+  if (atom->nmax > nmax_btmp) {
+    memory->destroy(b_temp);
+    nmax_btmp = atom->nmax;
+    memory->create(b_temp, nthreads, nmax_btmp, "qeq/dynamic/omp:b_temp");
+  }
+
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    if (mask[i] & groupbit) qf[i] = 0.0;
+  }
+
+  // communicate charge force to all nodes, first forward then reverse
+  pack_flag = 2;
+  comm->forward_comm(this);
+
+  const int nall = atom->nlocal + atom->nghost;
+
+#if defined(_OPENMP)
+#pragma omp parallel default(shared)
+#endif
+  {
+    int tid = 0;
+#if defined(_OPENMP)
+    tid = omp_get_thread_num();
+#endif
+    double *qf_t = b_temp[tid];
+    for (int i = 0; i < nall; ++i) qf_t[i] = 0.0;
+
+#if defined(_OPENMP)
+#pragma omp barrier
+#pragma omp for schedule(dynamic,50)
+#endif
+    for (int ii = 0; ii < inum; ii++) {
+      const int i = ilist[ii];
+      const int itype = type[i];
+      if (mask[i] & groupbit) {
+        qf[i] += chi[itype] + eta[itype] * q[i];
+
+        const int *jlist = firstneigh[i];
+        const int jnum = numneigh[i];
+
+        for (int jj = 0; jj < jnum; jj++) {
+          const int j = jlist[jj] & NEIGHMASK;
+          const double dx = x[i][0] - x[j][0];
+          const double dy = x[i][1] - x[j][1];
+          const double dz = x[i][2] - x[j][2];
+          const double rsq = dx*dx + dy*dy + dz*dz;
+          if (rsq > cutoff_sq) continue;
+
+          const double rinv = 1.0 / sqrt(rsq);
+          qf[i] += q[j] * rinv;
+          qf_t[j] += q[i] * rinv;
+        }
+      }
+    }
+
+#if defined(_OPENMP)
+#pragma omp barrier
+#pragma omp for schedule(dynamic,50)
+#endif
+    for (int i = 0; i < nall; ++i)
+      for (int t = 0; t < nthreads; ++t) qf[i] += b_temp[t][i];
+  }
+
+  pack_flag = 2;
+  comm->reverse_comm(this);
+
+  // sum charge force on each node and return it
+
+  double eneg = 0.0, enegtot = 0.0;
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    if (mask[i] & groupbit) eneg += qf[i];
+  }
+  MPI_Allreduce(&eneg, &enegtot, 1, MPI_DOUBLE, MPI_SUM, world);
+  return enegtot;
+}

--- a/src/OPENMP/fix_qeq_dynamic_omp.h
+++ b/src/OPENMP/fix_qeq_dynamic_omp.h
@@ -1,0 +1,39 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef FIX_CLASS
+// clang-format off
+FixStyle(qeq/dynamic/omp,FixQEqDynamicOMP);
+// clang-format on
+#else
+
+#ifndef LMP_FIX_QEQ_DYNAMIC_OMP_H
+#define LMP_FIX_QEQ_DYNAMIC_OMP_H
+
+#include "fix_qeq_dynamic.h"
+
+namespace LAMMPS_NS {
+
+class FixQEqDynamicOMP : public FixQEqDynamic {
+ public:
+  FixQEqDynamicOMP(class LAMMPS *, int, char **);
+  ~FixQEqDynamicOMP() override;
+
+ protected:
+  double compute_eneg() override;
+
+  double **b_temp;
+  int nmax_btmp;
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/fix_qeq_fire_omp.cpp
+++ b/src/OPENMP/fix_qeq_fire_omp.cpp
@@ -1,0 +1,141 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "fix_qeq_fire_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "memory.h"
+#include "neigh_list.h"
+
+#include <cmath>
+
+#if defined(_OPENMP)
+#include <omp.h>
+#endif
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+FixQEqFireOMP::FixQEqFireOMP(LAMMPS *lmp, int narg, char **arg) :
+  FixQEqFire(lmp, narg, arg), b_temp(nullptr), nmax_btmp(0)
+{
+}
+
+/* ---------------------------------------------------------------------- */
+
+FixQEqFireOMP::~FixQEqFireOMP()
+{
+  memory->destroy(b_temp);
+}
+
+/* ----------------------------------------------------------------------
+   threaded matrix-free charge-force evaluation.  The forward/reverse
+   communication (which zeroes ghost qf and sums ghost contributions back
+   to their owners) stays serial; only the O(N*neigh) accumulation loop is
+   threaded.  The qf[j] cross-write is deferred to per-thread b_temp and
+   reduced, reproducing the serial FixQEqFire::compute_eneg().
+------------------------------------------------------------------------- */
+
+double FixQEqFireOMP::compute_eneg()
+{
+  int *ilist, *numneigh, **firstneigh;
+  int *type = atom->type;
+  int *mask = atom->mask;
+  double *q = atom->q;
+  double **x = atom->x;
+
+  const int inum = list->inum;
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  const int nthreads = comm->nthreads;
+  if (atom->nmax > nmax_btmp) {
+    memory->destroy(b_temp);
+    nmax_btmp = atom->nmax;
+    memory->create(b_temp, nthreads, nmax_btmp, "qeq/fire/omp:b_temp");
+  }
+
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    if (mask[i] & groupbit) qf[i] = 0.0;
+  }
+
+  // communicate charge force to all nodes, first forward then reverse
+  pack_flag = 2;
+  comm->forward_comm(this);
+
+  const int nall = atom->nlocal + atom->nghost;
+
+#if defined(_OPENMP)
+#pragma omp parallel default(shared)
+#endif
+  {
+    int tid = 0;
+#if defined(_OPENMP)
+    tid = omp_get_thread_num();
+#endif
+    double *qf_t = b_temp[tid];
+    for (int i = 0; i < nall; ++i) qf_t[i] = 0.0;
+
+#if defined(_OPENMP)
+#pragma omp barrier
+#pragma omp for schedule(dynamic,50)
+#endif
+    for (int ii = 0; ii < inum; ii++) {
+      const int i = ilist[ii];
+      const int itype = type[i];
+      if (mask[i] & groupbit) {
+        qf[i] += chi[itype] + eta[itype] * q[i];
+
+        const int *jlist = firstneigh[i];
+        const int jnum = numneigh[i];
+
+        for (int jj = 0; jj < jnum; jj++) {
+          const int j = jlist[jj] & NEIGHMASK;
+          const double dx = x[i][0] - x[j][0];
+          const double dy = x[i][1] - x[j][1];
+          const double dz = x[i][2] - x[j][2];
+          const double rsq = dx*dx + dy*dy + dz*dz;
+          if (rsq > cutoff_sq) continue;
+
+          const double rinv = 1.0 / sqrt(rsq);
+          qf[i] += q[j] * rinv;
+          qf_t[j] += q[i] * rinv;
+        }
+      }
+    }
+
+#if defined(_OPENMP)
+#pragma omp barrier
+#pragma omp for schedule(dynamic,50)
+#endif
+    for (int i = 0; i < nall; ++i)
+      for (int t = 0; t < nthreads; ++t) qf[i] += b_temp[t][i];
+  }
+
+  pack_flag = 2;
+  comm->reverse_comm(this);
+
+  // sum charge force on each node and return it
+
+  double eneg = 0.0, enegtot = 0.0;
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    if (mask[i] & groupbit) eneg += qf[i];
+  }
+  MPI_Allreduce(&eneg, &enegtot, 1, MPI_DOUBLE, MPI_SUM, world);
+  return enegtot;
+}

--- a/src/OPENMP/fix_qeq_fire_omp.h
+++ b/src/OPENMP/fix_qeq_fire_omp.h
@@ -1,0 +1,39 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef FIX_CLASS
+// clang-format off
+FixStyle(qeq/fire/omp,FixQEqFireOMP);
+// clang-format on
+#else
+
+#ifndef LMP_FIX_QEQ_FIRE_OMP_H
+#define LMP_FIX_QEQ_FIRE_OMP_H
+
+#include "fix_qeq_fire.h"
+
+namespace LAMMPS_NS {
+
+class FixQEqFireOMP : public FixQEqFire {
+ public:
+  FixQEqFireOMP(class LAMMPS *, int, char **);
+  ~FixQEqFireOMP() override;
+
+ protected:
+  double compute_eneg() override;
+
+  double **b_temp;
+  int nmax_btmp;
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/fix_qeq_point_omp.cpp
+++ b/src/OPENMP/fix_qeq_point_omp.cpp
@@ -1,0 +1,247 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "fix_qeq_point_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "error.h"
+#include "force.h"
+#include "kspace.h"
+#include "memory.h"
+#include "neigh_list.h"
+#include "neighbor.h"
+#include "update.h"
+
+#include <cmath>
+
+#if defined(_OPENMP)
+#include <omp.h>
+#endif
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+
+static constexpr double DANGER_ZONE = 0.95;
+
+/* ---------------------------------------------------------------------- */
+
+FixQEqPointOMP::FixQEqPointOMP(LAMMPS *lmp, int narg, char **arg) :
+  FixQEqPoint(lmp, narg, arg), b_temp(nullptr), nmax_btmp(0)
+{
+}
+
+/* ---------------------------------------------------------------------- */
+
+FixQEqPointOMP::~FixQEqPointOMP()
+{
+  memory->destroy(b_temp);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixQEqPointOMP::pre_force(int /*vflag*/)
+{
+  if (update->ntimestep % nevery) return;
+
+  nlocal = atom->nlocal;
+
+  if (atom->nmax > nmax) reallocate_storage();
+
+  if (nlocal > n_cap*DANGER_ZONE || m_fill > m_cap*DANGER_ZONE)
+    reallocate_matrix();
+
+  // (re)allocate per-thread scatter buffers for sparse_matvec
+
+  const int nthreads = comm->nthreads;
+  if (atom->nmax > nmax_btmp) {
+    memory->destroy(b_temp);
+    nmax_btmp = atom->nmax;
+    memory->create(b_temp, nthreads, nmax_btmp, "qeq/point/omp:b_temp");
+  }
+
+  init_matvec();
+  matvecs = CG(b_s, s);         // CG on s - parallel
+  matvecs += CG(b_t, t);        // CG on t - parallel
+  matvecs /= 2;
+  calculate_Q();
+
+  if (force->kspace) force->kspace->qsum_qsq();
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixQEqPointOMP::init_matvec()
+{
+  compute_H();
+
+  int inum, ii, i;
+  int *ilist;
+
+  inum = list->inum;
+  ilist = list->ilist;
+
+  for (ii = 0; ii < inum; ++ii) {
+    i = ilist[ii];
+    if (atom->mask[i] & groupbit) {
+      Hdia_inv[i] = 1. / eta[atom->type[i]];
+      b_s[i]      = -(chi[atom->type[i]] + chizj[i]);
+      b_t[i]      = -1.0;
+      t[i] = t_hist[i][2] + 3 * (t_hist[i][0] - t_hist[i][1]);
+      s[i] = 4*(s_hist[i][0]+s_hist[i][2])-(6*s_hist[i][1]+s_hist[i][3]);
+    }
+  }
+
+  pack_flag = 2;
+  comm->forward_comm(this); //Dist_vector(s);
+  pack_flag = 3;
+  comm->forward_comm(this); //Dist_vector(t);
+}
+
+/* ----------------------------------------------------------------------
+   threaded build of the sparse H matrix.  A serial sum-scan over the
+   per-atom (filtered) neighbor counts assigns each atom a contiguous,
+   non-overlapping block in the CSR arrays, so the two per-atom fill passes
+   are race-free.  The resulting matrix layout is identical to the serial
+   FixQEqPoint::compute_H().
+------------------------------------------------------------------------- */
+
+void FixQEqPointOMP::compute_H()
+{
+  int *ilist, *numneigh, **firstneigh;
+  double **x = atom->x;
+  int *mask = atom->mask;
+
+  const int inum = list->inum;
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // pass 1: count neighbors within cutoff for each atom
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(dynamic,50) default(shared)
+#endif
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    if (mask[i] & groupbit) {
+      const int *jlist = firstneigh[i];
+      const int jnum = numneigh[i];
+      int cnt = 0;
+      for (int jj = 0; jj < jnum; jj++) {
+        const int j = jlist[jj] & NEIGHMASK;
+        const double dx = x[j][0] - x[i][0];
+        const double dy = x[j][1] - x[i][1];
+        const double dz = x[j][2] - x[i][2];
+        if (dx*dx + dy*dy + dz*dz <= cutoff_sq) cnt++;
+      }
+      H.numnbrs[i] = cnt;
+    }
+  }
+
+  // serial sum-scan: assign contiguous CSR offsets in ilist order
+
+  m_fill = 0;
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    if (mask[i] & groupbit) {
+      H.firstnbr[i] = m_fill;
+      m_fill += H.numnbrs[i];
+    }
+  }
+
+  // pass 2: fill each atom's contiguous block (race-free)
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(dynamic,50) default(shared)
+#endif
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    if (mask[i] & groupbit) {
+      const int *jlist = firstneigh[i];
+      const int jnum = numneigh[i];
+      int mfill = H.firstnbr[i];
+      for (int jj = 0; jj < jnum; jj++) {
+        const int j = jlist[jj] & NEIGHMASK;
+        const double dx = x[j][0] - x[i][0];
+        const double dy = x[j][1] - x[i][1];
+        const double dz = x[j][2] - x[i][2];
+        const double r_sqr = dx*dx + dy*dy + dz*dz;
+        if (r_sqr <= cutoff_sq) {
+          H.jlist[mfill] = j;
+          H.val[mfill] = 0.5/sqrt(r_sqr);
+          mfill++;
+        }
+      }
+    }
+  }
+}
+
+/* ----------------------------------------------------------------------
+   threaded sparse matrix-vector product.  The diagonal/gather part writes
+   only b[i] (race-free under the omp for over i).  The symmetric scatter
+   b[j] += val*x[i] is accumulated into per-thread buffers and reduced, to
+   avoid races on shared j (ghosts / cross-thread neighbors).
+------------------------------------------------------------------------- */
+
+void FixQEqPointOMP::sparse_matvec(sparse_matrix *A, double *x, double *b)
+{
+  const int nthreads = comm->nthreads;
+
+#if defined(_OPENMP)
+#pragma omp parallel default(shared)
+#endif
+  {
+    int tid = 0;
+#if defined(_OPENMP)
+    tid = omp_get_thread_num();
+#endif
+    const int nloc = atom->nlocal;
+    const int nall = atom->nlocal + atom->nghost;
+    double *b_t = b_temp[tid];
+
+#if defined(_OPENMP)
+#pragma omp for schedule(dynamic,50)
+#endif
+    for (int i = 0; i < nloc; ++i)
+      if (atom->mask[i] & groupbit) b[i] = eta[atom->type[i]] * x[i];
+
+#if defined(_OPENMP)
+#pragma omp for schedule(dynamic,50)
+#endif
+    for (int i = nloc; i < nall; ++i)
+      if (atom->mask[i] & groupbit) b[i] = 0.0;
+
+    for (int i = 0; i < nall; ++i) b_t[i] = 0.0;
+
+#if defined(_OPENMP)
+#pragma omp barrier
+#pragma omp for schedule(dynamic,50)
+#endif
+    for (int i = 0; i < nloc; ++i) {
+      if (atom->mask[i] & groupbit) {
+        for (int itr_j = A->firstnbr[i]; itr_j < A->firstnbr[i]+A->numnbrs[i]; itr_j++) {
+          int j = A->jlist[itr_j];
+          b[i] += A->val[itr_j] * x[j];
+          b_t[j] += A->val[itr_j] * x[i];
+        }
+      }
+    }
+
+#if defined(_OPENMP)
+#pragma omp barrier
+#pragma omp for schedule(dynamic,50)
+#endif
+    for (int i = 0; i < nall; ++i)
+      for (int t = 0; t < nthreads; ++t) b[i] += b_temp[t][i];
+  }
+}

--- a/src/OPENMP/fix_qeq_point_omp.h
+++ b/src/OPENMP/fix_qeq_point_omp.h
@@ -3,41 +3,40 @@
    https://www.lammps.org/, Sandia National Laboratories
    LAMMPS development team: developers@lammps.org
 
-   Copyright (2003) Sandia Corporation.  Under the terms of Contract
-   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
-   certain rights in this software.  This software is distributed under
-   the GNU General Public License.
+   This software is distributed under the GNU General Public License.
 
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
 #ifdef FIX_CLASS
 // clang-format off
-FixStyle(qeq/shielded,FixQEqShielded);
+FixStyle(qeq/point/omp,FixQEqPointOMP);
 // clang-format on
 #else
 
-#ifndef LMP_FIX_QEQ_SHIELDED_H
-#define LMP_FIX_QEQ_SHIELDED_H
+#ifndef LMP_FIX_QEQ_POINT_OMP_H
+#define LMP_FIX_QEQ_POINT_OMP_H
 
-#include "fix_qeq.h"
+#include "fix_qeq_point.h"
 
 namespace LAMMPS_NS {
 
-class FixQEqShielded : public FixQEq {
+class FixQEqPointOMP : public FixQEqPoint {
  public:
-  FixQEqShielded(class LAMMPS *, int, char **);
-
-  void init() override;
+  FixQEqPointOMP(class LAMMPS *, int, char **);
+  ~FixQEqPointOMP() override;
   void pre_force(int) override;
 
  protected:
-  void extract_reax();
-  void init_shielding();
   void init_matvec();
   void compute_H();
-  double calculate_H(double, double);
+  void sparse_matvec(sparse_matrix *, double *, double *) override;
+
+  double **b_temp;
+  int nmax_btmp;
 };
+
 }    // namespace LAMMPS_NS
+
 #endif
 #endif

--- a/src/OPENMP/fix_qeq_shielded_omp.cpp
+++ b/src/OPENMP/fix_qeq_shielded_omp.cpp
@@ -1,0 +1,243 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "fix_qeq_shielded_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "error.h"
+#include "force.h"
+#include "kspace.h"
+#include "memory.h"
+#include "neigh_list.h"
+#include "neighbor.h"
+#include "update.h"
+
+#include <cmath>
+
+#if defined(_OPENMP)
+#include <omp.h>
+#endif
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+
+static constexpr double DANGER_ZONE = 0.95;
+
+/* ---------------------------------------------------------------------- */
+
+FixQEqShieldedOMP::FixQEqShieldedOMP(LAMMPS *lmp, int narg, char **arg) :
+  FixQEqShielded(lmp, narg, arg), b_temp(nullptr), nmax_btmp(0)
+{
+}
+
+/* ---------------------------------------------------------------------- */
+
+FixQEqShieldedOMP::~FixQEqShieldedOMP()
+{
+  memory->destroy(b_temp);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixQEqShieldedOMP::pre_force(int /*vflag*/)
+{
+  if (update->ntimestep % nevery) return;
+
+  nlocal = atom->nlocal;
+
+  if (atom->nmax > nmax) reallocate_storage();
+
+  if (nlocal > n_cap*DANGER_ZONE || m_fill > m_cap*DANGER_ZONE)
+    reallocate_matrix();
+
+  const int nthreads = comm->nthreads;
+  if (atom->nmax > nmax_btmp) {
+    memory->destroy(b_temp);
+    nmax_btmp = atom->nmax;
+    memory->create(b_temp, nthreads, nmax_btmp, "qeq/shielded/omp:b_temp");
+  }
+
+  init_matvec();
+  matvecs = CG(b_s, s);
+  matvecs += CG(b_t, t);
+  matvecs /= 2;
+  calculate_Q();
+
+  if (force->kspace) force->kspace->qsum_qsq();
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixQEqShieldedOMP::init_matvec()
+{
+  compute_H();
+
+  int inum, ii, i;
+  int *ilist;
+
+  inum = list->inum;
+  ilist = list->ilist;
+
+  for (ii = 0; ii < inum; ++ii) {
+    i = ilist[ii];
+    if (atom->mask[i] & groupbit) {
+      Hdia_inv[i] = 1. / eta[atom->type[i]];
+      b_s[i]      = -(chi[atom->type[i]] + chizj[i]);
+      b_t[i]      = -1.0;
+      t[i] = t_hist[i][2] + 3 * (t_hist[i][0] - t_hist[i][1]);
+      s[i] = 4*(s_hist[i][0]+s_hist[i][2])-(6*s_hist[i][1]+s_hist[i][3]);
+    }
+  }
+
+  pack_flag = 2;
+  comm->forward_comm(this); //Dist_vector(s);
+  pack_flag = 3;
+  comm->forward_comm(this); //Dist_vector(t);
+}
+
+/* ----------------------------------------------------------------------
+   threaded build of the sparse H matrix (shielded coulomb).  Serial
+   sum-scan over per-atom filtered neighbor counts gives contiguous,
+   non-overlapping CSR blocks, so the two per-atom fill passes are race-free
+   and reproduce the serial FixQEqShielded::compute_H() layout.
+------------------------------------------------------------------------- */
+
+void FixQEqShieldedOMP::compute_H()
+{
+  int *ilist, *numneigh, **firstneigh;
+  int *type = atom->type;
+  double **x = atom->x;
+  int *mask = atom->mask;
+
+  const int inum = list->inum;
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // pass 1: count neighbors within cutoff for each atom
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(dynamic,50) default(shared)
+#endif
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    if (mask[i] & groupbit) {
+      const int *jlist = firstneigh[i];
+      const int jnum = numneigh[i];
+      int cnt = 0;
+      for (int jj = 0; jj < jnum; jj++) {
+        const int j = jlist[jj] & NEIGHMASK;
+        const double dx = x[j][0] - x[i][0];
+        const double dy = x[j][1] - x[i][1];
+        const double dz = x[j][2] - x[i][2];
+        if (dx*dx + dy*dy + dz*dz <= cutoff_sq) cnt++;
+      }
+      H.numnbrs[i] = cnt;
+    }
+  }
+
+  // serial sum-scan: assign contiguous CSR offsets in ilist order
+
+  m_fill = 0;
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    if (mask[i] & groupbit) {
+      H.firstnbr[i] = m_fill;
+      m_fill += H.numnbrs[i];
+    }
+  }
+
+  // pass 2: fill each atom's contiguous block (race-free)
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(dynamic,50) default(shared)
+#endif
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    if (mask[i] & groupbit) {
+      const int *jlist = firstneigh[i];
+      const int jnum = numneigh[i];
+      const int itype = type[i];
+      int mfill = H.firstnbr[i];
+      for (int jj = 0; jj < jnum; jj++) {
+        const int j = jlist[jj] & NEIGHMASK;
+        const double dx = x[j][0] - x[i][0];
+        const double dy = x[j][1] - x[i][1];
+        const double dz = x[j][2] - x[i][2];
+        const double r_sqr = dx*dx + dy*dy + dz*dz;
+        if (r_sqr <= cutoff_sq) {
+          H.jlist[mfill] = j;
+          H.val[mfill] = 0.5 * calculate_H(sqrt(r_sqr), shld[itype][type[j]]);
+          mfill++;
+        }
+      }
+    }
+  }
+}
+
+/* ----------------------------------------------------------------------
+   threaded sparse matrix-vector product (see fix_qeq_point_omp.cpp)
+------------------------------------------------------------------------- */
+
+void FixQEqShieldedOMP::sparse_matvec(sparse_matrix *A, double *x, double *b)
+{
+  const int nthreads = comm->nthreads;
+
+#if defined(_OPENMP)
+#pragma omp parallel default(shared)
+#endif
+  {
+    int tid = 0;
+#if defined(_OPENMP)
+    tid = omp_get_thread_num();
+#endif
+    const int nloc = atom->nlocal;
+    const int nall = atom->nlocal + atom->nghost;
+    double *b_t = b_temp[tid];
+
+#if defined(_OPENMP)
+#pragma omp for schedule(dynamic,50)
+#endif
+    for (int i = 0; i < nloc; ++i)
+      if (atom->mask[i] & groupbit) b[i] = eta[atom->type[i]] * x[i];
+
+#if defined(_OPENMP)
+#pragma omp for schedule(dynamic,50)
+#endif
+    for (int i = nloc; i < nall; ++i)
+      if (atom->mask[i] & groupbit) b[i] = 0.0;
+
+    for (int i = 0; i < nall; ++i) b_t[i] = 0.0;
+
+#if defined(_OPENMP)
+#pragma omp barrier
+#pragma omp for schedule(dynamic,50)
+#endif
+    for (int i = 0; i < nloc; ++i) {
+      if (atom->mask[i] & groupbit) {
+        for (int itr_j = A->firstnbr[i]; itr_j < A->firstnbr[i]+A->numnbrs[i]; itr_j++) {
+          int j = A->jlist[itr_j];
+          b[i] += A->val[itr_j] * x[j];
+          b_t[j] += A->val[itr_j] * x[i];
+        }
+      }
+    }
+
+#if defined(_OPENMP)
+#pragma omp barrier
+#pragma omp for schedule(dynamic,50)
+#endif
+    for (int i = 0; i < nall; ++i)
+      for (int t = 0; t < nthreads; ++t) b[i] += b_temp[t][i];
+  }
+}

--- a/src/OPENMP/fix_qeq_shielded_omp.h
+++ b/src/OPENMP/fix_qeq_shielded_omp.h
@@ -3,41 +3,40 @@
    https://www.lammps.org/, Sandia National Laboratories
    LAMMPS development team: developers@lammps.org
 
-   Copyright (2003) Sandia Corporation.  Under the terms of Contract
-   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
-   certain rights in this software.  This software is distributed under
-   the GNU General Public License.
+   This software is distributed under the GNU General Public License.
 
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
 #ifdef FIX_CLASS
 // clang-format off
-FixStyle(qeq/shielded,FixQEqShielded);
+FixStyle(qeq/shielded/omp,FixQEqShieldedOMP);
 // clang-format on
 #else
 
-#ifndef LMP_FIX_QEQ_SHIELDED_H
-#define LMP_FIX_QEQ_SHIELDED_H
+#ifndef LMP_FIX_QEQ_SHIELDED_OMP_H
+#define LMP_FIX_QEQ_SHIELDED_OMP_H
 
-#include "fix_qeq.h"
+#include "fix_qeq_shielded.h"
 
 namespace LAMMPS_NS {
 
-class FixQEqShielded : public FixQEq {
+class FixQEqShieldedOMP : public FixQEqShielded {
  public:
-  FixQEqShielded(class LAMMPS *, int, char **);
-
-  void init() override;
+  FixQEqShieldedOMP(class LAMMPS *, int, char **);
+  ~FixQEqShieldedOMP() override;
   void pre_force(int) override;
 
  protected:
-  void extract_reax();
-  void init_shielding();
   void init_matvec();
   void compute_H();
-  double calculate_H(double, double);
+  void sparse_matvec(sparse_matrix *, double *, double *) override;
+
+  double **b_temp;
+  int nmax_btmp;
 };
+
 }    // namespace LAMMPS_NS
+
 #endif
 #endif

--- a/src/OPENMP/fix_qeq_slater_omp.cpp
+++ b/src/OPENMP/fix_qeq_slater_omp.cpp
@@ -1,0 +1,261 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "fix_qeq_slater_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "error.h"
+#include "force.h"
+#include "kspace.h"
+#include "math_const.h"
+#include "memory.h"
+#include "neigh_list.h"
+#include "neighbor.h"
+#include "update.h"
+
+#include <cmath>
+
+#if defined(_OPENMP)
+#include <omp.h>
+#endif
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+using namespace MathConst;
+
+static constexpr double DANGER_ZONE = 0.95;
+
+/* ---------------------------------------------------------------------- */
+
+FixQEqSlaterOMP::FixQEqSlaterOMP(LAMMPS *lmp, int narg, char **arg) :
+  FixQEqSlater(lmp, narg, arg), b_temp(nullptr), nmax_btmp(0)
+{
+}
+
+/* ---------------------------------------------------------------------- */
+
+FixQEqSlaterOMP::~FixQEqSlaterOMP()
+{
+  memory->destroy(b_temp);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixQEqSlaterOMP::pre_force(int /*vflag*/)
+{
+  if (update->ntimestep % nevery) return;
+
+  nlocal = atom->nlocal;
+  nall = atom->nlocal + atom->nghost;
+
+  if (atom->nmax > nmax) reallocate_storage();
+
+  if (nlocal > n_cap*DANGER_ZONE || m_fill > m_cap*DANGER_ZONE)
+    reallocate_matrix();
+
+  const int nthreads = comm->nthreads;
+  if (atom->nmax > nmax_btmp) {
+    memory->destroy(b_temp);
+    nmax_btmp = atom->nmax;
+    memory->create(b_temp, nthreads, nmax_btmp, "qeq/slater/omp:b_temp");
+  }
+
+  init_matvec();
+  matvecs = CG(b_s, s);
+  matvecs += CG(b_t, t);
+  matvecs /= 2;
+  calculate_Q();
+
+  if (force->kspace) force->kspace->qsum_qsq();
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixQEqSlaterOMP::init_matvec()
+{
+  compute_H();
+
+  int inum, ii, i;
+  int *ilist;
+
+  inum = list->inum;
+  ilist = list->ilist;
+
+  for (ii = 0; ii < inum; ++ii) {
+    i = ilist[ii];
+    if (atom->mask[i] & groupbit) {
+      Hdia_inv[i] = 1. / eta[atom->type[i]];
+      b_s[i]      = -(chi[atom->type[i]] + chizj[i]);
+      b_t[i]      = -1.0;
+      t[i] = t_hist[i][2] + 3 * (t_hist[i][0] - t_hist[i][1]);
+      s[i] = 4*(s_hist[i][0]+s_hist[i][2])-(6*s_hist[i][1]+s_hist[i][3]);
+    }
+  }
+
+  pack_flag = 2;
+  comm->forward_comm(this); //Dist_vector(s);
+  pack_flag = 3;
+  comm->forward_comm(this); //Dist_vector(t);
+}
+
+/* ----------------------------------------------------------------------
+   threaded build of the slater H matrix.  Two-pass (count -> serial
+   sum-scan offsets -> fill) gives contiguous, non-overlapping CSR blocks
+   that reproduce FixQEqSlater::compute_H().  The per-i chizj accumulation
+   stays local to each atom's block, so no cross-atom race occurs.
+------------------------------------------------------------------------- */
+
+void FixQEqSlaterOMP::compute_H()
+{
+  int *ilist, *numneigh, **firstneigh;
+  int *type = atom->type;
+  double **x = atom->x;
+  int *mask = atom->mask;
+
+  const int inum = list->inum;
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // pass 1: count neighbors within cutoff for each atom
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(dynamic,50) default(shared)
+#endif
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    const int *jlist = firstneigh[i];
+    const int jnum = numneigh[i];
+    int cnt = 0;
+    for (int jj = 0; jj < jnum; jj++) {
+      const int j = jlist[jj] & NEIGHMASK;
+      const double dx = x[i][0] - x[j][0];
+      const double dy = x[i][1] - x[j][1];
+      const double dz = x[i][2] - x[j][2];
+      if (dx*dx + dy*dy + dz*dz <= cutoff_sq) cnt++;
+    }
+    H.numnbrs[i] = cnt;
+  }
+
+  // serial sum-scan: assign contiguous CSR offsets in ilist order
+
+  m_fill = 0;
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    H.firstnbr[i] = m_fill;
+    m_fill += H.numnbrs[i];
+  }
+
+  // pass 2: fill each atom's contiguous block (race-free)
+
+#if defined(_OPENMP)
+#pragma omp parallel for schedule(dynamic,50) default(shared)
+#endif
+  for (int ii = 0; ii < inum; ii++) {
+    const int i = ilist[ii];
+    const int itype = type[i];
+    const double zei = zeta[itype];
+    const int *jlist = firstneigh[i];
+    const int jnum = numneigh[i];
+    int mfill = H.firstnbr[i];
+    double zjtmp = 0.0;
+
+    for (int jj = 0; jj < jnum; jj++) {
+      const int j = jlist[jj] & NEIGHMASK;
+      const int jtype = type[j];
+      const double zej = zeta[jtype];
+      const double zj = zcore[jtype];
+
+      const double dx = x[i][0] - x[j][0];
+      const double dy = x[i][1] - x[j][1];
+      const double dz = x[i][2] - x[j][2];
+      const double rsq = dx*dx + dy*dy + dz*dz;
+      if (rsq > cutoff_sq) continue;
+
+      const double r = sqrt(rsq);
+      H.jlist[mfill] = j;
+      if (vtype == 0)
+        H.val[mfill] = calculate_H(zei, zej, zj, r, zjtmp);
+      else if (vtype == 1)
+        H.val[mfill] = calculate_H_wolf(zei, zej, zj, r, zjtmp);
+      else if (vtype == 2)
+        H.val[mfill] = calculate_H_dsf(zei, zej, zj, r, zjtmp);
+      mfill++;
+    }
+    chizj[i] = zjtmp;
+  }
+
+  if (m_fill >= H.m)
+    error->all(FLERR,"Fix qeq/slater/omp has insufficient H "
+                     "matrix size: m_fill={} H.m={}\n",m_fill,H.m);
+}
+
+/* ----------------------------------------------------------------------
+   threaded sparse matrix-vector product (slater woself diagonal)
+------------------------------------------------------------------------- */
+
+void FixQEqSlaterOMP::sparse_matvec(sparse_matrix *A, double *x, double *b)
+{
+  const int nthreads = comm->nthreads;
+  const double rc = cutoff;
+  const double woself = 0.50*erfc(alpha*rc)/rc + alpha/MY_PIS;
+  const double diag_shift = 2.0*force->qqr2e*woself;
+
+#if defined(_OPENMP)
+#pragma omp parallel default(shared)
+#endif
+  {
+    int tid = 0;
+#if defined(_OPENMP)
+    tid = omp_get_thread_num();
+#endif
+    const int nloc = atom->nlocal;
+    const int na = atom->nlocal + atom->nghost;
+    double *b_t = b_temp[tid];
+
+#if defined(_OPENMP)
+#pragma omp for schedule(dynamic,50)
+#endif
+    for (int i = 0; i < nloc; ++i)
+      if (atom->mask[i] & groupbit) b[i] = (eta[atom->type[i]] - diag_shift) * x[i];
+
+#if defined(_OPENMP)
+#pragma omp for schedule(dynamic,50)
+#endif
+    for (int i = nloc; i < na; ++i)
+      if (atom->mask[i] & groupbit) b[i] = 0.0;
+
+    for (int i = 0; i < na; ++i) b_t[i] = 0.0;
+
+#if defined(_OPENMP)
+#pragma omp barrier
+#pragma omp for schedule(dynamic,50)
+#endif
+    for (int i = 0; i < nloc; ++i) {
+      if (atom->mask[i] & groupbit) {
+        for (int itr_j = A->firstnbr[i]; itr_j < A->firstnbr[i]+A->numnbrs[i]; itr_j++) {
+          int j = A->jlist[itr_j];
+          b[i] += A->val[itr_j] * x[j];
+          b_t[j] += A->val[itr_j] * x[i];
+        }
+      }
+    }
+
+#if defined(_OPENMP)
+#pragma omp barrier
+#pragma omp for schedule(dynamic,50)
+#endif
+    for (int i = 0; i < na; ++i)
+      for (int t = 0; t < nthreads; ++t) b[i] += b_temp[t][i];
+  }
+}

--- a/src/OPENMP/fix_qeq_slater_omp.h
+++ b/src/OPENMP/fix_qeq_slater_omp.h
@@ -3,41 +3,40 @@
    https://www.lammps.org/, Sandia National Laboratories
    LAMMPS development team: developers@lammps.org
 
-   Copyright (2003) Sandia Corporation.  Under the terms of Contract
-   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
-   certain rights in this software.  This software is distributed under
-   the GNU General Public License.
+   This software is distributed under the GNU General Public License.
 
    See the README file in the top-level LAMMPS directory.
 ------------------------------------------------------------------------- */
 
 #ifdef FIX_CLASS
 // clang-format off
-FixStyle(qeq/shielded,FixQEqShielded);
+FixStyle(qeq/slater/omp,FixQEqSlaterOMP);
 // clang-format on
 #else
 
-#ifndef LMP_FIX_QEQ_SHIELDED_H
-#define LMP_FIX_QEQ_SHIELDED_H
+#ifndef LMP_FIX_QEQ_SLATER_OMP_H
+#define LMP_FIX_QEQ_SLATER_OMP_H
 
-#include "fix_qeq.h"
+#include "fix_qeq_slater.h"
 
 namespace LAMMPS_NS {
 
-class FixQEqShielded : public FixQEq {
+class FixQEqSlaterOMP : public FixQEqSlater {
  public:
-  FixQEqShielded(class LAMMPS *, int, char **);
-
-  void init() override;
+  FixQEqSlaterOMP(class LAMMPS *, int, char **);
+  ~FixQEqSlaterOMP() override;
   void pre_force(int) override;
 
  protected:
-  void extract_reax();
-  void init_shielding();
   void init_matvec();
   void compute_H();
-  double calculate_H(double, double);
+  void sparse_matvec(sparse_matrix *, double *, double *) override;
+
+  double **b_temp;
+  int nmax_btmp;
 };
+
 }    // namespace LAMMPS_NS
+
 #endif
 #endif

--- a/src/OPENMP/pair_born_coul_dsf_cs_omp.cpp
+++ b/src/OPENMP/pair_born_coul_dsf_cs_omp.cpp
@@ -1,0 +1,197 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_born_coul_dsf_cs_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "math_const.h"
+#include "math_special.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+using namespace MathConst;
+
+static constexpr double EPSILON = 1.0e-20;
+
+/* ---------------------------------------------------------------------- */
+
+PairBornCoulDSFCSOMP::PairBornCoulDSFCSOMP(LAMMPS *lmp) :
+  PairBornCoulDSFCS(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairBornCoulDSFCSOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairBornCoulDSFCSOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum,itype,jtype;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,ecoul,fpair;
+  double r,rsq,r2inv,r6inv,forcecoul,forceborn,factor_coul,factor_lj;
+  double prefactor,erfcc,erfcd,arg;
+  double rexp;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  evdwl = ecoul = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const double * const q = atom->q;
+  const int * const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * const special_lj = force->special_lj;
+  const double * const special_coul = force->special_coul;
+  const double qqrd2e = force->qqrd2e;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    // self coulombic energy
+    if (EFLAG) {
+      double e_self = -(e_shift/2.0 + alpha/MY_PIS) * qtmp*qtmp*qqrd2e;
+      if (EVFLAG) ev_tally_thr(this,i,i,nlocal,0,0.0,e_self,0.0,0.0,0.0,0.0,thr);
+    }
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_lj = special_lj[sbmask(j)];
+      factor_coul = special_coul[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+      jtype = type[j];
+
+      if (rsq < cutsq[itype][jtype]) {
+        rsq += EPSILON; // Add Epsilon for case: r = 0; Interaction must be removed by special bond;
+        r2inv = 1.0/rsq;
+
+        if (rsq < cut_coulsq) {
+          r = sqrt(rsq);
+          prefactor = qqrd2e*qtmp*q[j] / r;
+          arg = alpha * r ;
+          erfcd = MathSpecial::expmsq(arg);
+          erfcc = MathSpecial::my_erfcx(arg) * erfcd;
+          forcecoul = prefactor * (erfcc/r + 2.0*alpha/MY_PIS * erfcd +
+                                   r*f_shift) * r;
+          if (factor_coul < 1.0) forcecoul -= (1.0-factor_coul)*prefactor;
+        } else forcecoul = 0.0;
+
+        if (rsq < cut_ljsq[itype][jtype]) {
+          r6inv = r2inv*r2inv*r2inv;
+          r = sqrt(rsq);
+          rexp = exp((sigma[itype][jtype]-r)*rhoinv[itype][jtype]);
+          forceborn = born1[itype][jtype]*r*rexp - born2[itype][jtype]*r6inv
+            + born3[itype][jtype]*r2inv*r6inv;
+        } else forceborn = 0.0;
+
+        fpair = (forcecoul + factor_lj*forceborn) * r2inv;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (EFLAG) {
+          if (rsq < cut_coulsq) {
+            ecoul = prefactor * (erfcc - r*e_shift - rsq*f_shift);
+            if (factor_coul < 1.0) ecoul -= (1.0-factor_coul)*prefactor;
+          } else ecoul = 0.0;
+          if (rsq < cut_ljsq[itype][jtype]) {
+            evdwl = a[itype][jtype]*rexp - c[itype][jtype]*r6inv +
+              d[itype][jtype]*r6inv*r2inv - offset[itype][jtype];
+            evdwl *= factor_lj;
+          } else evdwl = 0.0;
+        }
+
+        if (EVFLAG) ev_tally_thr(this, i,j,nlocal,NEWTON_PAIR,
+                                 evdwl,ecoul,fpair,delx,dely,delz,thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairBornCoulDSFCSOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairBornCoulDSFCS::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_born_coul_dsf_cs_omp.h
+++ b/src/OPENMP/pair_born_coul_dsf_cs_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(born/coul/dsf/cs/omp,PairBornCoulDSFCSOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_BORN_COUL_DSF_CS_OMP_H
+#define LMP_PAIR_BORN_COUL_DSF_CS_OMP_H
+
+#include "pair_born_coul_dsf_cs.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairBornCoulDSFCSOMP : public PairBornCoulDSFCS, public ThrOMP {
+
+ public:
+  PairBornCoulDSFCSOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_born_coul_dsf_omp.cpp
+++ b/src/OPENMP/pair_born_coul_dsf_omp.cpp
@@ -1,0 +1,195 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_born_coul_dsf_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "math_const.h"
+#include "math_special.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+using namespace MathConst;
+
+/* ---------------------------------------------------------------------- */
+
+PairBornCoulDSFOMP::PairBornCoulDSFOMP(LAMMPS *lmp) :
+  PairBornCoulDSF(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairBornCoulDSFOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairBornCoulDSFOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum,itype,jtype;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,ecoul,fpair;
+  double r,rsq,r2inv,r6inv,forcecoul,forceborn,factor_coul,factor_lj;
+  double prefactor,erfcc,erfcd,arg;
+  double rexp;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  evdwl = ecoul = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const double * const q = atom->q;
+  const int * const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * const special_lj = force->special_lj;
+  const double * const special_coul = force->special_coul;
+  const double qqrd2e = force->qqrd2e;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    // self coulombic energy
+
+    if (EFLAG) {
+      double e_self = -(e_shift/2.0 + alpha/MY_PIS) * qtmp*qtmp*qqrd2e;
+      if (EVFLAG) ev_tally_thr(this,i,i,nlocal,0,0.0,e_self,0.0,0.0,0.0,0.0,thr);
+    }
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_lj = special_lj[sbmask(j)];
+      factor_coul = special_coul[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+      jtype = type[j];
+
+      if (rsq < cutsq[itype][jtype]) {
+        r2inv = 1.0/rsq;
+
+        if (rsq < cut_coulsq) {
+          r = sqrt(rsq);
+          prefactor = qqrd2e*qtmp*q[j]/r;
+          arg = alpha * r ;
+          erfcd = MathSpecial::expmsq(arg);
+          erfcc = MathSpecial::my_erfcx(arg) * erfcd;
+          forcecoul = prefactor * (erfcc/r + 2.0*alpha/MY_PIS * erfcd +
+                                   r*f_shift) * r;
+          if (factor_coul < 1.0) forcecoul -= (1.0-factor_coul)*prefactor;
+        } else forcecoul = 0.0;
+
+        if (rsq < cut_ljsq[itype][jtype]) {
+          r6inv = r2inv*r2inv*r2inv;
+          r = sqrt(rsq);
+          rexp = exp((sigma[itype][jtype]-r)*rhoinv[itype][jtype]);
+          forceborn = born1[itype][jtype]*r*rexp - born2[itype][jtype]*r6inv
+            + born3[itype][jtype]*r2inv*r6inv;
+        } else forceborn = 0.0;
+
+        fpair = (forcecoul + factor_lj*forceborn) * r2inv;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (EFLAG) {
+          if (rsq < cut_coulsq) {
+            ecoul = prefactor * (erfcc - r*e_shift - rsq*f_shift);
+            if (factor_coul < 1.0) ecoul -= (1.0-factor_coul)*prefactor;
+          } else ecoul = 0.0;
+          if (rsq < cut_ljsq[itype][jtype]) {
+            evdwl = a[itype][jtype]*rexp - c[itype][jtype]*r6inv +
+              d[itype][jtype]*r6inv*r2inv - offset[itype][jtype];
+            evdwl *= factor_lj;
+          } else evdwl = 0.0;
+        }
+
+        if (EVFLAG) ev_tally_thr(this, i,j,nlocal,NEWTON_PAIR,
+                                 evdwl,ecoul,fpair,delx,dely,delz,thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairBornCoulDSFOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairBornCoulDSF::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_born_coul_dsf_omp.h
+++ b/src/OPENMP/pair_born_coul_dsf_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(born/coul/dsf/omp,PairBornCoulDSFOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_BORN_COUL_DSF_OMP_H
+#define LMP_PAIR_BORN_COUL_DSF_OMP_H
+
+#include "pair_born_coul_dsf.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairBornCoulDSFOMP : public PairBornCoulDSF, public ThrOMP {
+
+ public:
+  PairBornCoulDSFOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_born_coul_long_cs_omp.cpp
+++ b/src/OPENMP/pair_born_coul_long_cs_omp.cpp
@@ -1,0 +1,237 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_born_coul_long_cs_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+
+static constexpr double EWALD_F = 1.12837917;
+static constexpr double EWALD_P = 9.95473818e-1;
+static constexpr double B0 = -0.1335096380159268;
+static constexpr double B1 = -2.57839507e-1;
+static constexpr double B2 = -1.37203639e-1;
+static constexpr double B3 = -8.88822059e-3;
+static constexpr double B4 = -5.80844129e-3;
+static constexpr double B5 = 1.14652755e-1;
+
+static constexpr double EPSILON = 1.0e-20;
+static constexpr double EPS_EWALD = 1.0e-6;
+static constexpr double EPS_EWALD_SQR = 1.0e-12;
+
+/* ---------------------------------------------------------------------- */
+
+PairBornCoulLongCSOMP::PairBornCoulLongCSOMP(LAMMPS *lmp) :
+  PairBornCoulLongCS(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+  cut_respa = nullptr;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairBornCoulLongCSOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairBornCoulLongCSOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum,itable,itype,jtype;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,ecoul,fpair;
+  double fraction,table;
+  double rsq,r2inv,r6inv,forcecoul,forceborn,factor_coul,factor_lj;
+  double grij,expm2,prefactor,t,erfc,u;
+  double r,rexp;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  evdwl = ecoul = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const double * const q = atom->q;
+  const int * const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * const special_coul = force->special_coul;
+  const double * const special_lj = force->special_lj;
+  const double qqrd2e = force->qqrd2e;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_lj = special_lj[sbmask(j)];
+      factor_coul = special_coul[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+      jtype = type[j];
+
+      if (rsq < cutsq[itype][jtype]) {
+        rsq += EPSILON; // Add Epsilon for case: r = 0; Interaction must be removed by special bond;
+        r2inv = 1.0/rsq;
+        if (rsq < cut_coulsq) {
+          if (!ncoultablebits || rsq <= tabinnersq) {
+            r = sqrt(rsq);
+            prefactor = qqrd2e * qtmp*q[j];
+            if (factor_coul < 1.0) {
+              // When bonded parts are being calculated a minimal distance (EPS_EWALD)
+              // has to be added to the prefactor and erfc in order to make the
+              // used approximation functions valid
+              grij = g_ewald * (r+EPS_EWALD);
+              expm2 = exp(-grij*grij);
+              t = 1.0 / (1.0 + EWALD_P*grij);
+              u = 1.0 - t;
+              erfc = t * (1.+u*(B0+u*(B1+u*(B2+u*(B3+u*(B4+u*B5)))))) * expm2;
+              prefactor /= (r+EPS_EWALD);
+              forcecoul = prefactor * (erfc + EWALD_F*grij*expm2 - (1.0-factor_coul));
+              // Additionally r2inv needs to be accordingly modified since the later
+              // scaling of the overall force shall be consistent
+              r2inv = 1.0/(rsq + EPS_EWALD_SQR);
+            } else {
+              grij = g_ewald * r;
+              expm2 = exp(-grij*grij);
+              t = 1.0 / (1.0 + EWALD_P*grij);
+              u = 1.0 - t;
+              erfc = t * (1.+u*(B0+u*(B1+u*(B2+u*(B3+u*(B4+u*B5)))))) * expm2;
+              prefactor /= r;
+              forcecoul = prefactor * (erfc + EWALD_F*grij*expm2);
+            }
+          } else {
+            union_int_float_t rsq_lookup;
+            rsq_lookup.f = rsq;
+            itable = rsq_lookup.i & ncoulmask;
+            itable >>= ncoulshiftbits;
+            fraction = ((double) rsq_lookup.f - rtable[itable]) * drtable[itable];
+            table = ftable[itable] + fraction*dftable[itable];
+            forcecoul = qtmp*q[j] * table;
+            if (factor_coul < 1.0) {
+              table = ctable[itable] + fraction*dctable[itable];
+              prefactor = qtmp*q[j] * table;
+              forcecoul -= (1.0-factor_coul)*prefactor;
+            }
+          }
+        } else forcecoul = 0.0;
+
+        if (rsq < cut_ljsq[itype][jtype]) {
+          r = sqrt(rsq);
+          r6inv = r2inv*r2inv*r2inv;
+          rexp = exp((sigma[itype][jtype]-r)*rhoinv[itype][jtype]);
+          forceborn = born1[itype][jtype]*r*rexp - born2[itype][jtype]*r6inv
+            + born3[itype][jtype]*r2inv*r6inv;
+        } else forceborn = 0.0;
+
+        fpair = (forcecoul + factor_lj*forceborn) * r2inv;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (EFLAG) {
+          if (rsq < cut_coulsq) {
+            if (!ncoultablebits || rsq <= tabinnersq)
+              ecoul = prefactor*erfc;
+            else {
+              table = etable[itable] + fraction*detable[itable];
+              ecoul = qtmp*q[j] * table;
+            }
+            if (factor_coul < 1.0) ecoul -= (1.0-factor_coul)*prefactor;
+          } else ecoul = 0.0;
+          if (rsq < cut_ljsq[itype][jtype]) {
+            evdwl = a[itype][jtype]*rexp - c[itype][jtype]*r6inv
+              + d[itype][jtype]*r6inv*r2inv - offset[itype][jtype];
+            evdwl *= factor_lj;
+          } else evdwl = 0.0;
+        }
+
+        if (EVFLAG) ev_tally_thr(this, i,j,nlocal,NEWTON_PAIR,
+                                 evdwl,ecoul,fpair,delx,dely,delz,thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairBornCoulLongCSOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairBornCoulLongCS::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_born_coul_long_cs_omp.h
+++ b/src/OPENMP/pair_born_coul_long_cs_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(born/coul/long/cs/omp,PairBornCoulLongCSOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_BORN_COUL_LONG_CS_OMP_H
+#define LMP_PAIR_BORN_COUL_LONG_CS_OMP_H
+
+#include "pair_born_coul_long_cs.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairBornCoulLongCSOMP : public PairBornCoulLongCS, public ThrOMP {
+
+ public:
+  PairBornCoulLongCSOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_born_coul_wolf_cs_omp.cpp
+++ b/src/OPENMP/pair_born_coul_wolf_cs_omp.cpp
@@ -1,0 +1,203 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_born_coul_wolf_cs_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "math_const.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+using namespace MathConst;
+
+static constexpr double EPSILON = 1.0e-20;
+
+/* ---------------------------------------------------------------------- */
+
+PairBornCoulWolfCSOMP::PairBornCoulWolfCSOMP(LAMMPS *lmp) :
+  PairBornCoulWolfCS(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairBornCoulWolfCSOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairBornCoulWolfCSOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum,itype,jtype;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,ecoul,fpair;
+  double rsq,r2inv,r6inv,forcecoul,forceborn,factor_coul,factor_lj;
+  double prefactor;
+  double r,rexp;
+  double erfcc,erfcd,v_sh,dvdrr,e_self,e_shift,f_shift,qisq;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  evdwl = ecoul = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const double * const q = atom->q;
+  const int * const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * const special_coul = force->special_coul;
+  const double * const special_lj = force->special_lj;
+  const double qqrd2e = force->qqrd2e;
+
+  // self and shifted coulombic energy
+
+  e_self = v_sh = 0.0;
+  e_shift = erfc(alf*cut_coul)/cut_coul;
+  f_shift = -(e_shift+ 2.0*alf/MY_PIS * exp(-alf*alf*cut_coul*cut_coul)) / cut_coul;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    qisq = qtmp*qtmp;
+    e_self = -(e_shift/2.0 + alf/MY_PIS) * qisq*qqrd2e;
+    if (EVFLAG) ev_tally_thr(this,i,i,nlocal,0,0.0,e_self,0.0,0.0,0.0,0.0,thr);
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_lj = special_lj[sbmask(j)];
+      factor_coul = special_coul[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+      jtype = type[j];
+
+      if (rsq < cutsq[itype][jtype]) {
+        rsq += EPSILON;
+        // Add EPSILON for case: r = 0; Interaction must be removed
+        // by special bond
+        r2inv = 1.0/rsq;
+
+        if (rsq < cut_coulsq) {
+          r = sqrt(rsq);
+          prefactor = qqrd2e*qtmp*q[j]/r;
+          erfcc = erfc(alf*r);
+          erfcd = exp(-alf*alf*r*r);
+          v_sh = (erfcc - e_shift*r) * prefactor;
+          dvdrr = (erfcc/rsq + 2.0*alf/MY_PIS * erfcd/r) + f_shift;
+          forcecoul = dvdrr*rsq*prefactor;
+          if (factor_coul < 1.0) forcecoul -= (1.0-factor_coul)*prefactor;
+        } else forcecoul = 0.0;
+
+        if (rsq < cut_ljsq[itype][jtype]) {
+          r6inv = r2inv*r2inv*r2inv;
+          r = sqrt(rsq);
+          rexp = exp((sigma[itype][jtype]-r)*rhoinv[itype][jtype]);
+          forceborn = born1[itype][jtype]*r*rexp - born2[itype][jtype]*r6inv
+            + born3[itype][jtype]*r2inv*r6inv;
+        } else forceborn = 0.0;
+
+        fpair = (forcecoul + factor_lj*forceborn) * r2inv;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (EFLAG) {
+          if (rsq < cut_coulsq) {
+            ecoul = v_sh;
+            if (factor_coul < 1.0) ecoul -= (1.0-factor_coul)*prefactor;
+          } else ecoul = 0.0;
+          if (rsq < cut_ljsq[itype][jtype]) {
+            evdwl = a[itype][jtype]*rexp - c[itype][jtype]*r6inv +
+              d[itype][jtype]*r6inv*r2inv - offset[itype][jtype];
+            evdwl *= factor_lj;
+          } else evdwl = 0.0;
+        }
+
+        if (EVFLAG) ev_tally_thr(this, i,j,nlocal,NEWTON_PAIR,
+                                 evdwl,ecoul,fpair,delx,dely,delz,thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairBornCoulWolfCSOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairBornCoulWolfCS::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_born_coul_wolf_cs_omp.h
+++ b/src/OPENMP/pair_born_coul_wolf_cs_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(born/coul/wolf/cs/omp,PairBornCoulWolfCSOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_BORN_COUL_WOLF_CS_OMP_H
+#define LMP_PAIR_BORN_COUL_WOLF_CS_OMP_H
+
+#include "pair_born_coul_wolf_cs.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairBornCoulWolfCSOMP : public PairBornCoulWolfCS, public ThrOMP {
+
+ public:
+  PairBornCoulWolfCSOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_buck_coul_long_cs_omp.cpp
+++ b/src/OPENMP/pair_buck_coul_long_cs_omp.cpp
@@ -1,0 +1,235 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_buck_coul_long_cs_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+
+static constexpr double EWALD_F = 1.12837917;
+static constexpr double EWALD_P = 9.95473818e-1;
+static constexpr double B0 = -0.1335096380159268;
+static constexpr double B1 = -2.57839507e-1;
+static constexpr double B2 = -1.37203639e-1;
+static constexpr double B3 = -8.88822059e-3;
+static constexpr double B4 = -5.80844129e-3;
+static constexpr double B5 = 1.14652755e-1;
+
+static constexpr double EPSILON = 1.0e-20;
+static constexpr double EPS_EWALD = 1.0e-6;
+static constexpr double EPS_EWALD_SQR = 1.0e-12;
+
+/* ---------------------------------------------------------------------- */
+
+PairBuckCoulLongCSOMP::PairBuckCoulLongCSOMP(LAMMPS *lmp) :
+  PairBuckCoulLongCS(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+  cut_respa = nullptr;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairBuckCoulLongCSOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairBuckCoulLongCSOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum,itable,itype,jtype;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,ecoul,fpair;
+  double fraction,table;
+  double rsq,r2inv,r6inv,forcecoul,forcebuck,factor_coul,factor_lj;
+  double grij,expm2,prefactor,t,erfc,u;
+  double r,rexp;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  evdwl = ecoul = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const double * const q = atom->q;
+  const int * const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * const special_coul = force->special_coul;
+  const double * const special_lj = force->special_lj;
+  const double qqrd2e = force->qqrd2e;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_lj = special_lj[sbmask(j)];
+      factor_coul = special_coul[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+      jtype = type[j];
+
+      if (rsq < cutsq[itype][jtype]) {
+        rsq += EPSILON; // Add Epsilon for case: r = 0; Interaction must be removed by special bond;
+        r2inv = 1.0/rsq;
+        if (rsq < cut_coulsq) {
+          if (!ncoultablebits || rsq <= tabinnersq) {
+            r = sqrt(rsq);
+            prefactor = qqrd2e * qtmp*q[j];
+            if (factor_coul < 1.0) {
+              // When bonded parts are being calculated a minimal distance (EPS_EWALD)
+              // has to be added to the prefactor and erfc in order to make the
+              // used approximation functions for the Ewald correction valid
+              grij = g_ewald * (r+EPS_EWALD);
+              expm2 = exp(-grij*grij);
+              t = 1.0 / (1.0 + EWALD_P*grij);
+              u = 1.0 - t;
+              erfc = t * (1.+u*(B0+u*(B1+u*(B2+u*(B3+u*(B4+u*B5)))))) * expm2;
+              prefactor /= (r+EPS_EWALD);
+              forcecoul = prefactor * (erfc + EWALD_F*grij*expm2 - (1.0-factor_coul));
+              // Additionally r2inv needs to be accordingly modified since the later
+              // scaling of the overall force shall be consistent
+              r2inv = 1.0/(rsq + EPS_EWALD_SQR);
+            } else {
+              grij = g_ewald * r;
+              expm2 = exp(-grij*grij);
+              t = 1.0 / (1.0 + EWALD_P*grij);
+              u = 1.0 - t;
+              erfc = t * (1.+u*(B0+u*(B1+u*(B2+u*(B3+u*(B4+u*B5)))))) * expm2;
+              prefactor /= r;
+              forcecoul = prefactor * (erfc + EWALD_F*grij*expm2);
+            }
+          } else {
+            union_int_float_t rsq_lookup;
+            rsq_lookup.f = rsq;
+            itable = rsq_lookup.i & ncoulmask;
+            itable >>= ncoulshiftbits;
+            fraction = ((double) rsq_lookup.f - rtable[itable]) * drtable[itable];
+            table = ftable[itable] + fraction*dftable[itable];
+            forcecoul = qtmp*q[j] * table;
+            if (factor_coul < 1.0) {
+              table = ctable[itable] + fraction*dctable[itable];
+              prefactor = qtmp*q[j] * table;
+              forcecoul -= (1.0-factor_coul)*prefactor;
+            }
+          }
+        } else forcecoul = 0.0;
+
+        if (rsq < cut_ljsq[itype][jtype]) {
+          r = sqrt(rsq);
+          r6inv = r2inv*r2inv*r2inv;
+          rexp = exp(-r*rhoinv[itype][jtype]);
+          forcebuck = buck1[itype][jtype]*r*rexp - buck2[itype][jtype]*r6inv;
+        } else forcebuck = 0.0;
+        fpair = (forcecoul + factor_lj*forcebuck) * r2inv;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (EFLAG) {
+          if (rsq < cut_coulsq) {
+            if (!ncoultablebits || rsq <= tabinnersq)
+              ecoul = prefactor*erfc;
+            else {
+              table = etable[itable] + fraction*detable[itable];
+              ecoul = qtmp*q[j] * table;
+            }
+            if (factor_coul < 1.0) ecoul -= (1.0-factor_coul)*prefactor;
+          } else ecoul = 0.0;
+          if (rsq < cut_ljsq[itype][jtype]) {
+            evdwl = a[itype][jtype]*rexp - c[itype][jtype]*r6inv -
+              offset[itype][jtype];
+            evdwl *= factor_lj;
+          } else evdwl = 0.0;
+        }
+
+        if (EVFLAG) ev_tally_thr(this, i,j,nlocal,NEWTON_PAIR,
+                                 evdwl,ecoul,fpair,delx,dely,delz,thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairBuckCoulLongCSOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairBuckCoulLongCS::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_buck_coul_long_cs_omp.h
+++ b/src/OPENMP/pair_buck_coul_long_cs_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(buck/coul/long/cs/omp,PairBuckCoulLongCSOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_BUCK_COUL_LONG_CS_OMP_H
+#define LMP_PAIR_BUCK_COUL_LONG_CS_OMP_H
+
+#include "pair_buck_coul_long_cs.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairBuckCoulLongCSOMP : public PairBuckCoulLongCS, public ThrOMP {
+
+ public:
+  PairBuckCoulLongCSOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_coul_cut_soft_gapsys_omp.cpp
+++ b/src/OPENMP/pair_coul_cut_soft_gapsys_omp.cpp
@@ -1,0 +1,179 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_coul_cut_soft_gapsys_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+PairCoulCutSoftGapsysOMP::PairCoulCutSoftGapsysOMP(LAMMPS *lmp) :
+  PairCoulCutSoftGapsys(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairCoulCutSoftGapsysOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairCoulCutSoftGapsysOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum,itype,jtype;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,ecoul,fpair;
+  double rsq,forcecoul,factor_coul;
+  double cut_inner;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  ecoul = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const double * const q = atom->q;
+  const int * const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * const special_coul = force->special_coul;
+  const double qqrd2e = force->qqrd2e;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_coul = special_coul[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+      jtype = type[j];
+
+      cut_inner = (1.0 + sigmaq * fabs(qtmp * q[j])) * alphaq * pow(lambda[itype][jtype], 1.0 / 6.0);
+
+      if (rsq < cut_inner * cut_inner) {
+
+        forcecoul = factor_coul * qqrd2e * qtmp * q[j];
+        fpair = (- 2.0 / pow(cut_inner, 3) + 3.0 / (pow(cut_inner, 2) * sqrt(rsq))) * forcecoul;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (EFLAG)
+          ecoul = factor_coul * qqrd2e * qtmp * q[j] *
+          (rsq / pow(cut_inner, 3) - 3 * sqrt(rsq) / pow(cut_inner, 2) + 3 / cut_inner);
+
+        if (EVFLAG) ev_tally_thr(this,i,j,nlocal,NEWTON_PAIR,
+                                 0.0,ecoul,fpair,delx,dely,delz,thr);
+
+      } else if (rsq < cutsq[itype][jtype]) {
+
+        double r2inv = 1.0 / rsq;
+        double rinv = sqrt(r2inv);
+        forcecoul = qqrd2e * qtmp * q[j] * rinv;
+        fpair = factor_coul * forcecoul * r2inv;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (EFLAG)
+          ecoul = factor_coul * qqrd2e * qtmp * q[j] * rinv;
+
+        if (EVFLAG) ev_tally_thr(this,i,j,nlocal,NEWTON_PAIR,
+                                 0.0,ecoul,fpair,delx,dely,delz,thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairCoulCutSoftGapsysOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairCoulCutSoftGapsys::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_coul_cut_soft_gapsys_omp.h
+++ b/src/OPENMP/pair_coul_cut_soft_gapsys_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(coul/cut/soft/gapsys/omp,PairCoulCutSoftGapsysOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_COUL_CUT_SOFT_GAPSYS_OMP_H
+#define LMP_PAIR_COUL_CUT_SOFT_GAPSYS_OMP_H
+
+#include "pair_coul_cut_soft_gapsys.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairCoulCutSoftGapsysOMP : public PairCoulCutSoftGapsys, public ThrOMP {
+
+ public:
+  PairCoulCutSoftGapsysOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_coul_exclude_omp.cpp
+++ b/src/OPENMP/pair_coul_exclude_omp.cpp
@@ -1,0 +1,153 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_coul_exclude_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+PairCoulExcludeOMP::PairCoulExcludeOMP(LAMMPS *lmp) :
+  PairCoulExclude(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairCoulExcludeOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairCoulExcludeOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,ecoul,fpair;
+  double rsq,r2inv,rinv,forcecoul,factor_coul;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  ecoul = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const double * const q = atom->q;
+  const int nlocal = atom->nlocal;
+  const double * const special_coul = force->special_coul;
+  const double qqrd2e = force->qqrd2e;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+
+      // skip over all non-excluded pairs and subtract excluded coulomb
+
+      if (sbmask(j) == 0) continue;
+      factor_coul = special_coul[sbmask(j)] - 1.0;
+
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+
+      r2inv = 1.0/rsq;
+      rinv = sqrt(r2inv);
+      forcecoul = qqrd2e * qtmp*q[j]*rinv;
+      fpair = factor_coul*forcecoul * r2inv;
+
+      f[i][0] += delx*fpair;
+      f[i][1] += dely*fpair;
+      f[i][2] += delz*fpair;
+      if (NEWTON_PAIR || j < nlocal) {
+        f[j][0] -= delx*fpair;
+        f[j][1] -= dely*fpair;
+        f[j][2] -= delz*fpair;
+      }
+
+      if (EFLAG)
+        ecoul = factor_coul * qqrd2e * qtmp*q[j]*rinv;
+
+      if (EVFLAG) ev_tally_thr(this,i,j,nlocal,NEWTON_PAIR,0.0,ecoul,fpair,delx,dely,delz,thr);
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairCoulExcludeOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairCoulExclude::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_coul_exclude_omp.h
+++ b/src/OPENMP/pair_coul_exclude_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(coul/exclude/omp,PairCoulExcludeOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_COUL_EXCLUDE_OMP_H
+#define LMP_PAIR_COUL_EXCLUDE_OMP_H
+
+#include "pair_coul_exclude.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairCoulExcludeOMP : public PairCoulExclude, public ThrOMP {
+
+ public:
+  PairCoulExcludeOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_coul_long_cs_omp.cpp
+++ b/src/OPENMP/pair_coul_long_cs_omp.cpp
@@ -1,0 +1,217 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_coul_long_cs_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+
+static constexpr double EWALD_F = 1.12837917;
+static constexpr double EWALD_P = 9.95473818e-1;
+static constexpr double B0 = -0.1335096380159268;
+static constexpr double B1 = -2.57839507e-1;
+static constexpr double B2 = -1.37203639e-1;
+static constexpr double B3 = -8.88822059e-3;
+static constexpr double B4 = -5.80844129e-3;
+static constexpr double B5 = 1.14652755e-1;
+
+static constexpr double EPSILON = 1.0e-20;
+static constexpr double EPS_EWALD = 1.0e-6;
+static constexpr double EPS_EWALD_SQR = 1.0e-12;
+
+/* ---------------------------------------------------------------------- */
+
+PairCoulLongCSOMP::PairCoulLongCSOMP(LAMMPS *lmp) :
+  PairCoulLongCS(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+  cut_respa = nullptr;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairCoulLongCSOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairCoulLongCSOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum,itable,itype,jtype;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,ecoul,fpair;
+  double fraction,table;
+  double r,r2inv,rsq,forcecoul,factor_coul;
+  double grij,expm2,prefactor,t,erfc,u;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  ecoul = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const double * const q = atom->q;
+  const int * const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * const special_coul = force->special_coul;
+  const double qqrd2e = force->qqrd2e;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_coul = special_coul[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+      jtype = type[j];
+
+      if (rsq < cut_coulsq) {
+        rsq += EPSILON; // Add Epsilon for case: r = 0; Interaction must be removed by special bond;
+        r2inv = 1.0/rsq;
+        if (!ncoultablebits || rsq <= tabinnersq) {
+          r = sqrt(rsq);
+          prefactor = qqrd2e * scale[itype][jtype] * qtmp*q[j];
+          if (factor_coul < 1.0) {
+            // When bonded parts are being calculated a minimal distance (EPS_EWALD)
+            // has to be added to the prefactor and erfc in order to make the
+            // used approximation functions for the Ewald correction valid
+            grij = g_ewald * (r+EPS_EWALD);
+            expm2 = exp(-grij*grij);
+            t = 1.0 / (1.0 + EWALD_P*grij);
+            u = 1.0 - t;
+            erfc = t * (1.+u*(B0+u*(B1+u*(B2+u*(B3+u*(B4+u*B5)))))) * expm2;
+            prefactor /= (r+EPS_EWALD);
+            forcecoul = prefactor * (erfc + EWALD_F*grij*expm2 - (1.0-factor_coul));
+            // Additionally r2inv needs to be accordingly modified since the later
+            // scaling of the overall force shall be consistent
+            r2inv = 1.0/(rsq + EPS_EWALD_SQR);
+          } else {
+            grij = g_ewald * r;
+            expm2 = exp(-grij*grij);
+            t = 1.0 / (1.0 + EWALD_P*grij);
+            u = 1.0 - t;
+            erfc = t * (1.+u*(B0+u*(B1+u*(B2+u*(B3+u*(B4+u*B5)))))) * expm2;
+            prefactor /= r;
+            forcecoul = prefactor * (erfc + EWALD_F*grij*expm2);
+          }
+        } else {
+          union_int_float_t rsq_lookup;
+          rsq_lookup.f = rsq;
+          itable = rsq_lookup.i & ncoulmask;
+          itable >>= ncoulshiftbits;
+          fraction = ((double) rsq_lookup.f - rtable[itable]) * drtable[itable];
+          table = ftable[itable] + fraction*dftable[itable];
+          forcecoul = scale[itype][jtype] * qtmp*q[j] * table;
+          if (factor_coul < 1.0) {
+            table = ctable[itable] + fraction*dctable[itable];
+            prefactor = scale[itype][jtype] * qtmp*q[j] * table;
+            forcecoul -= (1.0-factor_coul)*prefactor;
+          }
+        }
+
+        fpair = forcecoul * r2inv;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (EFLAG) {
+          if (!ncoultablebits || rsq <= tabinnersq)
+            ecoul = prefactor*erfc;
+          else {
+            table = etable[itable] + fraction*detable[itable];
+            ecoul = scale[itype][jtype] * qtmp*q[j] * table;
+          }
+          if (factor_coul < 1.0) ecoul -= (1.0-factor_coul)*prefactor;
+        }
+
+        if (EVFLAG) ev_tally_thr(this, i,j,nlocal,NEWTON_PAIR,
+                                 0.0,ecoul,fpair,delx,dely,delz,thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairCoulLongCSOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairCoulLongCS::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_coul_long_cs_omp.h
+++ b/src/OPENMP/pair_coul_long_cs_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(coul/long/cs/omp,PairCoulLongCSOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_COUL_LONG_CS_OMP_H
+#define LMP_PAIR_COUL_LONG_CS_OMP_H
+
+#include "pair_coul_long_cs.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairCoulLongCSOMP : public PairCoulLongCS, public ThrOMP {
+
+ public:
+  PairCoulLongCSOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_coul_slater_cut_omp.cpp
+++ b/src/OPENMP/pair_coul_slater_cut_omp.cpp
@@ -1,0 +1,158 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_coul_slater_cut_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+PairCoulSlaterCutOMP::PairCoulSlaterCutOMP(LAMMPS *lmp) :
+  PairCoulSlaterCut(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairCoulSlaterCutOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairCoulSlaterCutOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum,itype,jtype;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,ecoul,fpair;
+  double rsq,r2inv,r,rinv,forcecoul,factor_coul,bracket_term;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  ecoul = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const double * const q = atom->q;
+  const int * const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * const special_coul = force->special_coul;
+  const double qqrd2e = force->qqrd2e;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_coul = special_coul[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+      jtype = type[j];
+
+      if (rsq < cutsq[itype][jtype]) {
+        r2inv = 1.0/rsq;
+        r = sqrt(rsq);
+        rinv = 1.0/r;
+        bracket_term = 1 - exp(-2*r/lamda)*(1 + (2*r/lamda*(1+r/lamda)));
+        forcecoul = qqrd2e * scale[itype][jtype] *
+          qtmp*q[j] * bracket_term * rinv;
+        fpair = factor_coul*forcecoul * r2inv;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (EFLAG) ecoul = factor_coul * qqrd2e *
+            scale[itype][jtype] * qtmp*q[j] * rinv *
+            (1 - (1 + r/lamda)*exp(-2*r/lamda));
+
+        if (EVFLAG) ev_tally_thr(this,i,j,nlocal,NEWTON_PAIR,
+                                 0.0,ecoul,fpair,delx,dely,delz,thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairCoulSlaterCutOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairCoulSlaterCut::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_coul_slater_cut_omp.h
+++ b/src/OPENMP/pair_coul_slater_cut_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(coul/slater/cut/omp,PairCoulSlaterCutOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_COUL_SLATER_CUT_OMP_H
+#define LMP_PAIR_COUL_SLATER_CUT_OMP_H
+
+#include "pair_coul_slater_cut.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairCoulSlaterCutOMP : public PairCoulSlaterCut, public ThrOMP {
+
+ public:
+  PairCoulSlaterCutOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_coul_slater_long_omp.cpp
+++ b/src/OPENMP/pair_coul_slater_long_omp.cpp
@@ -1,0 +1,169 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_coul_slater_long_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "ewald_const.h"
+#include "force.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+using namespace EwaldConst;
+
+/* ---------------------------------------------------------------------- */
+
+PairCoulSlaterLongOMP::PairCoulSlaterLongOMP(LAMMPS *lmp) :
+  PairCoulSlaterLong(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairCoulSlaterLongOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairCoulSlaterLongOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum,itype,jtype;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,ecoul,fpair;
+  double r,r2inv,forcecoul,factor_coul;
+  double grij,expm2,prefactor,t,erfc;
+  double rsq;
+  double slater_term;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  ecoul = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const double * const q = atom->q;
+  const int * const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * const special_coul = force->special_coul;
+  const double qqrd2e = force->qqrd2e;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_coul = special_coul[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+      jtype = type[j];
+
+      if (rsq < cut_coulsq) {
+        r2inv = 1.0/rsq;
+        r = sqrt(rsq);
+        grij = g_ewald * r;
+        expm2 = exp(-grij*grij);
+        t = 1.0 / (1.0 + EWALD_P*grij);
+        erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
+        slater_term = exp(-2*r/lamda)*(1 + (2*r/lamda*(1+r/lamda)));
+        prefactor = qqrd2e * scale[itype][jtype] * qtmp*q[j]/r;
+        forcecoul = prefactor * (erfc + EWALD_F*grij*expm2 - slater_term);
+        if (factor_coul < 1.0) forcecoul -= (1.0-factor_coul)*prefactor*(1-slater_term);
+
+        fpair = forcecoul * r2inv;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (EFLAG) {
+          ecoul = prefactor*(erfc - (1 + r/lamda)*exp(-2*r/lamda));
+          if (factor_coul < 1.0) ecoul -= (1.0-factor_coul)*prefactor*(1.0-(1 + r/lamda)*exp(-2*r/lamda));
+        }
+
+        if (EVFLAG) ev_tally_thr(this,i,j,nlocal,NEWTON_PAIR,
+                                 0.0,ecoul,fpair,delx,dely,delz,thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairCoulSlaterLongOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairCoulSlaterLong::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_coul_slater_long_omp.h
+++ b/src/OPENMP/pair_coul_slater_long_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(coul/slater/long/omp,PairCoulSlaterLongOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_COUL_SLATER_LONG_OMP_H
+#define LMP_PAIR_COUL_SLATER_LONG_OMP_H
+
+#include "pair_coul_slater_long.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairCoulSlaterLongOMP : public PairCoulSlaterLong, public ThrOMP {
+
+ public:
+  PairCoulSlaterLongOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_coul_wolf_cs_omp.cpp
+++ b/src/OPENMP/pair_coul_wolf_cs_omp.cpp
@@ -1,0 +1,178 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_coul_wolf_cs_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "math_const.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+using namespace MathConst;
+
+static constexpr double EPSILON = 1.0e-20;
+
+/* ---------------------------------------------------------------------- */
+
+PairCoulWolfCSOMP::PairCoulWolfCSOMP(LAMMPS *lmp) :
+  PairCoulWolfCS(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairCoulWolfCSOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairCoulWolfCSOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,ecoul,fpair;
+  double rsq,forcecoul,factor_coul;
+  double prefactor;
+  double r;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+  double erfcc,erfcd,v_sh,dvdrr,e_self,e_shift,f_shift,qisq;
+
+  ecoul = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const double * const q = atom->q;
+  const int nlocal = atom->nlocal;
+  const double * const special_coul = force->special_coul;
+  const double qqrd2e = force->qqrd2e;
+
+  // self and shifted coulombic energy
+
+  e_self = v_sh = 0.0;
+  e_shift = erfc(alf*cut_coul)/cut_coul;
+  f_shift = -(e_shift+ 2.0*alf/MY_PIS * exp(-alf*alf*cut_coul*cut_coul)) / cut_coul;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    qisq = qtmp*qtmp;
+    e_self = -(e_shift/2.0 + alf/MY_PIS) * qisq*qqrd2e;
+    if (EVFLAG) ev_tally_thr(this,i,i,nlocal,0,0.0,e_self,0.0,0.0,0.0,0.0,thr);
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_coul = special_coul[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+
+      if (rsq < cut_coulsq) {
+        rsq += EPSILON;
+        // Add EPSILON for case: r = 0; Interaction must be removed
+        // by special bond
+        r = sqrt(rsq);
+        prefactor = qqrd2e*qtmp*q[j]/r;
+        erfcc = erfc(alf*r);
+        erfcd = exp(-alf*alf*r*r);
+        v_sh = (erfcc - e_shift*r) * prefactor;
+        dvdrr = (erfcc/rsq + 2.0*alf/MY_PIS * erfcd/r) + f_shift;
+        forcecoul = dvdrr*rsq*prefactor;
+        if (factor_coul < 1.0) forcecoul -= (1.0-factor_coul)*prefactor;
+        fpair = forcecoul / rsq;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (EFLAG) {
+          ecoul = v_sh;
+          if (factor_coul < 1.0) ecoul -= (1.0-factor_coul)*prefactor;
+        } else ecoul = 0.0;
+
+        if (EVFLAG) ev_tally_thr(this,i,j,nlocal,NEWTON_PAIR,
+                                 0.0,ecoul,fpair,delx,dely,delz,thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairCoulWolfCSOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairCoulWolfCS::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_coul_wolf_cs_omp.h
+++ b/src/OPENMP/pair_coul_wolf_cs_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(coul/wolf/cs/omp,PairCoulWolfCSOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_COUL_WOLF_CS_OMP_H
+#define LMP_PAIR_COUL_WOLF_CS_OMP_H
+
+#include "pair_coul_wolf_cs.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairCoulWolfCSOMP : public PairCoulWolfCS, public ThrOMP {
+
+ public:
+  PairCoulWolfCSOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_lj_charmmfsw_coul_charmmfsh_omp.cpp
+++ b/src/OPENMP/pair_lj_charmmfsw_coul_charmmfsh_omp.cpp
@@ -1,0 +1,195 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_lj_charmmfsw_coul_charmmfsh_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+PairLJCharmmfswCoulCharmmfshOMP::PairLJCharmmfswCoulCharmmfshOMP(LAMMPS *lmp) :
+  PairLJCharmmfswCoulCharmmfsh(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairLJCharmmfswCoulCharmmfshOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairLJCharmmfswCoulCharmmfshOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum,itype,jtype;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,evdwl12,evdwl6,ecoul,fpair;
+  double r,rinv,r3inv,rsq,r2inv,r6inv,forcecoul,forcelj,factor_coul,factor_lj;
+  double switch1;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  evdwl = ecoul = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const double * const q = atom->q;
+  const int * const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * const special_coul = force->special_coul;
+  const double * const special_lj = force->special_lj;
+  const double qqrd2e = force->qqrd2e;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_lj = special_lj[sbmask(j)];
+      factor_coul = special_coul[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+
+      if (rsq < cut_bothsq) {
+        r2inv = 1.0/rsq;
+        r = sqrt(rsq);
+
+        if (rsq < cut_coulsq) {
+          forcecoul = qqrd2e * qtmp*q[j]*
+            (sqrt(r2inv) - r*cut_coulinv*cut_coulinv);
+        } else forcecoul = 0.0;
+
+        if (rsq < cut_ljsq) {
+          r6inv = r2inv*r2inv*r2inv;
+          jtype = type[j];
+          forcelj = r6inv * (lj1[itype][jtype]*r6inv - lj2[itype][jtype]);
+          if (rsq > cut_lj_innersq) {
+            switch1 = (cut_ljsq-rsq) * (cut_ljsq-rsq) *
+              (cut_ljsq + 2.0*rsq - 3.0*cut_lj_innersq) / denom_lj;
+            forcelj = forcelj*switch1;
+          }
+        } else forcelj = 0.0;
+
+        fpair = (factor_coul*forcecoul + factor_lj*forcelj) * r2inv;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (EFLAG) {
+          if (rsq < cut_coulsq) {
+            ecoul = qqrd2e * qtmp*q[j]*
+              (sqrt(r2inv) + cut_coulinv*cut_coulinv*r - 2.0*cut_coulinv);
+            ecoul *= factor_coul;
+          } else ecoul = 0.0;
+          if (rsq < cut_ljsq) {
+            if (rsq > cut_lj_innersq) {
+              rinv = 1.0/r;
+              r3inv = rinv*rinv*rinv;
+              evdwl12 = lj3[itype][jtype]*cut_lj6*denom_lj12 *
+                (r6inv - cut_lj6inv)*(r6inv - cut_lj6inv);
+              evdwl6 = -lj4[itype][jtype]*cut_lj3*denom_lj6 *
+                (r3inv - cut_lj3inv)*(r3inv - cut_lj3inv);
+              evdwl = evdwl12 + evdwl6;
+            } else {
+              evdwl12 = r6inv*lj3[itype][jtype]*r6inv -
+                lj3[itype][jtype]*cut_lj_inner6inv*cut_lj6inv;
+              evdwl6 = -lj4[itype][jtype]*r6inv +
+                lj4[itype][jtype]*cut_lj_inner3inv*cut_lj3inv;
+              evdwl = evdwl12 + evdwl6;
+            }
+            evdwl *= factor_lj;
+          } else evdwl = 0.0;
+        }
+
+        if (EVFLAG) ev_tally_thr(this,i,j,nlocal,NEWTON_PAIR,
+                                 evdwl,ecoul,fpair,delx,dely,delz,thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairLJCharmmfswCoulCharmmfshOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairLJCharmmfswCoulCharmmfsh::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_lj_charmmfsw_coul_charmmfsh_omp.h
+++ b/src/OPENMP/pair_lj_charmmfsw_coul_charmmfsh_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(lj/charmmfsw/coul/charmmfsh/omp,PairLJCharmmfswCoulCharmmfshOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_LJ_CHARMMFSW_COUL_CHARMMFSH_OMP_H
+#define LMP_PAIR_LJ_CHARMMFSW_COUL_CHARMMFSH_OMP_H
+
+#include "pair_lj_charmmfsw_coul_charmmfsh.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairLJCharmmfswCoulCharmmfshOMP : public PairLJCharmmfswCoulCharmmfsh, public ThrOMP {
+
+ public:
+  PairLJCharmmfswCoulCharmmfshOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_lj_charmmfsw_coul_long_omp.cpp
+++ b/src/OPENMP/pair_lj_charmmfsw_coul_long_omp.cpp
@@ -1,0 +1,226 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_lj_charmmfsw_coul_long_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "ewald_const.h"
+#include "force.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+using namespace EwaldConst;
+
+/* ---------------------------------------------------------------------- */
+
+PairLJCharmmfswCoulLongOMP::PairLJCharmmfswCoulLongOMP(LAMMPS *lmp) :
+  PairLJCharmmfswCoulLong(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+  cut_respa = nullptr;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairLJCharmmfswCoulLongOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairLJCharmmfswCoulLongOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum,itype,jtype,itable;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,evdwl12,evdwl6,ecoul,fpair;
+  double fraction,table;
+  double r,rinv,r2inv,r3inv,r6inv,rsq,forcecoul,forcelj,factor_coul,factor_lj;
+  double grij,expm2,prefactor,t,erfc;
+  double switch1;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  evdwl = ecoul = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const double * const q = atom->q;
+  const int * const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * const special_coul = force->special_coul;
+  const double * const special_lj = force->special_lj;
+  const double qqrd2e = force->qqrd2e;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_lj = special_lj[sbmask(j)];
+      factor_coul = special_coul[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+
+      if (rsq < cut_bothsq) {
+        r2inv = 1.0/rsq;
+
+        if (rsq < cut_coulsq) {
+          if (!ncoultablebits || rsq <= tabinnersq) {
+            r = sqrt(rsq);
+            grij = g_ewald * r;
+            expm2 = exp(-grij*grij);
+            t = 1.0 / (1.0 + EWALD_P*grij);
+            erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
+            prefactor = qqrd2e * qtmp*q[j]/r;
+            forcecoul = prefactor * (erfc + EWALD_F*grij*expm2);
+            if (factor_coul < 1.0) forcecoul -= (1.0-factor_coul)*prefactor;
+          } else {
+            union_int_float_t rsq_lookup;
+            rsq_lookup.f = rsq;
+            itable = rsq_lookup.i & ncoulmask;
+            itable >>= ncoulshiftbits;
+            fraction = ((double) rsq_lookup.f - rtable[itable]) * drtable[itable];
+            table = ftable[itable] + fraction*dftable[itable];
+            forcecoul = qtmp*q[j] * table;
+            if (factor_coul < 1.0) {
+              table = ctable[itable] + fraction*dctable[itable];
+              prefactor = qtmp*q[j] * table;
+              forcecoul -= (1.0-factor_coul)*prefactor;
+            }
+          }
+        } else forcecoul = 0.0;
+
+        if (rsq < cut_ljsq) {
+          r6inv = r2inv*r2inv*r2inv;
+          jtype = type[j];
+          forcelj = r6inv * (lj1[itype][jtype]*r6inv - lj2[itype][jtype]);
+          if (rsq > cut_lj_innersq) {
+            switch1 = (cut_ljsq-rsq) * (cut_ljsq-rsq) *
+              (cut_ljsq + 2.0*rsq - 3.0*cut_lj_innersq) / denom_lj;
+            forcelj = forcelj*switch1;
+         }
+        } else forcelj = 0.0;
+
+        fpair = (forcecoul + factor_lj*forcelj) * r2inv;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (EFLAG) {
+          if (rsq < cut_coulsq) {
+            if (!ncoultablebits || rsq <= tabinnersq)
+              ecoul = prefactor*erfc;
+            else {
+              table = etable[itable] + fraction*detable[itable];
+              ecoul = qtmp*q[j] * table;
+            }
+            if (factor_coul < 1.0) ecoul -= (1.0-factor_coul)*prefactor;
+          } else ecoul = 0.0;
+
+          if (rsq < cut_ljsq) {
+            if (rsq > cut_lj_innersq) {
+              r = sqrt(rsq);
+              rinv = 1.0/r;
+              r3inv = rinv*rinv*rinv;
+              evdwl12 = lj3[itype][jtype]*cut_lj6*denom_lj12 *
+                (r6inv - cut_lj6inv)*(r6inv - cut_lj6inv);
+              evdwl6 = -lj4[itype][jtype]*cut_lj3*denom_lj6 *
+                (r3inv - cut_lj3inv)*(r3inv - cut_lj3inv);
+              evdwl = evdwl12 + evdwl6;
+            } else {
+              evdwl12 = r6inv*lj3[itype][jtype]*r6inv -
+                lj3[itype][jtype]*cut_lj_inner6inv*cut_lj6inv;
+              evdwl6 = -lj4[itype][jtype]*r6inv +
+                lj4[itype][jtype]*cut_lj_inner3inv*cut_lj3inv;
+              evdwl = evdwl12 + evdwl6;
+            }
+            evdwl *= factor_lj;
+          } else evdwl = 0.0;
+        }
+
+        if (EVFLAG) ev_tally_thr(this,i,j,nlocal,NEWTON_PAIR,
+                                 evdwl,ecoul,fpair,delx,dely,delz,thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairLJCharmmfswCoulLongOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairLJCharmmfswCoulLong::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_lj_charmmfsw_coul_long_omp.h
+++ b/src/OPENMP/pair_lj_charmmfsw_coul_long_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(lj/charmmfsw/coul/long/omp,PairLJCharmmfswCoulLongOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_LJ_CHARMMFSW_COUL_LONG_OMP_H
+#define LMP_PAIR_LJ_CHARMMFSW_COUL_LONG_OMP_H
+
+#include "pair_lj_charmmfsw_coul_long.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairLJCharmmfswCoulLongOMP : public PairLJCharmmfswCoulLong, public ThrOMP {
+
+ public:
+  PairLJCharmmfswCoulLongOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_lj_class2_coul_cut_soft_omp.cpp
+++ b/src/OPENMP/pair_lj_class2_coul_cut_soft_omp.cpp
@@ -1,0 +1,177 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_lj_class2_coul_cut_soft_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+PairLJClass2CoulCutSoftOMP::PairLJClass2CoulCutSoftOMP(LAMMPS *lmp) :
+  PairLJClass2CoulCutSoft(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairLJClass2CoulCutSoftOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairLJClass2CoulCutSoftOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum,itype,jtype;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,ecoul,fpair;
+  double rsq,forcecoul,forcelj;
+  double factor_coul,factor_lj;
+  double denc, denlj, r4sig6;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  evdwl = ecoul = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const double * const q = atom->q;
+  const int * const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * const special_coul = force->special_coul;
+  const double * const special_lj = force->special_lj;
+  const double qqrd2e = force->qqrd2e;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_lj = special_lj[sbmask(j)];
+      factor_coul = special_coul[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+      jtype = type[j];
+
+      if (rsq < cutsq[itype][jtype]) {
+
+        if (rsq < cut_coulsq[itype][jtype]) {
+          denc = sqrt(lj4[itype][jtype] + rsq);
+          forcecoul = qqrd2e * lj1[itype][jtype] * qtmp*q[j] / (denc*denc*denc);
+        } else forcecoul = 0.0;
+
+        if (rsq < cut_ljsq[itype][jtype]) {
+          denlj = lj3[itype][jtype] + pow(rsq, 3) * pow(sigma[itype][jtype], -6.0);
+          r4sig6 = rsq*rsq / lj2[itype][jtype];
+          forcelj = lj1[itype][jtype] * epsilon[itype][jtype] *
+           (18.0*r4sig6*pow(denlj, -2.5) - 18.0*r4sig6*pow(denlj, -2));
+        } else forcelj = 0.0;
+
+        fpair = factor_coul*forcecoul + factor_lj*forcelj;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (EFLAG) {
+          if (rsq < cut_coulsq[itype][jtype])
+            ecoul = factor_coul * qqrd2e * lj1[itype][jtype] * qtmp*q[j] / denc;
+          else ecoul = 0.0;
+          if (rsq < cut_ljsq[itype][jtype]) {
+            denlj = lj3[itype][jtype] + pow(rsq, 3) * pow(sigma[itype][jtype], -6.0);
+            evdwl = lj1[itype][jtype] * epsilon[itype][jtype] * (2.0/(denlj*sqrt(denlj)) - 3.0/denlj) -
+              offset[itype][jtype];
+            evdwl *= factor_lj;
+          } else evdwl = 0.0;
+        }
+
+        if (EVFLAG) ev_tally_thr(this,i,j,nlocal,NEWTON_PAIR,
+                                 evdwl,ecoul,fpair,delx,dely,delz,thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairLJClass2CoulCutSoftOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairLJClass2CoulCutSoft::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_lj_class2_coul_cut_soft_omp.h
+++ b/src/OPENMP/pair_lj_class2_coul_cut_soft_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(lj/class2/coul/cut/soft/omp,PairLJClass2CoulCutSoftOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_LJ_CLASS2_COUL_CUT_SOFT_OMP_H
+#define LMP_PAIR_LJ_CLASS2_COUL_CUT_SOFT_OMP_H
+
+#include "pair_lj_class2_coul_cut_soft.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairLJClass2CoulCutSoftOMP : public PairLJClass2CoulCutSoft, public ThrOMP {
+
+ public:
+  PairLJClass2CoulCutSoftOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_lj_class2_coul_long_cs_omp.cpp
+++ b/src/OPENMP/pair_lj_class2_coul_long_cs_omp.cpp
@@ -1,0 +1,235 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_lj_class2_coul_long_cs_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+
+static constexpr double EWALD_F = 1.12837917;
+static constexpr double EWALD_P = 9.95473818e-1;
+static constexpr double B0 = -0.1335096380159268;
+static constexpr double B1 = -2.57839507e-1;
+static constexpr double B2 = -1.37203639e-1;
+static constexpr double B3 = -8.88822059e-3;
+static constexpr double B4 = -5.80844129e-3;
+static constexpr double B5 = 1.14652755e-1;
+
+static constexpr double EPSILON = 1.0e-20;
+static constexpr double EPS_EWALD = 1.0e-6;
+static constexpr double EPS_EWALD_SQR = 1.0e-12;
+
+/* ---------------------------------------------------------------------- */
+
+PairLJClass2CoulLongCSOMP::PairLJClass2CoulLongCSOMP(LAMMPS *lmp) :
+  PairLJClass2CoulLongCS(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+  cut_respa = nullptr;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairLJClass2CoulLongCSOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairLJClass2CoulLongCSOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum,itable,itype,jtype;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,ecoul,fpair;
+  double fraction,table;
+  double r,rinv,rsq,r2inv,r3inv,r6inv,forcecoul,forcelj,factor_coul,factor_lj;
+  double grij,expm2,prefactor,t,erfc,u;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  evdwl = ecoul = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const double * const q = atom->q;
+  const int * const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * const special_coul = force->special_coul;
+  const double * const special_lj = force->special_lj;
+  const double qqrd2e = force->qqrd2e;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_lj = special_lj[sbmask(j)];
+      factor_coul = special_coul[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+      jtype = type[j];
+
+      if (rsq < cutsq[itype][jtype]) {
+        rsq += EPSILON; // Add Epsilon for case: r = 0; Interaction must be removed by special bond;
+        r2inv = 1.0/rsq;
+        if (rsq < cut_coulsq) {
+          if (!ncoultablebits || rsq <= tabinnersq) {
+            r = sqrt(rsq);
+            prefactor = qqrd2e * qtmp*q[j];
+            if (factor_coul < 1.0) {
+              // When bonded parts are being calculated a minimal distance (EPS_EWALD)
+              // has to be added to the prefactor and erfc in order to make the
+              // used approximation functions for the Ewald correction valid
+              grij = g_ewald * (r+EPS_EWALD);
+              expm2 = exp(-grij*grij);
+              t = 1.0 / (1.0 + EWALD_P*grij);
+              u = 1.0 - t;
+              erfc = t * (1.+u*(B0+u*(B1+u*(B2+u*(B3+u*(B4+u*B5)))))) * expm2;
+              prefactor /= (r+EPS_EWALD);
+              forcecoul = prefactor * (erfc + EWALD_F*grij*expm2 - (1.0-factor_coul));
+              // Additionally r2inv needs to be accordingly modified since the later
+              // scaling of the overall force shall be consistent
+              r2inv = 1.0/(rsq + EPS_EWALD_SQR);
+            } else {
+              grij = g_ewald * r;
+              expm2 = exp(-grij*grij);
+              t = 1.0 / (1.0 + EWALD_P*grij);
+              u = 1.0 - t;
+              erfc = t * (1.+u*(B0+u*(B1+u*(B2+u*(B3+u*(B4+u*B5)))))) * expm2;
+              prefactor /= r;
+              forcecoul = prefactor * (erfc + EWALD_F*grij*expm2);
+            }
+          } else {
+            union_int_float_t rsq_lookup;
+            rsq_lookup.f = rsq;
+            itable = rsq_lookup.i & ncoulmask;
+            itable >>= ncoulshiftbits;
+            fraction = ((double) rsq_lookup.f - rtable[itable]) * drtable[itable];
+            table = ftable[itable] + fraction*dftable[itable];
+            forcecoul = qtmp*q[j] * table;
+            if (factor_coul < 1.0) {
+              table = ctable[itable] + fraction*dctable[itable];
+              prefactor = qtmp*q[j] * table;
+              forcecoul -= (1.0-factor_coul)*prefactor;
+            }
+          }
+        } else forcecoul = 0.0;
+
+        if (rsq < cut_ljsq[itype][jtype]) {
+          rinv = sqrt(r2inv);
+          r3inv = r2inv*rinv;
+          r6inv = r3inv*r3inv;
+          forcelj = r6inv * (lj1[itype][jtype]*r3inv - lj2[itype][jtype]);
+        } else forcelj = 0.0;
+
+        fpair = (forcecoul + factor_lj*forcelj) * r2inv;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (EFLAG) {
+          if (rsq < cut_coulsq) {
+            if (!ncoultablebits || rsq <= tabinnersq)
+              ecoul = prefactor*erfc;
+            else {
+              table = etable[itable] + fraction*detable[itable];
+              ecoul = qtmp*q[j] * table;
+            }
+            if (factor_coul < 1.0) ecoul -= (1.0-factor_coul)*prefactor;
+          } else ecoul = 0.0;
+          if (rsq < cut_ljsq[itype][jtype]) {
+            evdwl = r6inv*(lj3[itype][jtype]*r3inv-lj4[itype][jtype]) -
+              offset[itype][jtype];
+            evdwl *= factor_lj;
+          } else evdwl = 0.0;
+        }
+
+        if (EVFLAG) ev_tally_thr(this, i,j,nlocal,NEWTON_PAIR,
+                                 evdwl,ecoul,fpair,delx,dely,delz,thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairLJClass2CoulLongCSOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairLJClass2CoulLongCS::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_lj_class2_coul_long_cs_omp.h
+++ b/src/OPENMP/pair_lj_class2_coul_long_cs_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(lj/class2/coul/long/cs/omp,PairLJClass2CoulLongCSOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_LJ_CLASS2_COUL_LONG_CS_OMP_H
+#define LMP_PAIR_LJ_CLASS2_COUL_LONG_CS_OMP_H
+
+#include "pair_lj_class2_coul_long_cs.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairLJClass2CoulLongCSOMP : public PairLJClass2CoulLongCS, public ThrOMP {
+
+ public:
+  PairLJClass2CoulLongCSOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_lj_class2_coul_long_soft_omp.cpp
+++ b/src/OPENMP/pair_lj_class2_coul_long_soft_omp.cpp
@@ -1,0 +1,190 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_lj_class2_coul_long_soft_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "ewald_const.h"
+#include "force.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+using namespace EwaldConst;
+
+/* ---------------------------------------------------------------------- */
+
+PairLJClass2CoulLongSoftOMP::PairLJClass2CoulLongSoftOMP(LAMMPS *lmp) :
+  PairLJClass2CoulLongSoft(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairLJClass2CoulLongSoftOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairLJClass2CoulLongSoftOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum,itype,jtype;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,ecoul,fpair;
+  double rsq,r,forcecoul,forcelj;
+  double grij,expm2,prefactor,t,erfc;
+  double factor_coul,factor_lj;
+  double denc, denlj, r4sig6;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  evdwl = ecoul = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const double * const q = atom->q;
+  const int * const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * const special_coul = force->special_coul;
+  const double * const special_lj = force->special_lj;
+  const double qqrd2e = force->qqrd2e;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_lj = special_lj[sbmask(j)];
+      factor_coul = special_coul[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+      jtype = type[j];
+
+      if (rsq < cutsq[itype][jtype]) {
+
+        if (rsq < cut_coulsq) {
+          r = sqrt(rsq);
+          grij = g_ewald * r;
+          expm2 = exp(-grij*grij);
+          t = 1.0 / (1.0 + EWALD_P*grij);
+          erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
+          denc = sqrt(lj4[itype][jtype] + rsq);
+          prefactor = qqrd2e * lj1[itype][jtype] * qtmp*q[j] / (denc*denc*denc);
+          forcecoul = prefactor * (erfc + EWALD_F*grij*expm2);
+          if (factor_coul < 1.0) forcecoul -= (1.0-factor_coul)*prefactor;
+        } else forcecoul = 0.0;
+
+        if (rsq < cut_ljsq[itype][jtype]) {
+          r4sig6 = rsq*rsq / lj2[itype][jtype];
+          denlj = lj3[itype][jtype] + rsq*r4sig6;
+          forcelj = lj1[itype][jtype] * epsilon[itype][jtype] *
+            (18.0*r4sig6*pow(denlj, -2.5) - 18.0*r4sig6*pow(denlj, -2));
+        } else forcelj = 0.0;
+
+        fpair = forcecoul + factor_lj*forcelj;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (EFLAG) {
+          if (rsq < cut_coulsq) {
+            prefactor = qqrd2e * lj1[itype][jtype] * qtmp*q[j] / denc;
+            ecoul = prefactor*erfc;
+            if (factor_coul < 1.0) ecoul -= (1.0-factor_coul)*prefactor;
+          } else ecoul = 0.0;
+          if (rsq < cut_ljsq[itype][jtype]) {
+            r4sig6 = rsq*rsq / lj2[itype][jtype];
+            denlj = lj3[itype][jtype] + rsq*r4sig6;
+            evdwl = lj1[itype][jtype] * epsilon[itype][jtype] * (2.0/(denlj*sqrt(denlj)) - 3.0/denlj) -
+              offset[itype][jtype];
+            evdwl *= factor_lj;
+          } else evdwl = 0.0;
+        }
+
+        if (EVFLAG) ev_tally_thr(this,i,j,nlocal,NEWTON_PAIR,
+                                 evdwl,ecoul,fpair,delx,dely,delz,thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairLJClass2CoulLongSoftOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairLJClass2CoulLongSoft::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_lj_class2_coul_long_soft_omp.h
+++ b/src/OPENMP/pair_lj_class2_coul_long_soft_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(lj/class2/coul/long/soft/omp,PairLJClass2CoulLongSoftOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_LJ_CLASS2_COUL_LONG_SOFT_OMP_H
+#define LMP_PAIR_LJ_CLASS2_COUL_LONG_SOFT_OMP_H
+
+#include "pair_lj_class2_coul_long_soft.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairLJClass2CoulLongSoftOMP : public PairLJClass2CoulLongSoft, public ThrOMP {
+
+ public:
+  PairLJClass2CoulLongSoftOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_lj_class2_soft_omp.cpp
+++ b/src/OPENMP/pair_lj_class2_soft_omp.cpp
@@ -1,0 +1,157 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_lj_class2_soft_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+PairLJClass2SoftOMP::PairLJClass2SoftOMP(LAMMPS *lmp) :
+  PairLJClass2Soft(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairLJClass2SoftOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairLJClass2SoftOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum,itype,jtype;
+  double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair;
+  double rsq,forcelj,factor_lj;
+  double denlj, r4sig6;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  evdwl = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const int * const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * const special_lj = force->special_lj;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_lj = special_lj[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+      jtype = type[j];
+
+      if (rsq < cutsq[itype][jtype]) {
+        denlj = lj3[itype][jtype] + pow(rsq, 3) * pow(sigma[itype][jtype], -6.0);
+        r4sig6 = rsq*rsq / lj2[itype][jtype];
+        forcelj = lj1[itype][jtype] * epsilon[itype][jtype] *
+            (18.0*r4sig6*pow(denlj, -2.5) - 18.0*r4sig6*pow(denlj, -2));
+        fpair = factor_lj*forcelj;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (EFLAG) {
+          denlj = lj3[itype][jtype] + pow(rsq, 3) * pow(sigma[itype][jtype], -6.0);
+          evdwl = lj1[itype][jtype] * epsilon[itype][jtype] * (2.0/(denlj*sqrt(denlj)) - 3.0/denlj) -
+            offset[itype][jtype];
+          evdwl *= factor_lj;
+        }
+
+        if (EVFLAG) ev_tally_thr(this,i,j,nlocal,NEWTON_PAIR,
+                                 evdwl,0.0,fpair,delx,dely,delz,thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairLJClass2SoftOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairLJClass2Soft::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_lj_class2_soft_omp.h
+++ b/src/OPENMP/pair_lj_class2_soft_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(lj/class2/soft/omp,PairLJClass2SoftOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_LJ_CLASS2_SOFT_OMP_H
+#define LMP_PAIR_LJ_CLASS2_SOFT_OMP_H
+
+#include "pair_lj_class2_soft.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairLJClass2SoftOMP : public PairLJClass2Soft, public ThrOMP {
+
+ public:
+  PairLJClass2SoftOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_lj_cut_coul_long_cs_omp.cpp
+++ b/src/OPENMP/pair_lj_cut_coul_long_cs_omp.cpp
@@ -1,0 +1,233 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_lj_cut_coul_long_cs_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+
+static constexpr double EWALD_F = 1.12837917;
+static constexpr double EWALD_P = 9.95473818e-1;
+static constexpr double B0 = -0.1335096380159268;
+static constexpr double B1 = -2.57839507e-1;
+static constexpr double B2 = -1.37203639e-1;
+static constexpr double B3 = -8.88822059e-3;
+static constexpr double B4 = -5.80844129e-3;
+static constexpr double B5 = 1.14652755e-1;
+
+static constexpr double EPSILON = 1.0e-20;
+static constexpr double EPS_EWALD = 1.0e-6;
+static constexpr double EPS_EWALD_SQR = 1.0e-12;
+
+/* ---------------------------------------------------------------------- */
+
+PairLJCutCoulLongCSOMP::PairLJCutCoulLongCSOMP(LAMMPS *lmp) :
+  PairLJCutCoulLongCS(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+  cut_respa = nullptr;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairLJCutCoulLongCSOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairLJCutCoulLongCSOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum,itable,itype,jtype;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,ecoul,fpair;
+  double fraction,table;
+  double r,rsq,r2inv,r6inv,forcecoul,forcelj,factor_coul,factor_lj;
+  double grij,expm2,prefactor,t,erfc,u;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  evdwl = ecoul = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const double * const q = atom->q;
+  const int * const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * const special_coul = force->special_coul;
+  const double * const special_lj = force->special_lj;
+  const double qqrd2e = force->qqrd2e;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_lj = special_lj[sbmask(j)];
+      factor_coul = special_coul[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+      jtype = type[j];
+
+      if (rsq < cutsq[itype][jtype]) {
+        rsq += EPSILON; // Add Epsilon for case: r = 0; Interaction must be removed by special bond;
+        r2inv = 1.0/rsq;
+        if (rsq < cut_coulsq) {
+          if (!ncoultablebits || rsq <= tabinnersq) {
+            r = sqrt(rsq);
+            prefactor = qqrd2e * qtmp*q[j];
+            if (factor_coul < 1.0) {
+              // When bonded parts are being calculated a minimal distance (EPS_EWALD)
+              // has to be added to the prefactor and erfc in order to make the
+              // used approximation functions for the Ewald correction valid
+              grij = g_ewald * (r+EPS_EWALD);
+              expm2 = exp(-grij*grij);
+              t = 1.0 / (1.0 + EWALD_P*grij);
+              u = 1.0 - t;
+              erfc = t * (1.+u*(B0+u*(B1+u*(B2+u*(B3+u*(B4+u*B5)))))) * expm2;
+              prefactor /= (r+EPS_EWALD);
+              forcecoul = prefactor * (erfc + EWALD_F*grij*expm2 - (1.0-factor_coul));
+              // Additionally r2inv needs to be accordingly modified since the later
+              // scaling of the overall force shall be consistent
+              r2inv = 1.0/(rsq + EPS_EWALD_SQR);
+            } else {
+              grij = g_ewald * r;
+              expm2 = exp(-grij*grij);
+              t = 1.0 / (1.0 + EWALD_P*grij);
+              u = 1.0 - t;
+              erfc = t * (1.+u*(B0+u*(B1+u*(B2+u*(B3+u*(B4+u*B5)))))) * expm2;
+              prefactor /= r;
+              forcecoul = prefactor * (erfc + EWALD_F*grij*expm2);
+            }
+          } else {
+            union_int_float_t rsq_lookup;
+            rsq_lookup.f = rsq;
+            itable = rsq_lookup.i & ncoulmask;
+            itable >>= ncoulshiftbits;
+            fraction = ((double) rsq_lookup.f - rtable[itable]) * drtable[itable];
+            table = ftable[itable] + fraction*dftable[itable];
+            forcecoul = qtmp*q[j] * table;
+            if (factor_coul < 1.0) {
+              table = ctable[itable] + fraction*dctable[itable];
+              prefactor = qtmp*q[j] * table;
+              forcecoul -= (1.0-factor_coul)*prefactor;
+            }
+          }
+        } else forcecoul = 0.0;
+
+        if (rsq < cut_ljsq[itype][jtype]) {
+          r6inv = r2inv*r2inv*r2inv;
+          forcelj = r6inv * (lj1[itype][jtype]*r6inv - lj2[itype][jtype]);
+        } else forcelj = 0.0;
+
+        fpair = (forcecoul + factor_lj*forcelj) * r2inv;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (EFLAG) {
+          if (rsq < cut_coulsq) {
+            if (!ncoultablebits || rsq <= tabinnersq)
+              ecoul = prefactor*erfc;
+            else {
+              table = etable[itable] + fraction*detable[itable];
+              ecoul = qtmp*q[j] * table;
+            }
+            if (factor_coul < 1.0) ecoul -= (1.0-factor_coul)*prefactor;
+          } else ecoul = 0.0;
+          if (rsq < cut_ljsq[itype][jtype]) {
+            evdwl = r6inv*(lj3[itype][jtype]*r6inv-lj4[itype][jtype]) -
+              offset[itype][jtype];
+            evdwl *= factor_lj;
+          } else evdwl = 0.0;
+        }
+
+        if (EVFLAG) ev_tally_thr(this, i,j,nlocal,NEWTON_PAIR,
+                                 evdwl,ecoul,fpair,delx,dely,delz,thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairLJCutCoulLongCSOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairLJCutCoulLongCS::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_lj_cut_coul_long_cs_omp.h
+++ b/src/OPENMP/pair_lj_cut_coul_long_cs_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(lj/cut/coul/long/cs/omp,PairLJCutCoulLongCSOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_LJ_CUT_COUL_LONG_CS_OMP_H
+#define LMP_PAIR_LJ_CUT_COUL_LONG_CS_OMP_H
+
+#include "pair_lj_cut_coul_long_cs.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairLJCutCoulLongCSOMP : public PairLJCutCoulLongCS, public ThrOMP {
+
+ public:
+  PairLJCutCoulLongCSOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_lj_cut_dipole_long_omp.cpp
+++ b/src/OPENMP/pair_lj_cut_dipole_long_omp.cpp
@@ -1,0 +1,325 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_lj_cut_dipole_long_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "ewald_const.h"
+#include "force.h"
+#include "math_const.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+using namespace MathConst;
+using namespace EwaldConst;
+
+/* ---------------------------------------------------------------------- */
+
+PairLJCutDipoleLongOMP::PairLJCutDipoleLongOMP(LAMMPS *lmp) :
+  PairLJCutDipoleLong(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairLJCutDipoleLongOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairLJCutDipoleLongOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum,itype,jtype;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz;
+  double rsq,r,rinv,r2inv,r6inv;
+  double forcecoulx,forcecouly,forcecoulz,fforce;
+  double tixcoul,tiycoul,tizcoul,tjxcoul,tjycoul,tjzcoul;
+  double fx,fy,fz,fdx,fdy,fdz,fax,fay,faz;
+  double pdotp,pidotr,pjdotr,pre1,pre2,pre3;
+  double grij,expm2,t,erfc;
+  double g0,g1,g2,b0,b1,b2,b3,d0,d1,d2,d3;
+  double zdix,zdiy,zdiz,zdjx,zdjy,zdjz,zaix,zaiy,zaiz,zajx,zajy,zajz;
+  double g0b1_g1b2_g2b3,g0d1_g1d2_g2d3;
+  double forcelj,factor_coul,factor_lj,facm1;
+  double evdwl,ecoul;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  evdwl = ecoul = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const double * const q = atom->q;
+  const double * const * const mu = atom->mu;
+  double * const * const torque = thr->get_torque();
+  const int * const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * const special_coul = force->special_coul;
+  const double * const special_lj = force->special_lj;
+  const double qqrd2e = force->qqrd2e;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  pre1 = 2.0 * g_ewald / MY_PIS;
+  pre2 = 4.0 * pow(g_ewald,3.0) / MY_PIS;
+  pre3 = 8.0 * pow(g_ewald,5.0) / MY_PIS;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_lj = special_lj[sbmask(j)];
+      factor_coul = special_coul[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+      jtype = type[j];
+
+      if (rsq < cutsq[itype][jtype]) {
+        r2inv = 1.0/rsq;
+        rinv = sqrt(r2inv);
+
+        if (rsq < cut_coulsq) {
+          r = sqrt(rsq);
+          grij = g_ewald * r;
+          expm2 = exp(-grij*grij);
+          t = 1.0 / (1.0 + EWALD_P*grij);
+          erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
+
+          pdotp = mu[i][0]*mu[j][0] + mu[i][1]*mu[j][1] + mu[i][2]*mu[j][2];
+          pidotr = mu[i][0]*delx + mu[i][1]*dely + mu[i][2]*delz;
+          pjdotr = mu[j][0]*delx + mu[j][1]*dely + mu[j][2]*delz;
+
+          g0 = qtmp*q[j];
+          g1 = qtmp*pjdotr - q[j]*pidotr + pdotp;
+          g2 = -pidotr*pjdotr;
+
+          if (factor_coul > 0.0) {
+            b0 = erfc * rinv;
+            b1 = (b0 + pre1*expm2) * r2inv;
+            b2 = (3.0*b1 + pre2*expm2) * r2inv;
+            b3 = (5.0*b2 + pre3*expm2) * r2inv;
+
+            g0b1_g1b2_g2b3 = g0*b1 + g1*b2 + g2*b3;
+            fdx = delx * g0b1_g1b2_g2b3 -
+              b1 * (qtmp*mu[j][0] - q[j]*mu[i][0]) +
+              b2 * (pjdotr*mu[i][0] + pidotr*mu[j][0]);
+            fdy = dely * g0b1_g1b2_g2b3 -
+              b1 * (qtmp*mu[j][1] - q[j]*mu[i][1]) +
+              b2 * (pjdotr*mu[i][1] + pidotr*mu[j][1]);
+            fdz = delz * g0b1_g1b2_g2b3 -
+              b1 * (qtmp*mu[j][2] - q[j]*mu[i][2]) +
+              b2 * (pjdotr*mu[i][2] + pidotr*mu[j][2]);
+
+            zdix = delx * (q[j]*b1 + b2*pjdotr) - b1*mu[j][0];
+            zdiy = dely * (q[j]*b1 + b2*pjdotr) - b1*mu[j][1];
+            zdiz = delz * (q[j]*b1 + b2*pjdotr) - b1*mu[j][2];
+            zdjx = delx * (-qtmp*b1 + b2*pidotr) - b1*mu[i][0];
+            zdjy = dely * (-qtmp*b1 + b2*pidotr) - b1*mu[i][1];
+            zdjz = delz * (-qtmp*b1 + b2*pidotr) - b1*mu[i][2];
+
+            if (factor_coul < 1.0) {
+              fdx *= factor_coul;
+              fdy *= factor_coul;
+              fdz *= factor_coul;
+              zdix *= factor_coul;
+              zdiy *= factor_coul;
+              zdiz *= factor_coul;
+              zdjx *= factor_coul;
+              zdjy *= factor_coul;
+              zdjz *= factor_coul;
+            }
+          } else {
+            fdx = fdy = fdz = 0.0;
+            zdix = zdiy = zdiz = 0.0;
+            zdjx = zdjy = zdjz = 0.0;
+          }
+
+          if (factor_coul < 1.0) {
+            d0 = (erfc - 1.0) * rinv;
+            d1 = (d0 + pre1*expm2) * r2inv;
+            d2 = (3.0*d1 + pre2*expm2) * r2inv;
+            d3 = (5.0*d2 + pre3*expm2) * r2inv;
+
+            g0d1_g1d2_g2d3 = g0*d1 + g1*d2 + g2*d3;
+            fax = delx * g0d1_g1d2_g2d3 -
+              d1 * (qtmp*mu[j][0] - q[j]*mu[i][0]) +
+              d2 * (pjdotr*mu[i][0] + pidotr*mu[j][0]);
+            fay = dely * g0d1_g1d2_g2d3 -
+              d1 * (qtmp*mu[j][1] - q[j]*mu[i][1]) +
+              d2 * (pjdotr*mu[i][1] + pidotr*mu[j][1]);
+            faz = delz * g0d1_g1d2_g2d3 -
+              d1 * (qtmp*mu[j][2] - q[j]*mu[i][2]) +
+              d2 * (pjdotr*mu[i][2] + pidotr*mu[j][2]);
+
+            zaix = delx * (q[j]*d1 + d2*pjdotr) - d1*mu[j][0];
+            zaiy = dely * (q[j]*d1 + d2*pjdotr) - d1*mu[j][1];
+            zaiz = delz * (q[j]*d1 + d2*pjdotr) - d1*mu[j][2];
+            zajx = delx * (-qtmp*d1 + d2*pidotr) - d1*mu[i][0];
+            zajy = dely * (-qtmp*d1 + d2*pidotr) - d1*mu[i][1];
+            zajz = delz * (-qtmp*d1 + d2*pidotr) - d1*mu[i][2];
+
+            if (factor_coul > 0.0) {
+              facm1 = 1.0 - factor_coul;
+              fax *= facm1;
+              fay *= facm1;
+              faz *= facm1;
+              zaix *= facm1;
+              zaiy *= facm1;
+              zaiz *= facm1;
+              zajx *= facm1;
+              zajy *= facm1;
+              zajz *= facm1;
+            }
+          } else {
+            fax = fay = faz = 0.0;
+            zaix = zaiy = zaiz = 0.0;
+            zajx = zajy = zajz = 0.0;
+          }
+
+          forcecoulx = fdx + fax;
+          forcecouly = fdy + fay;
+          forcecoulz = fdz + faz;
+
+          tixcoul = mu[i][1]*(zdiz + zaiz) - mu[i][2]*(zdiy + zaiy);
+          tiycoul = mu[i][2]*(zdix + zaix) - mu[i][0]*(zdiz + zaiz);
+          tizcoul = mu[i][0]*(zdiy + zaiy) - mu[i][1]*(zdix + zaix);
+          tjxcoul = mu[j][1]*(zdjz + zajz) - mu[j][2]*(zdjy + zajy);
+          tjycoul = mu[j][2]*(zdjx + zajx) - mu[j][0]*(zdjz + zajz);
+          tjzcoul = mu[j][0]*(zdjy + zajy) - mu[j][1]*(zdjx + zajx);
+
+        } else {
+          forcecoulx = forcecouly = forcecoulz = 0.0;
+          tixcoul = tiycoul = tizcoul = 0.0;
+          tjxcoul = tjycoul = tjzcoul = 0.0;
+        }
+
+        // LJ interaction
+
+        if (rsq < cut_ljsq[itype][jtype]) {
+          r6inv = r2inv*r2inv*r2inv;
+          forcelj = r6inv * (lj1[itype][jtype]*r6inv - lj2[itype][jtype]);
+          fforce = factor_lj * forcelj*r2inv;
+        } else fforce = 0.0;
+
+        // total force
+
+        fx = qqrd2e*forcecoulx + delx*fforce;
+        fy = qqrd2e*forcecouly + dely*fforce;
+        fz = qqrd2e*forcecoulz + delz*fforce;
+
+        // force & torque accumulation
+
+        f[i][0] += fx;
+        f[i][1] += fy;
+        f[i][2] += fz;
+        torque[i][0] += qqrd2e*tixcoul;
+        torque[i][1] += qqrd2e*tiycoul;
+        torque[i][2] += qqrd2e*tizcoul;
+
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= fx;
+          f[j][1] -= fy;
+          f[j][2] -= fz;
+          torque[j][0] += qqrd2e*tjxcoul;
+          torque[j][1] += qqrd2e*tjycoul;
+          torque[j][2] += qqrd2e*tjzcoul;
+        }
+
+        if (EFLAG) {
+          if (rsq < cut_coulsq && factor_coul > 0.0) {
+            ecoul = qqrd2e*(b0*g0 + b1*g1 + b2*g2);
+            if (factor_coul < 1.0) {
+              ecoul *= factor_coul;
+              ecoul += (1-factor_coul) * qqrd2e * (d0*g0 + d1*g1 + d2*g2);
+            }
+          } else ecoul = 0.0;
+
+          if (rsq < cut_ljsq[itype][jtype]) {
+            evdwl = r6inv*(lj3[itype][jtype]*r6inv-lj4[itype][jtype]) -
+              offset[itype][jtype];
+            evdwl *= factor_lj;
+          } else evdwl = 0.0;
+        }
+
+        if (EVFLAG) ev_tally_xyz_thr(this,i,j,nlocal,NEWTON_PAIR,
+                                     evdwl,ecoul,fx,fy,fz,delx,dely,delz,thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairLJCutDipoleLongOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairLJCutDipoleLong::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_lj_cut_dipole_long_omp.h
+++ b/src/OPENMP/pair_lj_cut_dipole_long_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(lj/cut/dipole/long/omp,PairLJCutDipoleLongOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_LJ_CUT_DIPOLE_LONG_OMP_H
+#define LMP_PAIR_LJ_CUT_DIPOLE_LONG_OMP_H
+
+#include "pair_lj_cut_dipole_long.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairLJCutDipoleLongOMP : public PairLJCutDipoleLong, public ThrOMP {
+
+ public:
+  PairLJCutDipoleLongOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_lj_expand_coul_long_omp.cpp
+++ b/src/OPENMP/pair_lj_expand_coul_long_omp.cpp
@@ -1,0 +1,210 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_lj_expand_coul_long_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "ewald_const.h"
+#include "force.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+using namespace EwaldConst;
+
+/* ---------------------------------------------------------------------- */
+
+PairLJExpandCoulLongOMP::PairLJExpandCoulLongOMP(LAMMPS *lmp) :
+  PairLJExpandCoulLong(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+  cut_respa = nullptr;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairLJExpandCoulLongOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairLJExpandCoulLongOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum,itype,jtype,itable;
+  double qtmp,xtmp,ytmp,ztmp,delx,dely,delz,evdwl,ecoul,fpair;
+  double fraction,table;
+  double r,r2inv,r6inv,forcecoul,forcelj,factor_coul,factor_lj;
+  double grij,expm2,prefactor,t,erfc;
+  double rsq,rshift,rshiftsq,rshift2inv;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  evdwl = ecoul = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const double * const q = atom->q;
+  const int * const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * const special_coul = force->special_coul;
+  const double * const special_lj = force->special_lj;
+  const double qqrd2e = force->qqrd2e;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    qtmp = q[i];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_lj = special_lj[sbmask(j)];
+      factor_coul = special_coul[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+      jtype = type[j];
+
+      if (rsq < cutsq[itype][jtype]) {
+        r2inv = 1.0/rsq;
+
+        if (rsq < cut_coulsq) {
+          if (!ncoultablebits || rsq <= tabinnersq) {
+            r = sqrt(rsq);
+            grij = g_ewald * r;
+            expm2 = exp(-grij*grij);
+            t = 1.0 / (1.0 + EWALD_P*grij);
+            erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
+            prefactor = qqrd2e * qtmp*q[j]/r;
+            forcecoul = prefactor * (erfc + EWALD_F*grij*expm2);
+            if (factor_coul < 1.0) forcecoul -= (1.0-factor_coul)*prefactor;
+          } else {
+            union_int_float_t rsq_lookup;
+            rsq_lookup.f = rsq;
+            itable = rsq_lookup.i & ncoulmask;
+            itable >>= ncoulshiftbits;
+            fraction = ((double) rsq_lookup.f - rtable[itable]) * drtable[itable];
+            table = ftable[itable] + fraction*dftable[itable];
+            forcecoul = qtmp*q[j] * table;
+            if (factor_coul < 1.0) {
+              table = ctable[itable] + fraction*dctable[itable];
+              prefactor = qtmp*q[j] * table;
+              forcecoul -= (1.0-factor_coul)*prefactor;
+            }
+          }
+        } else forcecoul = 0.0;
+
+        if (rsq < cut_ljsq[itype][jtype]) {
+          r = sqrt(rsq);
+          rshift = r - shift[itype][jtype];
+          rshiftsq = rshift*rshift;
+          rshift2inv = 1.0/rshiftsq;
+          r6inv = rshift2inv*rshift2inv*rshift2inv;
+          forcelj = r6inv * (lj1[itype][jtype]*r6inv - lj2[itype][jtype]);
+          forcelj *= factor_lj/rshift/r;
+        } else forcelj = 0.0;
+
+        fpair = forcecoul*r2inv + forcelj;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (EFLAG) {
+          if (rsq < cut_coulsq) {
+            if (!ncoultablebits || rsq <= tabinnersq)
+              ecoul = prefactor*erfc;
+            else {
+              table = etable[itable] + fraction*detable[itable];
+              ecoul = qtmp*q[j] * table;
+            }
+            if (factor_coul < 1.0) ecoul -= (1.0-factor_coul)*prefactor;
+          } else ecoul = 0.0;
+
+          if (rsq < cut_ljsq[itype][jtype]) {
+            evdwl = r6inv*(lj3[itype][jtype]*r6inv-lj4[itype][jtype]) - offset[itype][jtype];
+            evdwl *= factor_lj;
+          } else evdwl = 0.0;
+        }
+
+        if (EVFLAG) ev_tally_thr(this,i,j,nlocal,NEWTON_PAIR,evdwl,ecoul,fpair,delx,dely,delz,thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairLJExpandCoulLongOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairLJExpandCoulLong::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_lj_expand_coul_long_omp.h
+++ b/src/OPENMP/pair_lj_expand_coul_long_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(lj/expand/coul/long/omp,PairLJExpandCoulLongOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_LJ_EXPAND_COUL_LONG_OMP_H
+#define LMP_PAIR_LJ_EXPAND_COUL_LONG_OMP_H
+
+#include "pair_lj_expand_coul_long.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairLJExpandCoulLongOMP : public PairLJExpandCoulLong, public ThrOMP {
+
+ public:
+  PairLJExpandCoulLongOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_morse_soft_omp.cpp
+++ b/src/OPENMP/pair_morse_soft_omp.cpp
@@ -1,0 +1,189 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_morse_soft_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "math_special.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+PairMorseSoftOMP::PairMorseSoftOMP(LAMMPS *lmp) :
+  PairMorseSoft(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairMorseSoftOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairMorseSoftOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i, j, ii, jj, jnum, itype, jtype;
+  double xtmp, ytmp, ztmp, delx, dely, delz, evdwl, fpair;
+  double rsq, r, dr, dexp, dexp2, dexp3, factor_lj;
+  double ea, phi, V0, iea2;
+  double D, a, x0, l, B, s1, llf;
+  int *ilist, *jlist, *numneigh, **firstneigh;
+
+  evdwl = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const int * const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * const special_lj = force->special_lj;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_lj = special_lj[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx * delx + dely * dely + delz * delz;
+      jtype = type[j];
+
+      if (rsq < cutsq[itype][jtype]) {
+        r = sqrt(rsq);
+        dr = r - r0[itype][jtype];
+
+        D = d0[itype][jtype];
+        a = alpha[itype][jtype];
+        x0 = r0[itype][jtype];
+        dexp = exp(-a * dr);
+        dexp2 = dexp * dexp;
+        dexp3 = dexp2 * dexp;
+
+        l = lambda[itype][jtype];
+
+        ea = exp(a * x0);
+        iea2 = exp(-2. * a * x0);
+
+        V0 = D * dexp * (dexp - 2.0);
+        B = -2.0 * D * iea2 * (ea - 1.0) / 3.0;
+
+        if (l >= shift_range) {
+          s1 = (l - 1.0) / (shift_range - 1.0);
+          phi = V0 + B * dexp3 * s1;
+
+          // Force computation:
+          fpair = 3.0 * a * B * dexp3 * s1 + 2.0 * a * D * (dexp2 - dexp);
+          fpair /= r;
+        } else {
+          llf = MathSpecial::powint(l / shift_range, nlambda);
+          phi = V0 + B * dexp3;
+          phi *= llf;
+
+          // Force computation:
+          if (r == 0.0) {
+            fpair = 0.0;
+          } else {
+            fpair = 3.0 * a * B * dexp3 + 2.0 * a * D * (dexp2 - dexp);
+            fpair *= llf / r;
+          }
+        }
+
+        fpair *= factor_lj;
+
+        f[i][0] += delx * fpair;
+        f[i][1] += dely * fpair;
+        f[i][2] += delz * fpair;
+
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx * fpair;
+          f[j][1] -= dely * fpair;
+          f[j][2] -= delz * fpair;
+        }
+
+        if (EFLAG) { evdwl = phi * factor_lj; }
+
+        if (EVFLAG) ev_tally_thr(this, i, j, nlocal, NEWTON_PAIR, evdwl, 0.0, fpair, delx, dely, delz, thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairMorseSoftOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairMorseSoft::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_morse_soft_omp.h
+++ b/src/OPENMP/pair_morse_soft_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(morse/soft/omp,PairMorseSoftOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_MORSE_SOFT_OMP_H
+#define LMP_PAIR_MORSE_SOFT_OMP_H
+
+#include "pair_morse_soft.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairMorseSoftOMP : public PairMorseSoft, public ThrOMP {
+
+ public:
+  PairMorseSoftOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/pair_nm_cut_split_omp.cpp
+++ b/src/OPENMP/pair_nm_cut_split_omp.cpp
@@ -1,0 +1,173 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "pair_nm_cut_split_omp.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "math_special.h"
+#include "neigh_list.h"
+#include "suffix.h"
+
+#include <cmath>
+
+#include "omp_compat.h"
+
+using namespace LAMMPS_NS;
+using MathSpecial::powint;
+
+/* ---------------------------------------------------------------------- */
+
+PairNMCutSplitOMP::PairNMCutSplitOMP(LAMMPS *lmp) :
+  PairNMCutSplit(lmp), ThrOMP(lmp, THR_PAIR)
+{
+  suffix_flag |= Suffix::OMP;
+  respa_enable = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PairNMCutSplitOMP::compute(int eflag, int vflag)
+{
+  ev_init(eflag,vflag);
+
+  const int nall = atom->nlocal + atom->nghost;
+  const int nthreads = comm->nthreads;
+  const int inum = list->inum;
+
+#if defined(_OPENMP)
+#pragma omp parallel LMP_DEFAULT_NONE LMP_SHARED(eflag,vflag)
+#endif
+  {
+    int ifrom, ito, tid;
+
+    loop_setup_thr(ifrom, ito, tid, inum, nthreads);
+    ThrData *thr = fix->get_thr(tid);
+    thr->timer(Timer::START);
+    ev_setup_thr(eflag, vflag, nall, eatom, vatom, nullptr, thr);
+
+    if (evflag) {
+      if (eflag) {
+        if (force->newton_pair) eval<1,1,1>(ifrom, ito, thr);
+        else eval<1,1,0>(ifrom, ito, thr);
+      } else {
+        if (force->newton_pair) eval<1,0,1>(ifrom, ito, thr);
+        else eval<1,0,0>(ifrom, ito, thr);
+      }
+    } else {
+      if (force->newton_pair) eval<0,0,1>(ifrom, ito, thr);
+      else eval<0,0,0>(ifrom, ito, thr);
+    }
+
+    thr->timer(Timer::PAIR);
+    reduce_thr(this, eflag, vflag, thr);
+  } // end of omp parallel region
+}
+
+/* ---------------------------------------------------------------------- */
+
+template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+void PairNMCutSplitOMP::eval(int iifrom, int iito, ThrData * const thr)
+{
+  int i,j,ii,jj,jnum,itype,jtype;
+  double xtmp,ytmp,ztmp,delx,dely,delz,evdwl,fpair;
+  double rsq,r2inv,factor_lj;
+  double r,forcenm,rminv,rninv;
+  int *ilist,*jlist,*numneigh,**firstneigh;
+
+  evdwl = 0.0;
+
+  const double * const * const x = atom->x;
+  double * const * const f = thr->get_f();
+  const int * const type = atom->type;
+  const int nlocal = atom->nlocal;
+  const double * const special_lj = force->special_lj;
+
+  ilist = list->ilist;
+  numneigh = list->numneigh;
+  firstneigh = list->firstneigh;
+
+  // loop over neighbors of my atoms
+
+  for (ii = iifrom; ii < iito; ++ii) {
+    i = ilist[ii];
+    xtmp = x[i][0];
+    ytmp = x[i][1];
+    ztmp = x[i][2];
+    itype = type[i];
+    jlist = firstneigh[i];
+    jnum = numneigh[i];
+
+    for (jj = 0; jj < jnum; jj++) {
+      j = jlist[jj];
+      factor_lj = special_lj[sbmask(j)];
+      j &= NEIGHMASK;
+
+      delx = xtmp - x[j][0];
+      dely = ytmp - x[j][1];
+      delz = ztmp - x[j][2];
+      rsq = delx*delx + dely*dely + delz*delz;
+      jtype = type[j];
+
+      if (rsq < cutsq[itype][jtype]) {
+        r2inv = 1.0/rsq;
+        r = sqrt(rsq);
+
+        // r < r0 --> use generalized LJ
+        if (rsq < r0[itype][jtype]*r0[itype][jtype]) {
+          forcenm = e0nm[itype][jtype]*nm[itype][jtype]*
+            (r0n[itype][jtype]/pow(r,nn[itype][jtype])
+             -r0m[itype][jtype]/pow(r,mm[itype][jtype]));
+        }
+        // r > r0 --> use standard LJ (m = 6 n = 12)
+        else forcenm =(e0[itype][jtype]/6.0)*72.0*(4.0/powint(r,12)-2.0/powint(r,6));
+
+        fpair = factor_lj*forcenm*r2inv;
+
+        f[i][0] += delx*fpair;
+        f[i][1] += dely*fpair;
+        f[i][2] += delz*fpair;
+        if (NEWTON_PAIR || j < nlocal) {
+          f[j][0] -= delx*fpair;
+          f[j][1] -= dely*fpair;
+          f[j][2] -= delz*fpair;
+        }
+
+        if (EFLAG) {
+          // r < r0 --> use generalized LJ
+          if (rsq < r0[itype][jtype]*r0[itype][jtype]) {
+            rminv = pow(r2inv,mm[itype][jtype]/2.0);
+            rninv = pow(r2inv,nn[itype][jtype]/2.0);
+
+            evdwl = e0nm[itype][jtype]*(mm[itype][jtype]*r0n[itype][jtype]*rninv -
+                                        nn[itype][jtype]*r0m[itype][jtype]*rminv) -
+              offset[itype][jtype];
+          }
+          // r > r0 --> use standard LJ (m = 6 n = 12)
+          else evdwl = (e0[itype][jtype]/6.0)*(24.0*powint(r2inv,6) - 24.0*pow(r2inv,3));
+          evdwl *= factor_lj;
+        }
+        if (EVFLAG) ev_tally_thr(this,i,j,nlocal,NEWTON_PAIR,evdwl,0.0,fpair,delx,dely,delz,thr);
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairNMCutSplitOMP::memory_usage()
+{
+  double bytes = memory_usage_thr();
+  bytes += PairNMCutSplit::memory_usage();
+
+  return bytes;
+}

--- a/src/OPENMP/pair_nm_cut_split_omp.h
+++ b/src/OPENMP/pair_nm_cut_split_omp.h
@@ -1,0 +1,41 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   This software is distributed under the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(nm/cut/split/omp,PairNMCutSplitOMP);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_NM_CUT_SPLIT_OMP_H
+#define LMP_PAIR_NM_CUT_SPLIT_OMP_H
+
+#include "pair_nm_cut_split.h"
+#include "thr_omp.h"
+
+namespace LAMMPS_NS {
+
+class PairNMCutSplitOMP : public PairNMCutSplit, public ThrOMP {
+
+ public:
+  PairNMCutSplitOMP(class LAMMPS *);
+
+  void compute(int, int) override;
+  double memory_usage() override;
+
+ private:
+  template <int EVFLAG, int EFLAG, int NEWTON_PAIR>
+  void eval(int ifrom, int ito, ThrData *const thr);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/OPENMP/thr_omp.cpp
+++ b/src/OPENMP/thr_omp.cpp
@@ -312,6 +312,56 @@ void ThrOMP::reduce_thr(void *style, const int eflag, const int vflag,
     }
     break;
 
+  case THR_ANGLE|THR_CHARMM: // special case for angle styles with a 1-3 pairwise term
+
+    if (evflag) {
+      Angle * const angle = lmp->force->angle;
+      Pair * const pair = lmp->force->pair;
+#if defined(_OPENMP)
+#pragma omp critical
+#endif
+      {
+        if (eflag & ENERGY_GLOBAL) {
+          angle->energy += thr->eng_angle;
+          pair->eng_vdwl += thr->eng_vdwl;
+          pair->eng_coul += thr->eng_coul;
+          thr->eng_angle = 0.0;
+          thr->eng_vdwl = 0.0;
+          thr->eng_coul = 0.0;
+        }
+
+        if (vflag & (VIRIAL_PAIR | VIRIAL_FDOTR)) {
+          for (int i=0; i < 6; ++i) {
+            angle->virial[i] += thr->virial_angle[i];
+            pair->virial[i] += thr->virial_pair[i];
+            thr->virial_angle[i] = 0.0;
+            thr->virial_pair[i] = 0.0;
+          }
+        }
+      }
+
+      if (eflag & ENERGY_ATOM) {
+        data_reduce_thr(&(angle->eatom[0]), nall, nthreads, 1, tid);
+        data_reduce_thr(&(pair->eatom[0]), nall, nthreads, 1, tid);
+      }
+      if (vflag & VIRIAL_ATOM) {
+        data_reduce_thr(&(angle->vatom[0][0]), nall, nthreads, 6, tid);
+      }
+      if (vflag & VIRIAL_CENTROID) {
+        data_reduce_thr(&(angle->cvatom[0][0]), nall, nthreads, 9, tid);
+      }
+      // per-atom virial and per-atom centroid virial are the same for two-body
+      // many-body pair styles not yet implemented
+      if (vflag & (VIRIAL_ATOM | VIRIAL_CENTROID)) {
+        data_reduce_thr(&(pair->vatom[0][0]), nall, nthreads, 6, tid);
+      }
+      // check cvatom_pair, because can't access centroidstressflag
+      if ((vflag & VIRIAL_CENTROID) && thr->cvatom_pair) {
+        data_reduce_thr(&(pair->cvatom[0][0]), nall, nthreads, 9, tid);
+      }
+    }
+    break;
+
   case THR_DIHEDRAL:
 
     if (evflag) {

--- a/src/ORIENT/fix_orient_bcc.h
+++ b/src/ORIENT/fix_orient_bcc.h
@@ -56,7 +56,7 @@ class FixOrientBCC : public Fix {
   void unpack_forward_comm(int, int, double *) override;
   double memory_usage() override;
 
- private:
+ protected:
   int me;
   int ilevel_respa;
 

--- a/src/ORIENT/fix_orient_eco.cpp
+++ b/src/ORIENT/fix_orient_eco.cpp
@@ -51,12 +51,6 @@ static const char cite_fix_orient_eco[] =
   " url = {https://doi.org/10.1016/j.commatsci.2020.109774}\n"
   "}\n\n";
 
-struct FixOrientECO::Nbr {
-  double duchi;            // potential derivative
-  double real_phi[2][3];   // real part of wave function
-  double imag_phi[2][3];   // imaginary part of wave function
-};
-
 /* ---------------------------------------------------------------------- */
 
 FixOrientECO::FixOrientECO(LAMMPS *lmp, int narg, char **arg) :

--- a/src/ORIENT/fix_orient_eco.h
+++ b/src/ORIENT/fix_orient_eco.h
@@ -39,8 +39,12 @@ class FixOrientECO : public Fix {
   void unpack_forward_comm(int, int, double *) override;
   double memory_usage() override;
 
- private:
-  struct Nbr;    // forward declaration. private struct for managing precomputed terms
+ protected:
+  struct Nbr {               // precomputed terms per owned and ghost atom
+    double duchi;            // potential derivative
+    double real_phi[2][3];   // real part of wave function
+    double imag_phi[2][3];   // imaginary part of wave function
+  };
 
   int me;              // this processors rank
   int nmax;            // maximal # of owned + ghost atoms on this processor

--- a/src/ORIENT/fix_orient_fcc.h
+++ b/src/ORIENT/fix_orient_fcc.h
@@ -56,7 +56,7 @@ class FixOrientFCC : public Fix {
   void unpack_forward_comm(int, int, double *) override;
   double memory_usage() override;
 
- private:
+ protected:
   int me;
   int ilevel_respa;
 

--- a/src/QEQ/fix_qeq_dynamic.h
+++ b/src/QEQ/fix_qeq_dynamic.h
@@ -36,8 +36,8 @@ class FixQEqDynamic : public FixQEq {
   int pack_reverse_comm(int, int, double *) override;
   void unpack_reverse_comm(int, int *, double *) override;
 
- private:
-  double compute_eneg();
+ protected:
+  virtual double compute_eneg();
 };
 
 }    // namespace LAMMPS_NS

--- a/src/QEQ/fix_qeq_fire.h
+++ b/src/QEQ/fix_qeq_fire.h
@@ -36,9 +36,10 @@ class FixQEqFire : public FixQEq {
   int pack_reverse_comm(int, int, double *) override;
   void unpack_reverse_comm(int, int *, double *) override;
 
- private:
-  double compute_eneg();
+ protected:
+  virtual double compute_eneg();
 
+ private:
   class PairComb *comb;
   class PairComb3 *comb3;
 };

--- a/src/compute_centro_atom.h
+++ b/src/compute_centro_atom.h
@@ -33,7 +33,7 @@ class ComputeCentroAtom : public Compute {
   void compute_peratom() override;
   double memory_usage() override;
 
- private:
+ protected:
   int nmax, maxneigh, nnn;
   double *distsq;
   int *nearest;

--- a/src/compute_cna_atom.h
+++ b/src/compute_cna_atom.h
@@ -33,7 +33,7 @@ class ComputeCNAAtom : public Compute {
   void compute_peratom() override;
   double memory_usage() override;
 
- private:
+ protected:
   int nmax;
   double cutsq;
   class NeighList *list;

--- a/src/compute_erotate_sphere_atom.h
+++ b/src/compute_erotate_sphere_atom.h
@@ -32,7 +32,7 @@ class ComputeErotateSphereAtom : public Compute {
   void compute_peratom() override;
   double memory_usage() override;
 
- private:
+ protected:
   int nmax;
   double pfactor;
   double *erot;

--- a/src/compute_orientorder_atom.cpp
+++ b/src/compute_orientorder_atom.cpp
@@ -307,7 +307,7 @@ void ComputeOrientOrderAtom::compute_peratom()
         ncount = nnn;
       }
 
-      calc_boop(rlist, ncount, qn, qlist, nqlist);
+      calc_boop(rlist, ncount, qn, qlist, nqlist, qnm_r, qnm_i);
     }
   }
 }
@@ -417,7 +417,7 @@ void ComputeOrientOrderAtom::select3(int k, int n, double *arr, int *iarr, doubl
 ------------------------------------------------------------------------- */
 
 void ComputeOrientOrderAtom::calc_boop(double **rlist, int ncount, double qn[], int qlist[],
-                                       int nqlist)
+                                       int nqlist, double **qnm_r, double **qnm_i)
 {
 
   for (int il = 0; il < nqlist; il++) {

--- a/src/compute_orientorder_atom.h
+++ b/src/compute_orientorder_atom.h
@@ -50,7 +50,8 @@ class ComputeOrientOrderAtom : public Compute {
   double **qnm_i;
 
   void select3(int, int, double *, int *, double **);
-  void calc_boop(double **rlist, int numNeighbors, double qn[], int nlist[], int nnlist);
+  void calc_boop(double **rlist, int numNeighbors, double qn[], int nlist[], int nnlist,
+                 double **qnm_r, double **qnm_i);
 
   double polar_prefactor(int, int, double);
   double associated_legendre(int, int, double);

--- a/src/compute_rdf.h
+++ b/src/compute_rdf.h
@@ -32,7 +32,7 @@ class ComputeRDF : public Compute {
   void init_list(int, class NeighList *) override;
   void compute_array() override;
 
- private:
+ protected:
   int nbin;                // # of rdf bins
   int cutflag;             // user cutoff flag
   int npairs;              // # of rdf pairs


### PR DESCRIPTION
**Summary**

Add OpenMP-threaded (`/omp`) variants to the OPENMP package across analysis
*computes*, one *angle* style, and short-range *pair* styles. Until now the
OPENMP package threaded essentially every mainstream force/neighbor style but
left gaps: **no** compute style was threaded, and many variant pair styles
(core-shell, soft-core, CHARMM force-switch, dipole, ...) lacked an `/omp`
counterpart even though their close relatives had one.

**Compute styles (13):** `coord/atom/omp`, `orientorder/atom/omp`,
`ke/atom/omp`, `erotate/sphere/atom/omp`, `centro/atom/omp`, `cna/atom/omp`,
`hexorder/atom/omp`, `ackland/atom/omp`, `cnp/atom/omp`, `entropy/atom/omp`,
`ave/sphere/atom/omp`, `rdf/omp`. These write per-atom output (or an
integer-tallied histogram) and never touch `atom->f`, so they thread the
per-atom loop with a plain `#pragma omp parallel for` and do not use the
ThrOMP per-thread force machinery.

**Angle style (1):** `cosine/buck6d/omp` (the angle analogue of CHARMM
dihedral: a buck6d 1-3 term tallied into the pair accumulators). Supporting it
added a `THR_ANGLE|THR_CHARMM` case to `ThrOMP::reduce_thr` mirroring the
existing `THR_DIHEDRAL|THR_CHARMM` case.

**Pair styles, Tier 1 (21):** mechanical ports of short-range pairwise styles
whose non-`/omp` relatives are already threaded:

- core-shell (8): `coul/long/cs`, `coul/wolf/cs`, `born/coul/long/cs`,
  `born/coul/dsf/cs`, `born/coul/wolf/cs`, `buck/coul/long/cs`,
  `lj/cut/coul/long/cs`, `lj/class2/coul/long/cs`;
- FEP soft-core (5): `lj/class2/soft`, `lj/class2/coul/cut/soft`,
  `lj/class2/coul/long/soft`, `morse/soft`, `coul/cut/soft/gapsys`;
- CHARMM / simple (8): `lj/charmmfsw/coul/long`,
  `lj/charmmfsw/coul/charmmfsh`, `lj/expand/coul/long`, `nm/cut/split`,
  `born/coul/dsf`, `coul/slater/cut`, `coul/slater/long`, `coul/exclude`.

**Pair styles, Tier 2 (1):** `lj/cut/dipole/long/omp` -- threads the
real-space force + dipole-torque loop (using `thr->get_torque()` /
`ev_tally_xyz_thr`, mirroring `lj/cut/dipole/cut/omp`); the long-range half is
handled by the already-threaded `ewald/disp` solver.

Each pair `/omp` eval reproduces its serial `compute()` (e.g. the core-shell
`EPS_EWALD` handling and higher-order B0..B5 erfc, the soft-core
lambda-softened denominators, the CHARMM force-switch terms, the dipole
torque) threaded via the standard ThrOMP per-thread force/torque
decomposition; respa is disabled, matching the existing `/omp` pair-style
convention.

**Fix styles (9):** OpenMP variants of the QEQ charge-equilibration family and
the ORIENT grain-boundary driving-force fixes.

- QEQ (6): `qeq/point/omp`, `qeq/shielded/omp`, `qeq/slater/omp`,
  `qeq/ctip/omp`, `qeq/dynamic/omp`, `qeq/fire/omp`. The matrix-based variants
  thread the `H`-matrix build (two-pass count -> serial sum-scan offsets ->
  parallel fill, reproducing the serial packed-CSR layout) and the sparse
  matrix-vector product (a per-thread `b_temp` buffer absorbs the symmetric
  transpose scatter, then is reduced). The matrix-free variants (`dynamic`,
  `fire`) thread `compute_eneg()` with the same per-thread buffer. The base
  conjugate-gradient / FIRE drivers and all collective MPI communication stay
  serial.
- ORIENT (3): `orient/fcc/omp`, `orient/bcc/omp`, `orient/eco/omp`. Phase 1
  (per-atom order parameter and neighbor-term build) threads with per-thread
  sort/gradient scratch and reduced `added_energy` / neighbor-count statistics;
  phase 2 writes only `f[i]` -- it reads neighbor data acquired via
  `forward_comm` but never writes `f[m]`/`f[j]` -- so the per-atom partition is
  race-free and needs no per-thread force buffer.

Neither fix family uses ThrOMP: the QEQ fixes do not contribute to `atom->f`,
and the ORIENT phase-2 force is written to disjoint owned-atom slots.

**Related Issue(s)**

None.

**Author(s)**

Axel Kohlmeyer (Temple University), akohlmey@gmail.com

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

The `/omp` subclasses, the supporting base-class refactoring, the new
`ThrOMP::reduce_thr` case, and the documentation updates in this pull request
were generated with the assistance of an AI tool (Anthropic Claude, via Claude
Code), under the direction and review of the human author. The generated code
was reviewed, built, and verified by the author before submission (see the
`Co-Authored-By: Claude` trailers on the commits).

**Backward Compatibility**

No backward-incompatible changes. The PR is additive (new opt-in `/omp` styles
selected only under `-sf omp`). Edits to existing files are limited to:
widening a few `private:` members to `protected:` in base compute classes;
removing the `inline` specifier from two `ComputeHexOrderAtom` helpers so the
symbols have external linkage; making `ComputeOrientOrderAtom::calc_boop()`
reentrant by passing its accumulators as arguments; adding a new
(purely additive) `THR_ANGLE|THR_CHARMM` case to `ThrOMP::reduce_thr`; widening a few `private:` members to `protected:` in the QEQ and ORIENT fix base classes; making `FixQEqDynamic`/`FixQEqFire::compute_eneg()` `protected virtual`; and moving the `FixOrientECO::Nbr` struct definition into its header so the `/omp` subclass can see it.

**Implementation Notes**

Verification: every ported style was checked to produce per-atom forces (and,
where applicable, per-atom torques/energy) that are **bit-identical to the
serial style at 1 thread** and agree to round-off (~1e-12..1e-13 relative) at
4 threads, at np == 1 and (for the computes) np == 2. Style selection was
confirmed via `info computes` / `info` and the log. Pair styles were tested on
the `examples/coreshell` system and on small charged-FCC / bonded / dipolar
systems; the angle on `examples/PACKAGES/mofff`. The fix `/omp` variants were verified the same way: `orient/fcc` and `orient/bcc` are bit-identical to serial (per-atom force and order parameter), `orient/eco` agrees to round-off, and the QEQ single charge solve matches serial to ~1e-13 with MD-trajectory differences bounded by the conjugate-gradient tolerance (the expected behavior for a threaded iterative solver); QEQ was tested on `examples/qeq` and `examples/streitz`, ORIENT on `examples/PACKAGES/orient_eco` and small fcc/bcc bicrystal setups. `make check-whitespace` /
`check-permissions` are clean; the build was verified with CMake
(`-D PKG_OPENMP=on -D BUILD_OMP=on`, plus FEP / MOFFF / CORESHELL / KSPACE /
DIPOLE / MANYBODY).

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system


