### PR TITLE
fix dump vtk parallel summary referencing wrong piece files

### DIFF
--- a/src/VTK/dump_vtk.cpp
+++ b/src/VTK/dump_vtk.cpp
@@ -42,6 +42,7 @@
 #include "variable.h"
 
 #include <cmath>
+#include <cstdio>
 #include <cstring>
 #include <sstream>
 #include <vector>
@@ -60,7 +61,6 @@
 #include <vtkPolyData.h>
 #include <vtkPolyDataWriter.h>
 #include <vtkXMLPolyDataWriter.h>
-#include <vtkXMLPPolyDataWriter.h>
 #include <vtkRectilinearGrid.h>
 #include <vtkRectilinearGridWriter.h>
 #include <vtkXMLRectilinearGridWriter.h>
@@ -68,7 +68,6 @@
 #include <vtkUnstructuredGrid.h>
 #include <vtkUnstructuredGridWriter.h>
 #include <vtkXMLUnstructuredGridWriter.h>
-#include <vtkXMLPUnstructuredGridWriter.h>
 
 using namespace LAMMPS_NS;
 
@@ -1393,20 +1392,9 @@ void DumpVTK::write_vtp(int n, double *mybuf)
     writer->Write();
 
     if (me == 0) {
-      if (multiproc) {
-        vtkSmartPointer<vtkXMLPPolyDataWriter> pwriter = vtkSmartPointer<vtkXMLPPolyDataWriter>::New();
-        pwriter->SetFileName(parallelfilecurrent);
-        pwriter->SetNumberOfPieces((multiproc > 1)?multiproc:nprocs);
-        if (binary) pwriter->SetDataModeToBinary();
-        else        pwriter->SetDataModeToAscii();
-
-#if VTK_MAJOR_VERSION < 6
-        pwriter->SetInput(polyData);
-#else
-        pwriter->SetInputData(polyData);
-#endif
-        pwriter->Write();
-      }
+      // write the parallel summary file ourselves (see write_pvtk()), since the
+      // VTK parallel writer derives wrong piece file names from multi-dot names
+      if (multiproc) write_pvtk(PVTP);
 
       if (domain->triclinic == 0) {
         domainfilecurrent[strlen(domainfilecurrent)-1] = 'r'; // adjust filename extension
@@ -1457,20 +1445,9 @@ void DumpVTK::write_vtu(int n, double *mybuf)
     writer->Write();
 
     if (me == 0) {
-      if (multiproc) {
-        vtkSmartPointer<vtkXMLPUnstructuredGridWriter> pwriter = vtkSmartPointer<vtkXMLPUnstructuredGridWriter>::New();
-        pwriter->SetFileName(parallelfilecurrent);
-        pwriter->SetNumberOfPieces((multiproc > 1)?multiproc:nprocs);
-        if (binary) pwriter->SetDataModeToBinary();
-        else        pwriter->SetDataModeToAscii();
-
-#if VTK_MAJOR_VERSION < 6
-        pwriter->SetInput(unstructuredGrid);
-#else
-        pwriter->SetInputData(unstructuredGrid);
-#endif
-        pwriter->Write();
-      }
+      // write the parallel summary file ourselves (see write_pvtk()), since the
+      // VTK parallel writer derives wrong piece file names from multi-dot names
+      if (multiproc) write_pvtk(PVTU);
 
       if (domain->triclinic == 0) {
         domainfilecurrent[strlen(domainfilecurrent)-1] = 'r'; // adjust filename extension
@@ -1482,6 +1459,93 @@ void DumpVTK::write_vtu(int n, double *mybuf)
   }
 
   reset_vtk_data_containers();
+}
+
+/* ----------------------------------------------------------------------
+   construct the name of the per-processor piece file for piece "id" as it
+   should be referenced from the parallel (.pvtp/.pvtu) summary file.
+   mirrors the "%" -> "_<id>" substitution used to build the actual piece
+   files (see constructor / setFileCurrent) and returns the name relative to
+   the summary file (leading directory removed), since both live in the same
+   directory.  filename is guaranteed to contain '%' when multiproc is set.
+------------------------------------------------------------------------- */
+
+std::string DumpVTK::pvtk_piece_filename(int id)
+{
+  char *ptr = strchr(filename,'%');
+  std::string fname = std::string(filename, ptr-filename) + "_" + std::to_string(id) + (ptr+1);
+  if (multifile) fname = utils::star_subst(fname, update->ntimestep, padflag);
+
+  // strip leading directory so the reference is relative to the summary file
+  auto pos = fname.find_last_of("/\\");
+  if (pos != std::string::npos) fname = fname.substr(pos+1);
+  return fname;
+}
+
+/* ----------------------------------------------------------------------
+   write the parallel summary file (.pvtp for PVTP, .pvtu for PVTU) by hand.
+   we cannot let the VTK vtkXMLP*Writer classes do this: they derive the
+   per-processor piece file names from the summary file name by stripping
+   everything after the *first* '.', which yields wrong <Piece> references
+   (and an extra bogus piece file) whenever the dump file name contains extra
+   '.' characters (e.g. "dump.run.*%.vtp").  LAMMPS already writes the actual
+   piece files itself with the correct names, so we emit a matching summary
+   file directly.  called on rank 0 only, with multiproc set.
+------------------------------------------------------------------------- */
+
+void DumpVTK::write_pvtk(int fileformat)
+{
+  FILE *fp = fopen(parallelfilecurrent,"w");
+  if (!fp)
+    error->one(FLERR,"Cannot open dump vtk parallel file {}: {}",
+               parallelfilecurrent, utils::getsyserror());
+
+  const char *gridtype = (fileformat == PVTP) ? "PPolyData" : "PUnstructuredGrid";
+
+  int one = 1;
+  const char *byte_order = (*((char *) &one)) ? "LittleEndian" : "BigEndian";
+
+  utils::print(fp,"<?xml version=\"1.0\"?>\n");
+  utils::print(fp,"<VTKFile type=\"{}\" version=\"1.0\" byte_order=\"{}\">\n", gridtype, byte_order);
+  utils::print(fp,"  <{} GhostLevel=\"0\">\n", gridtype);
+
+  // point data array declarations, in the same order/grouping as the piece
+  // files (mirrors reset_vtk_data_containers(): skip x,y,z, group vectors)
+
+  utils::print(fp,"    <PPointData>\n");
+  auto it = vtype.begin();
+  ++it; ++it; ++it;    // skip the required x,y,z coordinate fields
+  for (; it != vtype.end(); ++it) {
+    const char *type = "Float64";
+    if (it->second == Dump::INT) type = "Int32";
+    else if (it->second == Dump::STRING) type = "String";
+    if (vector_set.find(it->first) != vector_set.end()) {
+      utils::print(fp,"      <PDataArray type=\"{}\" Name=\"{}\" NumberOfComponents=\"3\"/>\n",
+                   type, name[it->first]);
+      ++it; ++it;
+    } else {
+      utils::print(fp,"      <PDataArray type=\"{}\" Name=\"{}\"/>\n", type, name[it->first]);
+    }
+  }
+  utils::print(fp,"    </PPointData>\n");
+
+  // point coordinates: declare the same precision the piece files use
+  // (vtkPoints defaults to single precision, so do not hardcode Float64)
+
+  const char *ptype = (points->GetDataType() == VTK_DOUBLE) ? "Float64" : "Float32";
+  utils::print(fp,"    <PPoints>\n");
+  utils::print(fp,"      <PDataArray type=\"{}\" NumberOfComponents=\"3\"/>\n", ptype);
+  utils::print(fp,"    </PPoints>\n");
+
+  // one <Piece> entry per per-processor piece file
+
+  int npieces = (multiproc > 1) ? multiproc : nprocs;
+  for (int i = 0; i < npieces; ++i)
+    utils::print(fp,"    <Piece Source=\"{}\"/>\n", pvtk_piece_filename(i));
+
+  utils::print(fp,"  </{}>\n", gridtype);
+  utils::print(fp,"</VTKFile>\n");
+  fclose(fp);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/VTK/dump_vtk.cpp
+++ b/src/VTK/dump_vtk.cpp
@@ -1505,14 +1505,14 @@ void DumpVTK::write_pvtk(int fileformat)
   int one = 1;
   const char *byte_order = (*((char *) &one)) ? "LittleEndian" : "BigEndian";
 
-  utils::print(fp,"<?xml version=\"1.0\"?>\n");
-  utils::print(fp,"<VTKFile type=\"{}\" version=\"1.0\" byte_order=\"{}\">\n", gridtype, byte_order);
-  utils::print(fp,"  <{} GhostLevel=\"0\">\n", gridtype);
+  utils::print(fp, R"(<?xml version="1.0"?>)" "\n");
+  utils::print(fp, R"(<VTKFile type="{}" version="1.0" byte_order="{}">)" "\n", gridtype, byte_order);
+  utils::print(fp, R"(  <{} GhostLevel="0">)" "\n", gridtype);
 
   // point data array declarations, in the same order/grouping as the piece
   // files (mirrors reset_vtk_data_containers(): skip x,y,z, group vectors)
 
-  utils::print(fp,"    <PPointData>\n");
+  utils::print(fp, R"(    <PPointData>)" "\n");
   auto it = vtype.begin();
   ++it; ++it; ++it;    // skip the required x,y,z coordinate fields
   for (; it != vtype.end(); ++it) {
@@ -1520,31 +1520,31 @@ void DumpVTK::write_pvtk(int fileformat)
     if (it->second == Dump::INT) type = "Int32";
     else if (it->second == Dump::STRING) type = "String";
     if (vector_set.find(it->first) != vector_set.end()) {
-      utils::print(fp,"      <PDataArray type=\"{}\" Name=\"{}\" NumberOfComponents=\"3\"/>\n",
+      utils::print(fp, R"(      <PDataArray type="{}" Name="{}" NumberOfComponents="3"/>)" "\n",
                    type, name[it->first]);
       ++it; ++it;
     } else {
-      utils::print(fp,"      <PDataArray type=\"{}\" Name=\"{}\"/>\n", type, name[it->first]);
+      utils::print(fp, R"(      <PDataArray type="{}" Name="{}"/>)" "\n", type, name[it->first]);
     }
   }
-  utils::print(fp,"    </PPointData>\n");
+  utils::print(fp, R"(    </PPointData>)" "\n");
 
   // point coordinates: declare the same precision the piece files use
   // (vtkPoints defaults to single precision, so do not hardcode Float64)
 
   const char *ptype = (points->GetDataType() == VTK_DOUBLE) ? "Float64" : "Float32";
-  utils::print(fp,"    <PPoints>\n");
-  utils::print(fp,"      <PDataArray type=\"{}\" NumberOfComponents=\"3\"/>\n", ptype);
-  utils::print(fp,"    </PPoints>\n");
+  utils::print(fp, R"(    <PPoints>)" "\n");
+  utils::print(fp, R"(      <PDataArray type="{}" Name="Points" NumberOfComponents="3"/>)" "\n", ptype);
+  utils::print(fp, R"(    </PPoints>)" "\n");
 
   // one <Piece> entry per per-processor piece file
 
   int npieces = (multiproc > 1) ? multiproc : nprocs;
   for (int i = 0; i < npieces; ++i)
-    utils::print(fp,"    <Piece Source=\"{}\"/>\n", pvtk_piece_filename(i));
+    utils::print(fp, R"(    <Piece Source="{}"/>)" "\n", pvtk_piece_filename(i));
 
-  utils::print(fp,"  </{}>\n", gridtype);
-  utils::print(fp,"</VTKFile>\n");
+  utils::print(fp, R"(  </{}>)" "\n", gridtype);
+  utils::print(fp, R"(</VTKFile>)" "\n");
   fclose(fp);
 }
 

--- a/src/VTK/dump_vtk.h
+++ b/src/VTK/dump_vtk.h
@@ -96,6 +96,8 @@ class DumpVTK : public DumpCustom {
   void write_vtk(int, double *);
   void write_vtp(int, double *);
   void write_vtu(int, double *);
+  void write_pvtk(int);                  // write parallel .pvtp/.pvtu summary file
+  std::string pvtk_piece_filename(int);  // per-proc piece file name as referenced in summary
 
   void prepare_domain_data(vtkRectilinearGrid *);
   void prepare_domain_data_triclinic(vtkUnstructuredGrid *);


### PR DESCRIPTION
**Summary**

Fix the parallel summary file (`.pvtp`/`.pvtu`) written by `dump vtk` so it references
the correct per-processor piece files. Previously, for any dump file name containing more
than one `.` (e.g. `dump.reference.*%.vtp`), the `<Piece Source=...>` entries pointed at
nonexistent files (e.g. `dump_0.vtp`) and a spurious extra piece file was created, so the
distributed output could not be opened in ParaView without manual post-processing.

**Related Issue(s)**

No GitHub issue. Reported on the MatSci user forum:
https://matsci.org/t/66845 ("small problem with vtk files .pvtp").

**Author(s)**

Axel Kohlmeyer (akohlmey@gmail.com)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS
and redistributed under either the GNU General Public License version 2 (GPL v2) or the
GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

This pull request was prepared with the assistance of an AI tool (Claude Code, model
Claude Opus 4.8). The AI performed the root-cause analysis and generated the new
`DumpVTK::write_pvtk()` and `DumpVTK::pvtk_piece_filename()` methods and the edits to
`write_vtp()`/`write_vtu()` in `src/VTK/dump_vtk.cpp` (and the matching header
declarations), under human review and direction. The XML structure was cross-checked
against the VTK XML file-format specification.

**Backward Compatibility**

No input-script changes. The names of the actual per-processor piece files are unchanged.
The change only corrects the *content* of the generated `.pvtp`/`.pvtu` summary file (which
was previously wrong) and stops creating one stray piece file per snapshot. Anyone who had
worked around the bug by post-editing the `.pvtp` no longer needs to.

**Implementation Notes**

Root cause: `write_vtp()`/`write_vtu()` delegated the summary file to VTK's
`vtkXMLPPolyDataWriter` / `vtkXMLPUnstructuredGridWriter`. Those classes derive the piece
file names from the summary file name by stripping everything after the *first* `.`
(`vtksys` "complete extension" behavior), so `dump.reference.000000.pvtp` yields the piece
prefix `dump` and references `dump_0.vtp`, `dump_1.vtp`, ... — which do not match the
per-rank files LAMMPS itself writes (`dump.reference.000000_0.vtp`, ...). The parallel
writer also emitted its own (wrongly named) piece data file as a side effect.

Fix: LAMMPS already writes all per-rank piece files itself with correct names, so the two
VTK parallel-writer code paths are replaced by a hand-written summary file:
- `DumpVTK::write_pvtk(int)` emits the `PPolyData`/`PUnstructuredGrid` XML directly
  (`VTKFile` header with runtime-detected byte order, `GhostLevel="0"`, `PPointData`
  declarations built from the existing `vtype`/`vector_set`/`name` maps using the same
  iteration as `reset_vtk_data_containers()`, `PPoints`, and one `<Piece>` per rank).
  `PPoints` precision is read from the live `vtkPoints` object so it matches the piece
  files rather than being hardcoded. No `PCellData` is written because all dump-vtk fields
  are point data.
- `DumpVTK::pvtk_piece_filename(int)` builds each `<Piece>` `Source` with the same
  `%`->`_<id>` substitution and `utils::star_subst()` timestep handling used to create the
  actual files, stripped to a path relative to the summary file.

The now-unused `vtkXMLPPolyDataWriter`/`vtkXMLPUnstructuredGridWriter` includes were
removed and `<cstdio>` added.

Verification: the file-name construction was checked with a standalone reproduction and
produces `dump.reference.000000_0.vtp` ... `_3.vtp` for the reported case, handles
sub-directory paths (relative reference) and the `dump*.%.suffix.vtp` pattern. NOTE: this
was not compiled/run against the VTK library locally (VTK is not installed in the
development environment used / `PKG_VTK=OFF`), so a build with `-D PKG_VTK=on` and a
multi-rank visual check in ParaView still needs to be confirmed by CI or a reviewer.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the CMake based build system

**Further Information, Files, and Links**

- Forum report: https://matsci.org/t/66845
- VTK XML file format reference: https://docs.vtk.org/en/latest/vtk_file_formats/vtkxml_file_format.html
