### PR TITLE
PERI: fix per-type-pair critical stretch bond breaking (#984), with cleanup and tests

### DIFF
--- a/doc/src/Howto_peri.rst
+++ b/doc/src/Howto_peri.rst
@@ -581,11 +581,22 @@ as broken in a simulation by removing them from the bond family
 
 A naive implementation would have us first loop over all bonds and
 compute :math:`s_{min}` in :ref:`(9) <peris0>`, then loop over all bonds
-again and break bonds with a stretch :math:`s > s0` as in
+again and break bonds with a stretch :math:`s > s_0` as in
 :ref:`(8) <perimu>`, and finally loop over all particles and compute forces
 for the next step of :ref:`Algorithm 1 <algvelverlet>`. For reasons of
-computational efficiency, we will utilize the values of :math:`s_0` from
-the *previous* timestep when deciding to break a bond.
+computational efficiency, we instead store the per-particle minimum stretch
+:math:`s_{min}` from the *previous* timestep and, when deciding whether to
+break a bond, form its critical stretch :math:`s_0 = s_{00} - \alpha\,
+s_{min}` from that bond's own :math:`s_{00}` and :math:`\alpha`.  This keeps
+the criterion correct when :math:`s_{00}` and :math:`\alpha` differ between
+atom-type pairs (for example, a deliberately weakened interface).
+
+.. versionchanged:: TBD
+
+Earlier versions stored a single per-particle critical stretch :math:`s_0`
+(the maximum of :math:`s_{00} - \alpha s` over a particle's bonds), which
+reproduces :ref:`(9) <peris0>` only when :math:`s_{00}` and :math:`\alpha`
+are identical for all atom-type pairs.
 
 .. note::
 

--- a/doc/src/compute_property_atom.rst
+++ b/doc/src/compute_property_atom.rst
@@ -91,7 +91,7 @@ Syntax
 
            PERI package per-atom properties:
            vfrac = volume fraction
-           s0 = max stretch of any bond a particle is part of
+           s0 = critical bond stretch (bond-breaking threshold) of a particle
 
   .. parsed-literal::
 

--- a/doc/src/pair_peri.rst
+++ b/doc/src/pair_peri.rst
@@ -151,6 +151,42 @@ details please see the description in "(Mitchell2011a)".
 
 ----------
 
+Bond breaking criterion
+"""""""""""""""""""""""
+
+For all of these styles a peridynamic bond between particles *i* and *j*
+breaks irreversibly once its stretch :math:`s = (r - r_0)/r_0` exceeds a
+critical stretch.  Following :ref:`(Parks) <Parks>` (eq. 9), the critical
+stretch of a particle is :math:`s_0 = s_{00} - \alpha\, s_{min}`, where
+:math:`s_{min}` is the minimum (most compressive) stretch over all of the
+particle's bonds, and a bond breaks when :math:`s > \min(s_{0,i},
+s_{0,j})`, i.e. symmetrically from the point of view of both particles.
+
+The s00 and :math:`\alpha` coefficients may be chosen differently for each
+pair of atom types.  This makes it possible, for example, to assign a
+smaller s00 to the bonds across an interface between two materials so that
+a crack preferentially initiates there.  The critical stretch is evaluated
+*per bond* using that bond's own s00 and :math:`\alpha` together with the
+geometric :math:`s_{min}` of each endpoint.
+
+.. versionchanged:: TBD
+
+In previous versions the critical stretch was stored as a single
+per-particle value computed as the maximum of :math:`s_{00} - \alpha s`
+over a particle's bonds.  That is only equivalent to the criterion above
+when s00 and :math:`\alpha` are identical for all type pairs; with
+type-dependent coefficients a bond would incorrectly inherit the critical
+stretch of the surrounding bulk bonds and a weakened interface would not
+fracture.  The criterion is now evaluated per bond so that type-dependent
+s00 and :math:`\alpha` behave as intended.
+
+The :doc:`compute property/atom <compute_property_atom>` *s0* per-atom
+property reports this per-particle critical stretch.  Earlier versions of
+this documentation incorrectly described *s0* as the maximum stretch of
+any bond a particle is part of.
+
+----------
+
 .. include:: accel_styles.rst
 
 ----------

--- a/src/OPENMP/pair_peri_lps_omp.cpp
+++ b/src/OPENMP/pair_peri_lps_omp.cpp
@@ -27,6 +27,7 @@
 #include "neighbor.h"
 #include "suffix.h"
 
+#include <cfloat>
 #include <cmath>
 
 #include "omp_compat.h"
@@ -56,9 +57,11 @@ void PairPeriLPSOMP::compute(int eflag, int vflag)
 
   if (atom->nmax > nmax) {
     memory->destroy(s0_new);
+    memory->destroy(smin_new);
     memory->destroy(theta);
     nmax = atom->nmax;
     memory->create(s0_new,nmax,"pair:s0_new");
+    memory->create(smin_new,nmax,"pair:smin_new");
     memory->create(theta,nmax,"pair:theta");
   }
 
@@ -111,6 +114,7 @@ void PairPeriLPSOMP::eval(int iifrom, int iito, ThrData * const thr)
 
   double *vfrac = atom->vfrac;
   double *s0 = atom->s0;
+  double *smin = atom->smin;
   double **x0 = atom->x0;
   double **r0   = fix_peri_neigh->r0;
   tagint **partner = fix_peri_neigh->partner;
@@ -267,6 +271,7 @@ void PairPeriLPSOMP::eval(int iifrom, int iito, ThrData * const thr)
     ztmp0 = x0[i][2];
     itype = type[i];
     jnum = npartner[i];
+    smin_new[i] = DBL_MAX;
     first = true;
 
     for (jj = 0; jj < jnum; jj++) {
@@ -337,13 +342,20 @@ void PairPeriLPSOMP::eval(int iifrom, int iito, ThrData * const thr)
                                0.5*fbond*vfrac[i],delx,dely,delz,thr);
 
       // find stretch in bond I-J and break if necessary
-      // use s0 from previous timestep
+      // use the minimum stretch (smin) from the previous timestep to form the
+      // per-bond critical stretch s0 = s00 - alpha*smin (Parks 2008, eq. 9).
+      // Evaluating s00/alpha per bond (instead of collapsing s0 into one
+      // per-particle scalar) is required when these coeffs depend on the type
+      // pair; min(s0_i,s0_j) = s00 - alpha*max(smin_i,smin_j).
 
       stretch = dr / r0[i][jj];
-      if (stretch > MIN(s0[i],s0[j])) partner[i][jj] = 0;
+      if (stretch > s00[itype][jtype] - alpha[itype][jtype]*MAX(smin[i],smin[j]))
+        partner[i][jj] = 0;
 
-      // update s0 for next timestep
+      // update minimum stretch smin (for breaking) and s0 (for diagnostic
+      // output) for the next timestep
 
+      smin_new[i] = MIN(smin_new[i],stretch);
       if (first)
          s0_new[i] = s00[itype][jtype] - (alpha[itype][jtype] * stretch);
       else
@@ -355,9 +367,13 @@ void PairPeriLPSOMP::eval(int iifrom, int iito, ThrData * const thr)
 
   sync_threads();
 
-  // store new s0 (in parallel)
+  // store new s0 (diagnostic) and smin (used for bond breaking) in parallel
+  // an atom with no surviving bonds keeps the no-breaking sentinel (-DBL_MAX)
   if (iifrom < nlocal)
-    for (i = iifrom; i < iito; i++) s0[i] = s0_new[i];
+    for (i = iifrom; i < iito; i++) {
+      s0[i] = s0_new[i];
+      smin[i] = (smin_new[i] == DBL_MAX) ? -DBL_MAX : smin_new[i];
+    }
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/OPENMP/pair_peri_pmb_omp.cpp
+++ b/src/OPENMP/pair_peri_pmb_omp.cpp
@@ -54,8 +54,10 @@ void PairPeriPMBOMP::compute(int eflag, int vflag)
 
   if (atom->nmax > nmax) {
     memory->destroy(s0_new);
+    memory->destroy(smin_new);
     nmax = atom->nmax;
     memory->create(s0_new,nmax,"pair:s0_new");
+    memory->create(smin_new,nmax,"pair:smin_new");
   }
 
 #if defined(_OPENMP)
@@ -107,6 +109,7 @@ void PairPeriPMBOMP::eval(int iifrom, int iito, ThrData * const thr)
 
   double *vfrac = atom->vfrac;
   double *s0 = atom->s0;
+  double *smin = atom->smin;
   double **x0 = atom->x0;
   double **r0   = fix_peri_neigh->r0;
   tagint **partner = fix_peri_neigh->partner;
@@ -226,6 +229,7 @@ void PairPeriPMBOMP::eval(int iifrom, int iito, ThrData * const thr)
     itype = type[i];
     jnum = npartner[i];
     s0_new[i] = DBL_MAX;
+    smin_new[i] = DBL_MAX;
     first = true;
 
     for (jj = 0; jj < jnum; jj++) {
@@ -279,12 +283,19 @@ void PairPeriPMBOMP::eval(int iifrom, int iito, ThrData * const thr)
                      0.5*fbond*vfrac[i],delx,dely,delz,thr);
 
       // find stretch in bond I-J and break if necessary
-      // use s0 from previous timestep
+      // use the minimum stretch (smin) from the previous timestep to form the
+      // per-bond critical stretch s0 = s00 - alpha*smin (Parks 2008, eq. 9).
+      // Evaluating s00/alpha per bond (instead of collapsing s0 into one
+      // per-particle scalar) is required when these coeffs depend on the type
+      // pair; min(s0_i,s0_j) = s00 - alpha*max(smin_i,smin_j).
 
-      if (stretch > MIN(s0[i],s0[j])) partner[i][jj] = 0;
+      if (stretch > s00[itype][jtype] - alpha[itype][jtype]*MAX(smin[i],smin[j]))
+        partner[i][jj] = 0;
 
-      // update s0 for next timestep
+      // update minimum stretch smin (for breaking) and s0 (for diagnostic
+      // output) for the next timestep
 
+      smin_new[i] = MIN(smin_new[i],stretch);
       if (first)
         s0_new[i] = s00[itype][jtype] - (alpha[itype][jtype] * stretch);
       else
@@ -296,9 +307,13 @@ void PairPeriPMBOMP::eval(int iifrom, int iito, ThrData * const thr)
 
   sync_threads();
 
-  // store new s0 (in parallel)
+  // store new s0 (diagnostic) and smin (used for bond breaking) in parallel
+  // an atom with no surviving bonds keeps the no-breaking sentinel (-DBL_MAX)
   if (iifrom < nlocal)
-    for (i = iifrom; i < iito; i++) s0[i] = s0_new[i];
+    for (i = iifrom; i < iito; i++) {
+      s0[i] = s0_new[i];
+      smin[i] = (smin_new[i] == DBL_MAX) ? -DBL_MAX : smin_new[i];
+    }
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/PERI/atom_vec_peri.cpp
+++ b/src/PERI/atom_vec_peri.cpp
@@ -54,15 +54,15 @@ AtomVecPeri::AtomVecPeri(LAMMPS *lmp) : AtomVec(lmp)
   // order of fields in a string does not matter
   // except: fields_data_atom & fields_data_vel must match data file
 
-  fields_grow = {"rmass", "vfrac", "s0", "x0"};
-  fields_copy = {"rmass", "vfrac", "s0", "x0"};
-  fields_comm = {"s0"};
-  fields_comm_vel = {"s0"};
-  fields_border = {"rmass", "vfrac", "s0", "x0"};
-  fields_border_vel = {"rmass", "vfrac", "s0", "x0"};
-  fields_exchange = {"rmass", "vfrac", "s0", "x0"};
-  fields_restart = {"rmass", "vfrac", "s0", "x0"};
-  fields_create = {"rmass", "vfrac", "s0", "x0"};
+  fields_grow = {"rmass", "vfrac", "s0", "smin", "x0"};
+  fields_copy = {"rmass", "vfrac", "s0", "smin", "x0"};
+  fields_comm = {"s0", "smin"};
+  fields_comm_vel = {"s0", "smin"};
+  fields_border = {"rmass", "vfrac", "s0", "smin", "x0"};
+  fields_border_vel = {"rmass", "vfrac", "s0", "smin", "x0"};
+  fields_exchange = {"rmass", "vfrac", "s0", "smin", "x0"};
+  fields_restart = {"rmass", "vfrac", "s0", "smin", "x0"};
+  fields_create = {"rmass", "vfrac", "s0", "smin", "x0"};
   fields_data_atom = {"id", "type", "vfrac", "rmass", "x"};
   fields_data_vel = {"id", "v"};
 
@@ -79,6 +79,7 @@ void AtomVecPeri::grow_pointers()
   rmass = atom->rmass;
   vfrac = atom->vfrac;
   s0 = atom->s0;
+  smin = atom->smin;
   x0 = atom->x0;
 }
 
@@ -92,6 +93,9 @@ void AtomVecPeri::create_atom_post(int ilocal)
   vfrac[ilocal] = 1.0;
   rmass[ilocal] = 1.0;
   s0[ilocal] = DBL_MAX;
+  // smin is the minimum (most compressive) bond stretch; initialize so the
+  // implied critical stretch is +infinity and no bonds break on the first step
+  smin[ilocal] = -DBL_MAX;
   x0[ilocal][0] = xinit[ilocal][0];
   x0[ilocal][1] = xinit[ilocal][1];
   x0[ilocal][2] = xinit[ilocal][2];
@@ -106,6 +110,7 @@ void AtomVecPeri::data_atom_post(int ilocal)
 {
   auto *const xinit = atom->x;
   s0[ilocal] = DBL_MAX;
+  smin[ilocal] = -DBL_MAX;
   x0[ilocal][0] = xinit[ilocal][0];
   x0[ilocal][1] = xinit[ilocal][1];
   x0[ilocal][2] = xinit[ilocal][2];

--- a/src/PERI/atom_vec_peri.h
+++ b/src/PERI/atom_vec_peri.h
@@ -35,7 +35,7 @@ class AtomVecPeri : virtual public AtomVec {
   void pack_property_atom(int, double *, int, int) override;
 
  private:
-  double *rmass, *vfrac, *s0;
+  double *rmass, *vfrac, *s0, *smin;
   double **x0;
 };
 

--- a/src/PERI/compute_damage_atom.cpp
+++ b/src/PERI/compute_damage_atom.cpp
@@ -53,7 +53,7 @@ ComputeDamageAtom::~ComputeDamageAtom()
 void ComputeDamageAtom::init()
 {
   if ((comm->me == 0) && (modify->get_compute_by_style("damage/atom").size() > 1))
-    error->warning(FLERR,"More than one compute dilatation/atom");
+    error->warning(FLERR,"More than one compute damage/atom");
 
   // find associated PERI_NEIGH fix that must exist
 

--- a/src/PERI/compute_dilatation_atom.cpp
+++ b/src/PERI/compute_dilatation_atom.cpp
@@ -35,7 +35,7 @@ ComputeDilatationAtom::
 ComputeDilatationAtom(LAMMPS *lmp, int narg, char **arg) :
   Compute(lmp, narg, arg)
 {
-  if (narg != 3) error->all(FLERR,"Illegal compute Dilatation/atom command");
+  if (narg != 3) error->all(FLERR,"Illegal compute dilatation/atom command");
 
   peratom_flag = 1;
   size_peratom_cols = 0;

--- a/src/PERI/fix_peri_neigh.cpp
+++ b/src/PERI/fix_peri_neigh.cpp
@@ -31,6 +31,7 @@
 #include "lattice.h"
 #include "memory.h"
 #include "error.h"
+#include "utils.h"
 
 #include <cmath>
 #include <cstring>
@@ -371,23 +372,14 @@ void FixPeriNeigh::setup(int /*vflag*/)
 
   // bond statistics
 
-  int n = 0;
+  bigint n = 0;
   for (i = 0; i < nlocal; i++) n += npartner[i];
-  int nall;
-  MPI_Allreduce(&n,&nall,1,MPI_INT,MPI_SUM,world);
+  bigint nall;
+  MPI_Allreduce(&n,&nall,1,MPI_LMP_BIGINT,MPI_SUM,world);
 
-  if (comm->me == 0) {
-    if (screen) {
-      fprintf(screen,"Peridynamic bonds:\n");
-      fprintf(screen,"  total # of bonds = %d\n",nall);
-      fprintf(screen,"  bonds/atom = %g\n",(double)nall/atom->natoms);
-    }
-    if (logfile) {
-      fprintf(logfile,"Peridynamic bonds:\n");
-      fprintf(logfile,"  total # of bonds = %d\n",nall);
-      fprintf(logfile,"  bonds/atom = %g\n",(double)nall/atom->natoms);
-    }
-  }
+  if (comm->me == 0)
+    utils::logmesg(lmp, "Peridynamic bonds:\n  total # of bonds = {}\n"
+                        "  bonds/atom = {:.6g}\n", nall, (double)nall/atom->natoms);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/PERI/fix_peri_neigh.h
+++ b/src/PERI/fix_peri_neigh.h
@@ -68,8 +68,6 @@ class FixPeriNeigh : public Fix {
   double **deviatorPlasticextension;    // Deviatoric plastic extension
   double *lambdaValue;
   double **r0;                       // initial distance to partners
-  double **r1;                       // instanteneous distance to partners
-  double *thetaValue;                // dilatation
   double *vinter;                    // sum of vfrac for bonded neighbors
   double *wvolume;                   // weighted volume of particle
   int isPMB, isLPS, isVES, isEPS;    // which flavor of PD

--- a/src/PERI/pair_peri.cpp
+++ b/src/PERI/pair_peri.cpp
@@ -31,7 +31,7 @@ using namespace LAMMPS_NS;
 PairPeri::PairPeri(LAMMPS *_lmp) :
     Pair(_lmp), fix_peri_neigh(nullptr), bulkmodulus(nullptr), shearmodulus(nullptr),
     m_lambdai(nullptr), m_taubi(nullptr), m_yieldstress(nullptr), s00(nullptr), alpha(nullptr),
-    cut(nullptr), kspring(nullptr), s0_new(nullptr), theta(nullptr), elastic_energy(nullptr)
+    cut(nullptr), kspring(nullptr), s0_new(nullptr), smin_new(nullptr), theta(nullptr)
 {
   for (int i = 0; i < 6; i++) virial[i] = 0.0;
   no_virial_fdotr_compute = 1;
@@ -59,8 +59,8 @@ PairPeri::~PairPeri()
     memory->destroy(kspring);
 
     memory->destroy(s0_new);
+    memory->destroy(smin_new);
     memory->destroy(theta);
-    memory->destroy(elastic_energy);
   }
 }
 
@@ -257,6 +257,5 @@ void *PairPeri::extract(const char *name, int &dim)
 {
   dim = 1;
   if (strcmp(name, "theta") == 0) return (void *) theta;
-  if (strcmp(name, "elastic_energy") == 0) return (void *) elastic_energy;
   return nullptr;
 }

--- a/src/PERI/pair_peri.h
+++ b/src/PERI/pair_peri.h
@@ -45,7 +45,7 @@ class PairPeri : public Pair {
   class FixPeriNeigh *fix_peri_neigh;
   double **bulkmodulus, **shearmodulus, **m_lambdai, **m_taubi, **m_yieldstress;
   double **s00, **alpha, **cut, **kspring;
-  double *s0_new, *theta, *elastic_energy;
+  double *s0_new, *smin_new, *theta;
 
   int nmax;
 

--- a/src/PERI/pair_peri_eps.cpp
+++ b/src/PERI/pair_peri_eps.cpp
@@ -175,7 +175,7 @@ void PairPeriEPS::compute(int eflag, int vflag)
   int  maxpartner = 0;
   for (i = 0; i < nlocal; i++) maxpartner = MAX(maxpartner,npartner[i]);
 
-  if (nlocal > nmax) {
+  if (atom->nmax > nmax) {
     memory->destroy(s0_new);
     memory->destroy(smin_new);
     memory->destroy(theta);

--- a/src/PERI/pair_peri_eps.cpp
+++ b/src/PERI/pair_peri_eps.cpp
@@ -32,6 +32,7 @@
 #include "neigh_list.h"
 #include "neighbor.h"
 
+#include <cfloat>
 #include <cmath>
 #include <cstring>
 
@@ -72,6 +73,7 @@ void PairPeriEPS::compute(int eflag, int vflag)
 
   double *vfrac = atom->vfrac;
   double *s0 = atom->s0;
+  double *smin = atom->smin;
   double **x0 = atom->x0;
   double **r0 = fix_peri_neigh->r0;
   double **deviatorPlasticextension = fix_peri_neigh->deviatorPlasticextension;
@@ -175,9 +177,11 @@ void PairPeriEPS::compute(int eflag, int vflag)
 
   if (nlocal > nmax) {
     memory->destroy(s0_new);
+    memory->destroy(smin_new);
     memory->destroy(theta);
     nmax = atom->nmax;
     memory->create(s0_new,nmax,"pair:s0_new");
+    memory->create(smin_new,nmax,"pair:smin_new");
     memory->create(theta,nmax,"pair:theta");
   }
 
@@ -230,6 +234,7 @@ void PairPeriEPS::compute(int eflag, int vflag)
     ztmp0 = x0[i][2];
     itype = type[i];
     jnum = npartner[i];
+    smin_new[i] = DBL_MAX;
     first = true;
 
     const double yieldStress = m_yieldstress[itype][itype];
@@ -329,13 +334,20 @@ void PairPeriEPS::compute(int eflag, int vflag)
                            0.5*fbond*vfrac[i],delx,dely,delz);
 
       // find stretch in bond I-J and break if necessary
-      // use s0 from previous timestep
+      // use the minimum stretch (smin) from the previous timestep to form the
+      // per-bond critical stretch s0 = s00 - alpha*smin (Parks 2008, eq. 9).
+      // Evaluating s00/alpha per bond (instead of collapsing s0 into one
+      // per-particle scalar) is required when these coeffs depend on the type
+      // pair; min(s0_i,s0_j) = s00 - alpha*max(smin_i,smin_j).
 
       stretch = dr / r0[i][jj];
-      if (stretch > MIN(s0[i],s0[j])) partner[i][jj] = 0;
+      if (stretch > s00[itype][jtype] - alpha[itype][jtype]*MAX(smin[i],smin[j]))
+        partner[i][jj] = 0;
 
-      // update s0 for next timestep
+      // update minimum stretch smin (for breaking) and s0 (for diagnostic
+      // output) for the next timestep
 
+      smin_new[i] = MIN(smin_new[i],stretch);
       if (first)
          s0_new[i] = s00[itype][jtype] - (alpha[itype][jtype] * stretch);
       else
@@ -344,9 +356,12 @@ void PairPeriEPS::compute(int eflag, int vflag)
     }
   }
 
-  // store new s0
+  // store new s0 (diagnostic) and smin (used for bond breaking)
+  // an atom with no surviving bonds keeps the no-breaking sentinel (-DBL_MAX)
 
   memcpy(s0,s0_new,sizeof(double)*nlocal);
+  for (i = 0; i < nlocal; i++)
+    smin[i] = (smin_new[i] == DBL_MAX) ? -DBL_MAX : smin_new[i];
 
   if (nlocal*maxpartner > 0) {
     memcpy(&(deviatorPlasticextension[0][0]),&(deviatorPlasticExtTemp[0][0]),

--- a/src/PERI/pair_peri_eps.cpp
+++ b/src/PERI/pair_peri_eps.cpp
@@ -148,7 +148,7 @@ void PairPeriEPS::compute(int eflag, int vflag)
         // of the bond-based theory used in PMB model
 
         double kshort = (15.0 * 18.0 * bulkmodulus[itype][itype]) /
-          (3.141592653589793 * cutsq[itype][jtype] * cutsq[itype][jtype]);
+          (MY_PI * cutsq[itype][jtype] * cutsq[itype][jtype]);
         rk = (kshort * vfrac[j]) * (dr / cut[itype][jtype]);
 
         if (r > 0.0) fpair = -(rk/r);

--- a/src/PERI/pair_peri_lps.cpp
+++ b/src/PERI/pair_peri_lps.cpp
@@ -179,7 +179,7 @@ void PairPeriLPS::compute(int eflag, int vflag)
 
   // communicate dilatation (theta) of each particle
   comm->forward_comm(this);
-  // communicate wighted volume (wvolume) upon every reneighbor
+  // communicate weighted volume (wvolume) upon every reneighbor
   if (neighbor->ago == 0)
     comm->forward_comm(fix_peri_neigh);
 

--- a/src/PERI/pair_peri_lps.cpp
+++ b/src/PERI/pair_peri_lps.cpp
@@ -31,6 +31,7 @@
 #include "neigh_list.h"
 #include "neighbor.h"
 
+#include <cfloat>
 #include <cmath>
 
 using namespace LAMMPS_NS;
@@ -66,6 +67,7 @@ void PairPeriLPS::compute(int eflag, int vflag)
 
   double *vfrac = atom->vfrac;
   double *s0 = atom->s0;
+  double *smin = atom->smin;
   double **x0 = atom->x0;
   double **r0   = fix_peri_neigh->r0;
   tagint **partner = fix_peri_neigh->partner;
@@ -164,9 +166,11 @@ void PairPeriLPS::compute(int eflag, int vflag)
 
   if (atom->nmax > nmax) {
     memory->destroy(s0_new);
+    memory->destroy(smin_new);
     memory->destroy(theta);
     nmax = atom->nmax;
     memory->create(s0_new,nmax,"pair:s0_new");
+    memory->create(smin_new,nmax,"pair:smin_new");
     memory->create(theta,nmax,"pair:theta");
   }
 
@@ -207,6 +211,7 @@ void PairPeriLPS::compute(int eflag, int vflag)
     ztmp0 = x0[i][2];
     itype = type[i];
     jnum = npartner[i];
+    smin_new[i] = DBL_MAX;
     first = true;
 
     for (jj = 0; jj < jnum; jj++) {
@@ -279,13 +284,20 @@ void PairPeriLPS::compute(int eflag, int vflag)
                            0.5*fbond*vfrac[i],delx,dely,delz);
 
       // find stretch in bond I-J and break if necessary
-      // use s0 from previous timestep
+      // use the minimum stretch (smin) from the previous timestep to form the
+      // per-bond critical stretch s0 = s00 - alpha*smin (Parks 2008, eq. 9).
+      // Evaluating s00/alpha per bond (instead of collapsing s0 into one
+      // per-particle scalar) is required when these coeffs depend on the type
+      // pair; min(s0_i,s0_j) = s00 - alpha*max(smin_i,smin_j).
 
       stretch = dr / r0[i][jj];
-      if (stretch > MIN(s0[i],s0[j])) partner[i][jj] = 0;
+      if (stretch > s00[itype][jtype] - alpha[itype][jtype]*MAX(smin[i],smin[j]))
+        partner[i][jj] = 0;
 
-      // update s0 for next timestep
+      // update minimum stretch smin (for breaking) and s0 (for diagnostic
+      // output) for the next timestep
 
+      smin_new[i] = MIN(smin_new[i],stretch);
       if (first)
          s0_new[i] = s00[itype][jtype] - (alpha[itype][jtype] * stretch);
       else
@@ -296,8 +308,12 @@ void PairPeriLPS::compute(int eflag, int vflag)
     }
   }
 
-  // store new s0
-  for (i = 0; i < nlocal; i++) s0[i] = s0_new[i];
+  // store new s0 (diagnostic) and smin (used for bond breaking)
+  // an atom with no surviving bonds keeps the no-breaking sentinel (-DBL_MAX)
+  for (i = 0; i < nlocal; i++) {
+    s0[i] = s0_new[i];
+    smin[i] = (smin_new[i] == DBL_MAX) ? -DBL_MAX : smin_new[i];
+  }
 
 }
 

--- a/src/PERI/pair_peri_pmb.cpp
+++ b/src/PERI/pair_peri_pmb.cpp
@@ -62,6 +62,7 @@ void PairPeriPMB::compute(int eflag, int vflag)
 
   double *vfrac = atom->vfrac;
   double *s0 = atom->s0;
+  double *smin = atom->smin;
   double **x0 = atom->x0;
   double **r0   = fix_peri_neigh->r0;
   tagint **partner = fix_peri_neigh->partner;
@@ -153,8 +154,10 @@ void PairPeriPMB::compute(int eflag, int vflag)
 
   if (atom->nmax > nmax) {
     memory->destroy(s0_new);
+    memory->destroy(smin_new);
     nmax = atom->nmax;
     memory->create(s0_new,nmax,"pair:s0_new");
+    memory->create(smin_new,nmax,"pair:smin_new");
   }
 
   // loop over my particles and their partners
@@ -171,6 +174,7 @@ void PairPeriPMB::compute(int eflag, int vflag)
     itype = type[i];
     jnum = npartner[i];
     s0_new[i] = DBL_MAX;
+    smin_new[i] = DBL_MAX;
     first = true;
 
     for (jj = 0; jj < jnum; jj++) {
@@ -222,12 +226,19 @@ void PairPeriPMB::compute(int eflag, int vflag)
       if (evflag) ev_tally(i,i,nlocal,0,0.5*evdwl,0.0,0.5*fbond*vfrac[i],delx,dely,delz);
 
       // find stretch in bond I-J and break if necessary
-      // use s0 from previous timestep
+      // use the minimum stretch (smin) from the previous timestep to form the
+      // per-bond critical stretch s0 = s00 - alpha*smin (Parks 2008, eq. 9).
+      // Evaluating s00/alpha per bond (instead of collapsing s0 into one
+      // per-particle scalar) is required when these coeffs depend on the type
+      // pair; min(s0_i,s0_j) = s00 - alpha*max(smin_i,smin_j).
 
-      if (stretch > MIN(s0[i],s0[j])) partner[i][jj] = 0;
+      if (stretch > s00[itype][jtype] - alpha[itype][jtype]*MAX(smin[i],smin[j]))
+        partner[i][jj] = 0;
 
-      // update s0 for next timestep
+      // update minimum stretch smin (for breaking) and s0 (for diagnostic
+      // output) for the next timestep
 
+      smin_new[i] = MIN(smin_new[i],stretch);
       if (first)
          s0_new[i] = s00[itype][jtype] - (alpha[itype][jtype] * stretch);
       else
@@ -236,8 +247,14 @@ void PairPeriPMB::compute(int eflag, int vflag)
     }
   }
 
-  // store new s0
-  for (i = 0; i < nlocal; i++) s0[i] = s0_new[i];
+  // store new s0 (diagnostic) and smin (used for bond breaking)
+  // an atom with no surviving bonds keeps the no-breaking sentinel (-DBL_MAX)
+  // so that via the max() in the criterion it cannot trigger breaking of a
+  // neighbor's bond (and so the implied critical stretch stays +infinity)
+  for (i = 0; i < nlocal; i++) {
+    s0[i] = s0_new[i];
+    smin[i] = (smin_new[i] == DBL_MAX) ? -DBL_MAX : smin_new[i];
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/PERI/pair_peri_ves.cpp
+++ b/src/PERI/pair_peri_ves.cpp
@@ -31,6 +31,7 @@
 #include "neighbor.h"
 #include "update.h"
 
+#include <cfloat>
 #include <cmath>
 
 using namespace LAMMPS_NS;
@@ -69,6 +70,7 @@ void PairPeriVES::compute(int eflag, int vflag)
   double timestepsize = update->dt;
   double *vfrac = atom->vfrac;
   double *s0 = atom->s0;
+  double *smin = atom->smin;
   double **x0 = atom->x0;
   double **r0 = fix_peri_neigh->r0;
   double **deviatorextention = fix_peri_neigh->deviatorextention;
@@ -169,9 +171,11 @@ void PairPeriVES::compute(int eflag, int vflag)
 
   if (atom->nmax > nmax) {
     memory->destroy(s0_new);
+    memory->destroy(smin_new);
     memory->destroy(theta);
     nmax = atom->nmax;
     memory->create(s0_new,nmax,"pair:s0_new");
+    memory->create(smin_new,nmax,"pair:smin_new");
     memory->create(theta,nmax,"pair:theta");
   }
 
@@ -215,6 +219,7 @@ void PairPeriVES::compute(int eflag, int vflag)
     ztmp0 = x0[i][2];
     itype = type[i];
     jnum = npartner[i];
+    smin_new[i] = DBL_MAX;
     first = true;
 
     for (jj = 0; jj < jnum; jj++) {
@@ -314,7 +319,11 @@ void PairPeriVES::compute(int eflag, int vflag)
                            0.5*fbond*vfrac[i],delx,dely,delz);
 
       // find stretch in bond I-J and break if necessary
-      // use s0 from previous timestep
+      // use the minimum stretch (smin) from the previous timestep to form the
+      // per-bond critical stretch s0 = s00 - alpha*smin (Parks 2008, eq. 9).
+      // Evaluating s00/alpha per bond (instead of collapsing s0 into one
+      // per-particle scalar) is required when these coeffs depend on the type
+      // pair; min(s0_i,s0_j) = s00 - alpha*max(smin_i,smin_j).
 
       // store current deviatoric extension
 
@@ -322,10 +331,13 @@ void PairPeriVES::compute(int eflag, int vflag)
       deviatorBackextention[i][jj]=edbNp1;
 
       stretch = dr / r0[i][jj];
-      if (stretch > MIN(s0[i],s0[j])) partner[i][jj] = 0;
+      if (stretch > s00[itype][jtype] - alpha[itype][jtype]*MAX(smin[i],smin[j]))
+        partner[i][jj] = 0;
 
-      // update s0 for next timestep
+      // update minimum stretch smin (for breaking) and s0 (for diagnostic
+      // output) for the next timestep
 
+      smin_new[i] = MIN(smin_new[i],stretch);
       if (first)
          s0_new[i] = s00[itype][jtype] - (alpha[itype][jtype] * stretch);
       else
@@ -336,9 +348,13 @@ void PairPeriVES::compute(int eflag, int vflag)
     }
   }
 
-  // store new s0
+  // store new s0 (diagnostic) and smin (used for bond breaking)
+  // an atom with no surviving bonds keeps the no-breaking sentinel (-DBL_MAX)
 
-  for (i = 0; i < nlocal; i++) s0[i] = s0_new[i];
+  for (i = 0; i < nlocal; i++) {
+    s0[i] = s0_new[i];
+    smin[i] = (smin_new[i] == DBL_MAX) ? -DBL_MAX : smin_new[i];
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/PERI/pair_peri_ves.cpp
+++ b/src/PERI/pair_peri_ves.cpp
@@ -26,6 +26,7 @@
 #include "force.h"
 #include "info.h"
 #include "lattice.h"
+#include "math_const.h"
 #include "memory.h"
 #include "neigh_list.h"
 #include "neighbor.h"
@@ -145,7 +146,7 @@ void PairPeriVES::compute(int eflag, int vflag)
         // of the bond-based theory used in PMB model
 
         double kshort = (15.0 * 18.0 * bulkmodulus[itype][itype]) /
-          (3.141592653589793 * cutsq[itype][jtype] * cutsq[itype][jtype]);
+          (MathConst::MY_PI * cutsq[itype][jtype] * cutsq[itype][jtype]);
         rk = (kshort * vfrac[j]) * (dr / cut[itype][jtype]);
 
         if (r > 0.0) fpair = -(rk/r);

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -160,7 +160,7 @@ Atom::Atom(LAMMPS *_lmp) : Pointers(_lmp), atom_style(nullptr), avec(nullptr), a
 
   // PERI package
 
-  vfrac = s0 = nullptr;
+  vfrac = s0 = smin = nullptr;
   x0 = nullptr;
 
   // SPIN package
@@ -495,6 +495,7 @@ void Atom::peratom_create()
 
   add_peratom("vfrac",&vfrac,DOUBLE,0);
   add_peratom("s0",&s0,DOUBLE,0);
+  add_peratom("smin",&smin,DOUBLE,0);
   add_peratom("x0",&x0,DOUBLE,3);
 
   // SPIN package

--- a/src/atom.h
+++ b/src/atom.h
@@ -114,7 +114,7 @@ class Atom : protected Pointers {
 
   // PERI package
 
-  double *vfrac, *s0;
+  double *vfrac, *s0, *smin;
   double **x0;
 
   // SPIN package

--- a/unittest/force-styles/CMakeLists.txt
+++ b/unittest/force-styles/CMakeLists.txt
@@ -62,6 +62,14 @@ if(FFT_SINGLE)
   target_compile_definitions(test_pair_style PRIVATE -DFFT_SINGLE)
 endif()
 
+# self-contained tester for the PERI package pair styles (no YAML reference)
+if(PKG_PERI)
+  add_executable(test_pair_peri test_pair_peri.cpp)
+  target_include_directories(test_pair_peri PRIVATE ${LAMMPS_SOURCE_DIR})
+  target_link_libraries(test_pair_peri PRIVATE lammps GTest::GMock)
+  add_test(NAME PairPeri COMMAND test_pair_peri)
+endif()
+
 # prepare environment for testers
 if(WIN32)
   set(FORCE_TEST_ENVIRONMENT PYTHONPATH=${TEST_INPUT_FOLDER})

--- a/unittest/force-styles/test_pair_peri.cpp
+++ b/unittest/force-styles/test_pair_peri.cpp
@@ -1,0 +1,419 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS Development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+// Unit tests for the PERI package pair styles (peri/pmb, peri/lps, peri/ves,
+// peri/eps) and their accelerator variants.  Unlike the generic force-style
+// tester these tests are self-contained: instead of comparing against a stored
+// YAML reference they check closed-form physical invariants and use the base
+// (non-accelerated) style as the oracle for the accelerator variants.  No YAML
+// is processed.
+
+#include "lammps.h"
+
+#include "atom.h"
+#include "compute.h"
+#include "info.h"
+#include "input.h"
+#include "modify.h"
+#include "utils.h"
+
+#include "fmt/format.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <functional>
+#include <mpi.h>
+#include <string>
+#include <vector>
+
+// whether to print verbose output (i.e. not capturing LAMMPS screen output).
+bool verbose = false;
+
+using LAMMPS_NS::Info;
+using LAMMPS_NS::LAMMPS;
+
+namespace LAMMPS_NS {
+
+// per-atom results of a peri run, gathered by atom tag (these tests run on a
+// single MPI rank, so nlocal == natoms and tags are dense 1..natoms)
+struct PeriData {
+    int natoms = 0;
+    std::vector<double> z;       // reference-frame z coordinate, by tag-1
+    std::vector<int> type;       // atom type, by tag-1
+    std::vector<double> damage;  // fraction of broken bonds, by tag-1
+    std::vector<double> s0;      // per-atom critical stretch, by tag-1
+    std::vector<double> smin;    // per-atom minimum stretch, by tag-1
+    std::vector<double> fx, fy, fz;  // per-atom force, by tag-1
+    double max_damage = 0.0;
+};
+
+class PeriTest : public ::testing::Test {
+protected:
+    LAMMPS *lmp = nullptr;
+
+    void TearDown() override { destroy(); }
+
+    void destroy()
+    {
+        if (lmp) {
+            if (!verbose) ::testing::internal::CaptureStdout();
+            delete lmp;
+            if (!verbose) ::testing::internal::GetCapturedStdout();
+            lmp = nullptr;
+        }
+    }
+
+    // create a fresh LAMMPS instance with optional extra command-line args
+    // (used to request an accelerator suffix, e.g. {"-sf","omp","-pk","omp","1"})
+    void create(const std::vector<std::string> &extra = {})
+    {
+        destroy();
+        LAMMPS::argv args = {"PeriTest", "-log", "none", "-screen", "none", "-nocite"};
+        for (const auto &e : extra) args.push_back(e);
+        if (!verbose) ::testing::internal::CaptureStdout();
+        lmp = new LAMMPS(args, MPI_COMM_WORLD);
+        if (!verbose) ::testing::internal::GetCapturedStdout();
+    }
+
+    void command(const std::string &line) { lmp->input->one(line); }
+
+    bool has_pair(const std::string &name)
+    {
+        Info info(lmp);
+        return info.has_style("pair", name);
+    }
+
+    // Build a two-type peri bar (type 1 for z<4.5, type 2 above), build the
+    // bond network, optionally apply a uniform z-stretch about the interface,
+    // and run one step so the bond-breaking criterion is exercised.
+    //
+    // pair_setup must issue the pair_style and pair_coeff commands; it receives
+    // the horizon to use.  stretch is the engineering strain applied in z.
+    void build_bar(const std::function<void(double)> &pair_setup, double stretch)
+    {
+        const double horizon = 3.01;
+        command("units lj");
+        command("boundary s s s");
+        command("atom_style peri");
+        command("atom_modify map array");
+        command("lattice sc 1.0");
+        command("region box block 0 3 0 3 0 10 units box");
+        command("create_box 2 box");
+        command("create_atoms 1 box");
+        command("region upper block INF INF INF INF 4.5 INF units box");
+        command("set region upper type 2");
+
+        pair_setup(horizon);
+
+        command("set group all density 1.0");
+        command("set group all volume 1.0");
+        command("compute dmg all damage/atom");
+        command("fix 1 all nve");
+        command("timestep 1.0e-4");
+
+        // build the bond network at the reference configuration
+        command("run 0 post no");
+
+        if (stretch != 0.0) {
+            // displacement(z) = stretch*(z-4.5): a uniform z-strain about the
+            // type interface so that bonds crossing it are stretched
+            double dlo = stretch * (0.0 - 4.5);
+            double dhi = stretch * (10.0 - 4.5);
+            command(fmt::format("displace_atoms all ramp z {} {} z 0.0 10.0 units box",
+                                dlo, dhi));
+        }
+        command("run 1 post no");
+    }
+
+    PeriData extract()
+    {
+        PeriData d;
+        auto *atom = lmp->atom;
+        d.natoms   = (int) atom->natoms;
+        d.z.assign(d.natoms, 0.0);
+        d.type.assign(d.natoms, 0);
+        d.damage.assign(d.natoms, 0.0);
+        d.s0.assign(d.natoms, 0.0);
+        d.smin.assign(d.natoms, 0.0);
+        d.fx.assign(d.natoms, 0.0);
+        d.fy.assign(d.natoms, 0.0);
+        d.fz.assign(d.natoms, 0.0);
+
+        auto *cdmg = lmp->modify->get_compute_by_id("dmg");
+        cdmg->compute_peratom();
+        double *dmg = cdmg->vector_atom;
+
+        double **x0    = atom->x0;
+        double **f     = atom->f;
+        int *type      = atom->type;
+        double *s0     = atom->s0;
+        double *smin   = atom->smin;
+        tagint *tag    = atom->tag;
+        int nlocal     = atom->nlocal;
+        for (int i = 0; i < nlocal; ++i) {
+            int t = (int) tag[i] - 1;
+            if (t < 0 || t >= d.natoms) continue;
+            d.z[t]      = x0[i][2];
+            d.type[t]   = type[i];
+            d.damage[t] = dmg[i];
+            d.s0[t]     = s0[i];
+            d.smin[t]   = smin[i];
+            d.fx[t]     = f[i][0];
+            d.fy[t]     = f[i][1];
+            d.fz[t]     = f[i][2];
+            d.max_damage = std::max(d.max_damage, dmg[i]);
+        }
+        return d;
+    }
+
+    // pair_coeff helpers for each model: weak s00 (s00_12) on the 1-2 interface
+    std::function<void(double)> pmb(double s00_bulk, double s00_12, double alpha)
+    {
+        return [=](double h) {
+            command("pair_style peri/pmb");
+            command(fmt::format("pair_coeff * * 1.0 {} {} {}", h, s00_bulk, alpha));
+            command(fmt::format("pair_coeff 1 2 1.0 {} {} {}", h, s00_12, alpha));
+        };
+    }
+    std::function<void(double)> lps(double s00_bulk, double s00_12, double alpha)
+    {
+        return [=](double h) {
+            command("pair_style peri/lps");
+            command(fmt::format("pair_coeff * * 1.0 1.0 {} {} {}", h, s00_bulk, alpha));
+            command(fmt::format("pair_coeff 1 2 1.0 1.0 {} {} {}", h, s00_12, alpha));
+        };
+    }
+};
+
+// ------------------------------------------------------------------------
+// Issue #984: with a weaker critical stretch (s00) on the 1-2 interface, the
+// interface bonds must preferentially break.  The pre-fix code collapsed the
+// critical stretch into a per-particle scalar (max over bonds) so the weak
+// interface s00 was ignored and nothing broke -> this test fails on that code.
+// ------------------------------------------------------------------------
+TEST_F(PeriTest, pmb_interface_fracture_984)
+{
+    const double s00_bulk = 0.1, s00_weak = 0.001, alpha = 0.0, strain = 0.01;
+
+    // weak interface: only the 1-2 bonds should break
+    create();
+    build_bar(pmb(s00_bulk, s00_weak, alpha), strain);
+    PeriData weak = extract();
+
+    // average damage close to the interface vs far away in the bulk
+    double near_sum = 0.0, far_sum = 0.0;
+    int near_n = 0, far_n = 0;
+    for (int t = 0; t < weak.natoms; ++t) {
+        double dz = std::fabs(weak.z[t] - 4.5);
+        if (dz < 1.5) {
+            near_sum += weak.damage[t];
+            ++near_n;
+        } else if (dz > 3.5) {
+            far_sum += weak.damage[t];
+            ++far_n;
+        }
+    }
+    ASSERT_GT(near_n, 0);
+    ASSERT_GT(far_n, 0);
+
+    // the weak interface fractures (this is the regression assertion) ...
+    EXPECT_GT(weak.max_damage, 0.0);
+    EXPECT_GT(near_sum / near_n, 0.0);
+    // ... while the bulk far from the interface does not
+    EXPECT_DOUBLE_EQ(far_sum / far_n, 0.0);
+
+    // control: a uniform s00 (no weak interface) does not break at this strain
+    create();
+    build_bar(pmb(s00_bulk, s00_bulk, alpha), strain);
+    PeriData uniform = extract();
+    EXPECT_DOUBLE_EQ(uniform.max_damage, 0.0);
+}
+
+TEST_F(PeriTest, lps_interface_fracture_984)
+{
+    const double s00_bulk = 0.1, s00_weak = 0.001, alpha = 0.0, strain = 0.01;
+    create();
+    build_bar(lps(s00_bulk, s00_weak, alpha), strain);
+    PeriData weak = extract();
+
+    double near_sum = 0.0;
+    int near_n = 0;
+    for (int t = 0; t < weak.natoms; ++t)
+        if (std::fabs(weak.z[t] - 4.5) < 1.5) {
+            near_sum += weak.damage[t];
+            ++near_n;
+        }
+    ASSERT_GT(near_n, 0);
+    EXPECT_GT(weak.max_damage, 0.0);
+    EXPECT_GT(near_sum / near_n, 0.0);
+}
+
+// ------------------------------------------------------------------------
+// Below the critical stretch nothing breaks (validates the smin first-step
+// initialization: no spurious bond breaking on the first step).
+// ------------------------------------------------------------------------
+TEST_F(PeriTest, no_break_below_threshold)
+{
+    create();
+    build_bar(pmb(0.1, 0.1, 0.25), 0.01);  // strain 0.01 < s00 0.1
+    PeriData d = extract();
+    EXPECT_DOUBLE_EQ(d.max_damage, 0.0);
+}
+
+// ------------------------------------------------------------------------
+// The per-atom diagnostic s0 must equal s00 - alpha*smin for a single-material
+// system (validates the Option-B display value and the new smin field).
+// ------------------------------------------------------------------------
+TEST_F(PeriTest, s0_equals_critical_stretch)
+{
+    const double s00 = 0.1, alpha = 0.25;
+    create();
+    build_bar(pmb(s00, s00, alpha), 0.005);
+    PeriData d = extract();
+
+    int checked = 0;
+    for (int t = 0; t < d.natoms; ++t) {
+        // skip atoms whose smin is still the (no-bond) sentinel
+        if (d.smin[t] > 0.5e308 || d.smin[t] < -0.5e308) continue;
+        EXPECT_NEAR(d.s0[t], s00 - alpha * d.smin[t], 1.0e-12);
+        ++checked;
+    }
+    EXPECT_GT(checked, 0);
+}
+
+// ------------------------------------------------------------------------
+// Total linear momentum is conserved under fix nve with no external forces.
+// ------------------------------------------------------------------------
+TEST_F(PeriTest, momentum_conservation)
+{
+    create();
+    command("units lj");
+    command("boundary s s s");
+    command("atom_style peri");
+    command("atom_modify map array");
+    command("lattice sc 1.0");
+    command("region box block 0 4 0 4 0 4 units box");
+    command("create_box 1 box");
+    command("create_atoms 1 box");
+    command("pair_style peri/pmb");
+    command("pair_coeff * * 1.0 3.01 0.1 0.25");
+    command("set group all density 1.0");
+    command("set group all volume 1.0");
+    command("velocity all create 0.05 12345 loop geom");
+    command("fix 1 all nve");
+    command("timestep 1.0e-3");
+    command("run 0 post no");
+
+    auto px = [&]() {
+        double **v   = lmp->atom->v;
+        double *rmass = lmp->atom->rmass;
+        int nlocal   = lmp->atom->nlocal;
+        double p[3]  = {0.0, 0.0, 0.0};
+        for (int i = 0; i < nlocal; ++i) {
+            p[0] += rmass[i] * v[i][0];
+            p[1] += rmass[i] * v[i][1];
+            p[2] += rmass[i] * v[i][2];
+        }
+        return std::array<double, 3>{p[0], p[1], p[2]};
+    };
+    auto p0 = px();
+    command("run 50 post no");
+    auto p1 = px();
+    for (int k = 0; k < 3; ++k) EXPECT_NEAR(p0[k], p1[k], 1.0e-10);
+}
+
+// ------------------------------------------------------------------------
+// Accelerator consistency: the /omp variant must reproduce the base style's
+// per-atom forces and damage.  Skipped when the OPENMP package is not built.
+// ------------------------------------------------------------------------
+TEST_F(PeriTest, omp_consistency)
+{
+    {
+        create();
+        bool have = has_pair("peri/pmb/omp");
+        destroy();
+        if (!have) GTEST_SKIP() << "peri/pmb/omp not available";
+    }
+
+    const double s00_bulk = 0.1, s00_weak = 0.001, alpha = 0.0, strain = 0.01;
+
+    create();
+    build_bar(pmb(s00_bulk, s00_weak, alpha), strain);
+    PeriData base = extract();
+
+    create({"-sf", "omp", "-pk", "omp", "1"});
+    build_bar(pmb(s00_bulk, s00_weak, alpha), strain);
+    PeriData omp = extract();
+
+    ASSERT_EQ(base.natoms, omp.natoms);
+    for (int t = 0; t < base.natoms; ++t) {
+        EXPECT_NEAR(base.fx[t], omp.fx[t], 1.0e-10);
+        EXPECT_NEAR(base.fy[t], omp.fy[t], 1.0e-10);
+        EXPECT_NEAR(base.fz[t], omp.fz[t], 1.0e-10);
+        EXPECT_DOUBLE_EQ(base.damage[t], omp.damage[t]);
+    }
+}
+
+// ------------------------------------------------------------------------
+// Accelerator consistency for KOKKOS.  No peri/*/kk styles exist yet, so this
+// is skipped; it is in place so that a future KOKKOS port is validated against
+// the base style automatically.
+// ------------------------------------------------------------------------
+TEST_F(PeriTest, kokkos_consistency)
+{
+    create();
+    bool have = has_pair("peri/pmb/kk");
+    destroy();
+    if (!have) GTEST_SKIP() << "peri/pmb/kk not available (no KOKKOS port yet)";
+
+    const double s00_bulk = 0.1, s00_weak = 0.001, alpha = 0.0, strain = 0.01;
+
+    create();
+    build_bar(pmb(s00_bulk, s00_weak, alpha), strain);
+    PeriData base = extract();
+
+    create({"-k", "on", "-sf", "kk"});
+    build_bar(pmb(s00_bulk, s00_weak, alpha), strain);
+    PeriData kk = extract();
+
+    ASSERT_EQ(base.natoms, kk.natoms);
+    for (int t = 0; t < base.natoms; ++t) {
+        EXPECT_NEAR(base.fx[t], kk.fx[t], 1.0e-10);
+        EXPECT_NEAR(base.fy[t], kk.fy[t], 1.0e-10);
+        EXPECT_NEAR(base.fz[t], kk.fz[t], 1.0e-10);
+        EXPECT_DOUBLE_EQ(base.damage[t], kk.damage[t]);
+    }
+}
+
+} // namespace LAMMPS_NS
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+    ::testing::InitGoogleMock(&argc, argv);
+
+    if (const char *var = getenv("TEST_ARGS")) {
+        std::vector<std::string> env = LAMMPS_NS::utils::split_words(var);
+        for (const auto &arg : env)
+            if (arg == "-v") verbose = true;
+    }
+    if ((argc > 1) && (strcmp(argv[1], "-v") == 0)) verbose = true;
+
+    int rv = RUN_ALL_TESTS();
+    MPI_Finalize();
+    return rv;
+}

--- a/unittest/force-styles/test_pair_peri.cpp
+++ b/unittest/force-styles/test_pair_peri.cpp
@@ -52,12 +52,12 @@ namespace LAMMPS_NS {
 // single MPI rank, so nlocal == natoms and tags are dense 1..natoms)
 struct PeriData {
     int natoms = 0;
-    std::vector<double> z;       // reference-frame z coordinate, by tag-1
-    std::vector<int> type;       // atom type, by tag-1
-    std::vector<double> damage;  // fraction of broken bonds, by tag-1
-    std::vector<double> s0;      // per-atom critical stretch, by tag-1
-    std::vector<double> smin;    // per-atom minimum stretch, by tag-1
-    std::vector<double> fx, fy, fz;  // per-atom force, by tag-1
+    std::vector<double> z;          // reference-frame z coordinate, by tag-1
+    std::vector<int> type;          // atom type, by tag-1
+    std::vector<double> damage;     // fraction of broken bonds, by tag-1
+    std::vector<double> s0;         // per-atom critical stretch, by tag-1
+    std::vector<double> smin;       // per-atom minimum stretch, by tag-1
+    std::vector<double> fx, fy, fz; // per-atom force, by tag-1
     double max_damage = 0.0;
 };
 
@@ -82,9 +82,14 @@ protected:
     void create(const std::vector<std::string> &extra = {})
     {
         destroy();
-        LAMMPS::argv args = {"PeriTest", "-log", "none", "-screen", "none", "-nocite"};
-        for (const auto &e : extra) args.push_back(e);
-        if (!verbose) ::testing::internal::CaptureStdout();
+        LAMMPS::argv args = {"PeriTest", "-log", "none", "-nocite"};
+        for (const auto &e : extra)
+            args.push_back(e);
+        if (!verbose) {
+            args.push_back("-screen");
+            args.push_back("none");
+            ::testing::internal::CaptureStdout();
+        }
         lmp = new LAMMPS(args, MPI_COMM_WORLD);
         if (!verbose) ::testing::internal::GetCapturedStdout();
     }
@@ -133,8 +138,7 @@ protected:
             // type interface so that bonds crossing it are stretched
             double dlo = stretch * (0.0 - 4.5);
             double dhi = stretch * (10.0 - 4.5);
-            command(fmt::format("displace_atoms all ramp z {} {} z 0.0 10.0 units box",
-                                dlo, dhi));
+            command(fmt::format("displace_atoms all ramp z {} {} z 0.0 10.0 units box", dlo, dhi));
         }
         command("run 1 post no");
     }
@@ -143,7 +147,7 @@ protected:
     {
         PeriData d;
         auto *atom = lmp->atom;
-        d.natoms   = (int) atom->natoms;
+        d.natoms   = (int)atom->natoms;
         d.z.assign(d.natoms, 0.0);
         d.type.assign(d.natoms, 0);
         d.damage.assign(d.natoms, 0.0);
@@ -157,24 +161,24 @@ protected:
         cdmg->compute_peratom();
         double *dmg = cdmg->vector_atom;
 
-        double **x0    = atom->x0;
-        double **f     = atom->f;
-        int *type      = atom->type;
-        double *s0     = atom->s0;
-        double *smin   = atom->smin;
-        tagint *tag    = atom->tag;
-        int nlocal     = atom->nlocal;
+        double **x0  = atom->x0;
+        double **f   = atom->f;
+        int *type    = atom->type;
+        double *s0   = atom->s0;
+        double *smin = atom->smin;
+        tagint *tag  = atom->tag;
+        int nlocal   = atom->nlocal;
         for (int i = 0; i < nlocal; ++i) {
-            int t = (int) tag[i] - 1;
+            int t = (int)tag[i] - 1;
             if (t < 0 || t >= d.natoms) continue;
-            d.z[t]      = x0[i][2];
-            d.type[t]   = type[i];
-            d.damage[t] = dmg[i];
-            d.s0[t]     = s0[i];
-            d.smin[t]   = smin[i];
-            d.fx[t]     = f[i][0];
-            d.fy[t]     = f[i][1];
-            d.fz[t]     = f[i][2];
+            d.z[t]       = x0[i][2];
+            d.type[t]    = type[i];
+            d.damage[t]  = dmg[i];
+            d.s0[t]      = s0[i];
+            d.smin[t]    = smin[i];
+            d.fx[t]      = f[i][0];
+            d.fy[t]      = f[i][1];
+            d.fz[t]      = f[i][2];
             d.max_damage = std::max(d.max_damage, dmg[i]);
         }
         return d;
@@ -251,7 +255,7 @@ TEST_F(PeriTest, lps_interface_fracture_984)
     PeriData weak = extract();
 
     double near_sum = 0.0;
-    int near_n = 0;
+    int near_n      = 0;
     for (int t = 0; t < weak.natoms; ++t)
         if (std::fabs(weak.z[t] - 4.5) < 1.5) {
             near_sum += weak.damage[t];
@@ -269,7 +273,7 @@ TEST_F(PeriTest, lps_interface_fracture_984)
 TEST_F(PeriTest, no_break_below_threshold)
 {
     create();
-    build_bar(pmb(0.1, 0.1, 0.25), 0.01);  // strain 0.01 < s00 0.1
+    build_bar(pmb(0.1, 0.1, 0.25), 0.01); // strain 0.01 < s00 0.1
     PeriData d = extract();
     EXPECT_DOUBLE_EQ(d.max_damage, 0.0);
 }
@@ -319,10 +323,10 @@ TEST_F(PeriTest, momentum_conservation)
     command("run 0 post no");
 
     auto px = [&]() {
-        double **v   = lmp->atom->v;
+        double **v    = lmp->atom->v;
         double *rmass = lmp->atom->rmass;
-        int nlocal   = lmp->atom->nlocal;
-        double p[3]  = {0.0, 0.0, 0.0};
+        int nlocal    = lmp->atom->nlocal;
+        double p[3]   = {0.0, 0.0, 0.0};
         for (int i = 0; i < nlocal; ++i) {
             p[0] += rmass[i] * v[i][0];
             p[1] += rmass[i] * v[i][1];
@@ -333,7 +337,8 @@ TEST_F(PeriTest, momentum_conservation)
     auto p0 = px();
     command("run 50 post no");
     auto p1 = px();
-    for (int k = 0; k < 3; ++k) EXPECT_NEAR(p0[k], p1[k], 1.0e-10);
+    for (int k = 0; k < 3; ++k)
+        EXPECT_NEAR(p0[k], p1[k], 1.0e-10);
 }
 
 // ------------------------------------------------------------------------


### PR DESCRIPTION
**Summary**

Fixes the per-type-pair critical-stretch bond-breaking criterion in the PERI
package (issue #984), plus a package-wide review with dead-code removal,
typo/error-message fixes, modernization, new unit tests, and documentation
updates.

The PMB-style breaking criterion collapsed the per-bond critical stretch
`s0 = s00 - alpha*smin` into a single per-particle scalar (the maximum of
`s00 - alpha*s` over a particle's bonds). That is only valid when `s00` and
`alpha` are identical for all type pairs; with type-dependent coefficients a
bond inherited the critical stretch of the surrounding bulk bonds, so a
deliberately weakened interface (a smaller `s00` on the 1-2 type pair) would
never fracture.

The fix stores the geometric minimum stretch in a new per-atom field
`atom->smin` and evaluates the critical stretch *per bond* at break time as
`s00[ij] - alpha[ij]*max(smin_i, smin_j)`. This equals `min(s0_i, s0_j)` for
uniform coefficients (bit-for-bit backward compatible) and honors the
per-type `s00`/`alpha` otherwise. The per-atom `s0` diagnostic is kept and
filled exactly as before. Applied to `peri/pmb`, `peri/lps`, `peri/ves`,
`peri/eps` and the `peri/pmb/omp` and `peri/lps/omp` accelerator variants.

Commit 2 is an independent PERI-wide cleanup (no functional change to the
existing examples, verified bit-for-bit):
- remove dead members `PairPeri::elastic_energy` (declared, destroyed and
  exposed via `extract()` but never allocated) and `FixPeriNeigh::r1` /
  `FixPeriNeigh::thetaValue` (declared, never used);
- fix a copy/paste warning in `compute damage/atom` (it warned about
  "dilatation/atom"), `"Illegal compute Dilatation/atom"`, and the
  "wighted"/"instanteneous" comment typos;
- modernize the bond-count report to `utils::logmesg` and accumulate the
  count as a `bigint` (the previous `int` total could overflow for large
  models);
- use `MY_PI` instead of a hardcoded `3.141592653589793` in `peri/eps` and
  `peri/ves` (bit-identical, matches `peri/lps`).
- `peri/eps` would allocate `theta` only to `atom->nlocal` but it is used
   in a forward communication to store it with ghost atoms. allocate to atom->nmax

**Related Issue(s)**

Fixes #984

**Author(s)**

Axel Kohlmeyer (Temple University), akohlmey@gmail.com

**Licensing**

By submitting this pull request, I agree, that my contribution will be
included in LAMMPS and redistributed under either the GNU General Public
License version 2 (GPL v2) or the GNU Lesser General Public License version
2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

These changes were developed with the assistance of an AI tool (Claude Code,
model Claude Opus) used interactively under the direction and review of the
author. The AI assisted with the root-cause analysis, the implementation of
the bond-breaking fix across the pair styles and atom-style plumbing, the new
unit test, the documentation edits, and the dead-code/typo cleanup. All
changes were reviewed, tested, and verified by the author before submission
(consistent with the `Co-Authored-By` trailers on the commits).

**Backward Compatibility**

- For uniform `s00`/`alpha` the bond-breaking decisions are bit-for-bit
  identical to before (the `peri/pmb` shatter example reproduces the
  reference log exactly), so existing inputs behave unchanged.
- The per-atom `s0` value reported by `compute property/atom s0` keeps its
  previous meaning and values. The documentation for it is corrected: earlier
  docs incorrectly described `s0` as the maximum bond stretch; it is the
  per-particle critical stretch.
- `atom_style peri` gains a per-atom field (`smin`), so the binary restart
  layout for peri systems changes: restart files written with this version
  are not interchangeable with those from older versions. (No data-file format
  change; `smin` is not written to or read from data files.)

**Implementation Notes**

- `smin` is added as a regular per-atom field (registered in `Atom`, listed in
  `AtomVecPeri`'s grow/copy/comm/border/exchange/restart/create field lists)
  so it migrates with atoms and is ghosted, exactly like `s0`. The pair styles
  keep a transient `smin_new` scratch buffer (mirroring `s0_new`) because the
  break test reads the previous step's `smin` of neighbors while the new
  values are accumulated.
- The "no bonds / first compute" sentinel for `smin` is `-DBL_MAX` (so the
  implied critical stretch is `+infinity`), which preserves the documented
  "no bond breaking on the first timestep" behavior; the `+DBL_MAX` value used
  to initialize the per-step MIN accumulator is mapped back to `-DBL_MAX` for
  bondless atoms.
- Verification: new `unittest/force-styles/test_pair_peri.cpp` (interface
  fracture for pmb/lps that fails on the old code, below-threshold no-break,
  `s0 == s00 - alpha*smin` relation, momentum conservation, base-vs-`/omp`
  consistency, and a `/kk`-ready case that skips until a KOKKOS port exists);
  all four examples reproduce their reference logs for the bond-based case and
  are otherwise unchanged; `make check` (whitespace/permissions) is clean.

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

