### PR TITLE
Audit and revise memory_usage() across src/ packages

### DIFF
--- a/src/APIP/fix_lambda_apip.cpp
+++ b/src/APIP/fix_lambda_apip.cpp
@@ -782,3 +782,10 @@ void *FixLambdaAPIP::extract(const char *str, int &dim)
   if (strcmp(str, "fix_lambda:lambda_non_group") == 0) { return &lambda_non_group; }
   return nullptr;
 }
+
+/* ---------------------------------------------------------------------- */
+
+double FixLambdaAPIP::memory_usage()
+{
+  return (double) nmax_stats * size_peratom_cols * sizeof(double);    // peratom_stats[nmax_stats][ncols]
+}

--- a/src/APIP/fix_lambda_apip.h
+++ b/src/APIP/fix_lambda_apip.h
@@ -46,6 +46,7 @@ class FixLambdaAPIP : public Fix {
   void write_restart(FILE *) override;
   void restart(char *) override;
   void *extract(const char *, int &) override;
+  double memory_usage() override;
 
  private:
   enum { FORWARD_MAX, FORWARD_TA };

--- a/src/BODY/fix_wall_body_polygon.cpp
+++ b/src/BODY/fix_wall_body_polygon.cpp
@@ -832,3 +832,10 @@ int FixWallBodyPolygon::image(int *&objs, double **&parms)
   parms = imgparms;
   return numwalls;
 }
+
+/* ---------------------------------------------------------------------- */
+
+double FixWallBodyPolygon::memory_usage()
+{
+  return (double) nmax * 4 * sizeof(int);    // dnum + dfirst + ednum + edfirst [nmax]
+}

--- a/src/BODY/fix_wall_body_polygon.h
+++ b/src/BODY/fix_wall_body_polygon.h
@@ -33,6 +33,7 @@ class FixWallBodyPolygon : public Fix {
   void setup(int) override;
   void post_force(int) override;
   void reset_dt() override;
+  double memory_usage() override;
 
   int image(int *&, double **&) override;
 

--- a/src/BODY/fix_wall_body_polyhedron.cpp
+++ b/src/BODY/fix_wall_body_polyhedron.cpp
@@ -991,3 +991,10 @@ int FixWallBodyPolyhedron::image(int *&objs, double **&parms)
   if (domain->dimension == 2) return numwalls;
   return 2*numwalls;
 }
+
+/* ---------------------------------------------------------------------- */
+
+double FixWallBodyPolyhedron::memory_usage()
+{
+  return (double) nmax * 6 * sizeof(int);    // dnum+dfirst+ednum+edfirst+facnum+facfirst [nmax]
+}

--- a/src/BODY/fix_wall_body_polyhedron.h
+++ b/src/BODY/fix_wall_body_polyhedron.h
@@ -33,6 +33,7 @@ class FixWallBodyPolyhedron : public Fix {
   void setup(int) override;
   void post_force(int) override;
   void reset_dt() override;
+  double memory_usage() override;
 
   int image(int *&, double **&) override;
 

--- a/src/BODY/pair_body_nparticle.cpp
+++ b/src/BODY/pair_body_nparticle.cpp
@@ -481,3 +481,12 @@ void PairBodyNparticle::body2space(int i)
     ndiscrete++;
   }
 }
+
+/* ---------------------------------------------------------------------- */
+
+double PairBodyNparticle::memory_usage()
+{
+  double bytes = Pair::memory_usage();
+  bytes += (double) nmax * 2 * sizeof(int);    // dnum + dfirst [nmax]
+  return bytes;
+}

--- a/src/BODY/pair_body_nparticle.h
+++ b/src/BODY/pair_body_nparticle.h
@@ -33,6 +33,7 @@ class PairBodyNparticle : public Pair {
   void coeff(int, char **) override;
   void init_style() override;
   double init_one(int, int) override;
+  double memory_usage() override;
 
  protected:
   double cut_global;

--- a/src/BODY/pair_body_rounded_polygon.cpp
+++ b/src/BODY/pair_body_rounded_polygon.cpp
@@ -1370,3 +1370,12 @@ void PairBodyRoundedPolygon::distance(const double* x2, const double* x1,
     + (x2[1] - x1[1]) * (x2[1] - x1[1])
     + (x2[2] - x1[2]) * (x2[2] - x1[2]));
 }
+
+/* ---------------------------------------------------------------------- */
+
+double PairBodyRoundedPolygon::memory_usage()
+{
+  double bytes = Pair::memory_usage();
+  bytes += (double) nmax * 4 * sizeof(int);    // dnum + dfirst + ednum + edfirst [nmax]
+  return bytes;
+}

--- a/src/BODY/pair_body_rounded_polygon.h
+++ b/src/BODY/pair_body_rounded_polygon.h
@@ -33,6 +33,7 @@ class PairBodyRoundedPolygon : public Pair {
   void coeff(int, char **) override;
   void init_style() override;
   double init_one(int, int) override;
+  double memory_usage() override;
 
   struct Contact {
     int ibody, jbody;     // body (i.e. atom) indices (not tags)

--- a/src/BODY/pair_body_rounded_polyhedron.cpp
+++ b/src/BODY/pair_body_rounded_polyhedron.cpp
@@ -2392,3 +2392,11 @@ void PairBodyRoundedPolyhedron::sanity_check()
 */
 }
 
+/* ---------------------------------------------------------------------- */
+
+double PairBodyRoundedPolyhedron::memory_usage()
+{
+  double bytes = Pair::memory_usage();
+  bytes += (double) nmax * 6 * sizeof(int);    // dnum+dfirst+ednum+edfirst+facnum+facfirst [nmax]
+  return bytes;
+}

--- a/src/BODY/pair_body_rounded_polyhedron.h
+++ b/src/BODY/pair_body_rounded_polyhedron.h
@@ -33,6 +33,7 @@ class PairBodyRoundedPolyhedron : public Pair {
   void coeff(int, char **) override;
   void init_style() override;
   double init_one(int, int) override;
+  double memory_usage() override;
 
   virtual void kernel_force(double R, int itype, int jtype, double &energy, double &fpair);
 

--- a/src/BPM/bond_bpm_spring.cpp
+++ b/src/BPM/bond_bpm_spring.cpp
@@ -655,3 +655,12 @@ void BondBPMSpring::unpack_forward_comm(int n, int first, double *buf)
     }
   }
 }
+
+/* ---------------------------------------------------------------------- */
+
+double BondBPMSpring::memory_usage()
+{
+  double bytes = BondBPM::memory_usage();
+  bytes += (double) nmax * sizeof(double);    // dvol0[nmax]
+  return bytes;
+}

--- a/src/BPM/bond_bpm_spring.h
+++ b/src/BPM/bond_bpm_spring.h
@@ -38,6 +38,7 @@ class BondBPMSpring : public BondBPM {
   void read_restart_settings(FILE *) override;
   double single(int, double, int, int, double &) override;
   int pack_forward_comm(int, int *, double *, int, int *) override;
+  double memory_usage() override;
   void unpack_forward_comm(int, int, double *) override;
   int pack_reverse_comm(int, int, double *) override;
   void unpack_reverse_comm(int, int *, double *) override;

--- a/src/COLLOID/pair_lubricateU.cpp
+++ b/src/COLLOID/pair_lubricateU.cpp
@@ -2052,3 +2052,12 @@ double PairLubricateU::dot_vec_vec(int N, double *x, double *y)
   for (int i = 0; i < N; i++) dotp += x[i]*y[i];
   return dotp;
 }
+
+/* ---------------------------------------------------------------------- */
+
+double PairLubricateU::memory_usage()
+{
+  double bytes = Pair::memory_usage();
+  bytes += (double) nmax * 3 * 3 * sizeof(double);    // fl + Tl + xl [nmax][3]
+  return bytes;
+}

--- a/src/COLLOID/pair_lubricateU.h
+++ b/src/COLLOID/pair_lubricateU.h
@@ -39,6 +39,7 @@ class PairLubricateU : public Pair {
   void read_restart_settings(FILE *) override;
   int pack_forward_comm(int, int *, double *, int, int *) override;
   void unpack_forward_comm(int, int, double *) override;
+  double memory_usage() override;
 
  protected:
   double cut_inner_global, cut_global;

--- a/src/DIELECTRIC/msm_dielectric.cpp
+++ b/src/DIELECTRIC/msm_dielectric.cpp
@@ -346,3 +346,12 @@ void MSMDielectric::fieldforce()
     f[i][2] += qfactor*ekz;
   }
 }
+
+/* ---------------------------------------------------------------------- */
+
+double MSMDielectric::memory_usage()
+{
+  double bytes = MSM::memory_usage();
+  bytes += (double) nmax * 3 * sizeof(double);    // efield[nmax][3]
+  return bytes;
+}

--- a/src/DIELECTRIC/msm_dielectric.h
+++ b/src/DIELECTRIC/msm_dielectric.h
@@ -30,6 +30,7 @@ class MSMDielectric : public MSM {
   ~MSMDielectric() override;
   void init() override;
   void compute(int, int) override;
+  double memory_usage() override;
 
   double **efield;
 

--- a/src/DIELECTRIC/pppm_dielectric.cpp
+++ b/src/DIELECTRIC/pppm_dielectric.cpp
@@ -598,3 +598,12 @@ void PPPMDielectric::slabcorr()
     efield[i][2] += ffact * (dipole_all - qsum*x[i][2]);
   }
 }
+
+/* ---------------------------------------------------------------------- */
+
+double PPPMDielectric::memory_usage()
+{
+  double bytes = PPPM::memory_usage();
+  bytes += (double) nmax * 3 * sizeof(double);    // efield[nmax][3]
+  return bytes;
+}

--- a/src/DIELECTRIC/pppm_dielectric.h
+++ b/src/DIELECTRIC/pppm_dielectric.h
@@ -30,6 +30,7 @@ class PPPMDielectric : public PPPM {
   ~PPPMDielectric() override;
   void compute(int, int) override;
   void qsum_qsq(int warning_flag = 1) override;
+  double memory_usage() override;
 
   double **efield;
 

--- a/src/DPD-REACT/pair_dpd_fdt_energy.cpp
+++ b/src/DPD-REACT/pair_dpd_fdt_energy.cpp
@@ -44,6 +44,7 @@ PairDPDfdtEnergy::PairDPDfdtEnergy(LAMMPS *lmp) : Pair(lmp)
   random = nullptr;
   duCond = nullptr;
   duMech = nullptr;
+  nmax_dpd = 0;
   splitFDT_flag = false;
   a0_is_zero = false;
 
@@ -167,13 +168,12 @@ void PairDPDfdtEnergy::compute(int eflag, int vflag)
     }
   } else {
 
-    // Allocate memory for duCond and duMech
-    if (allocated) {
-      memory->destroy(duCond);
-      memory->destroy(duMech);
+    // Grow duCond/duMech to atom->nmax if needed; zero the active range
+    if (atom->nmax > nmax_dpd) {
+      memory->grow(duCond, atom->nmax, "pair:duCond");
+      memory->grow(duMech, atom->nmax, "pair:duMech");
+      nmax_dpd = atom->nmax;
     }
-    memory->create(duCond,nlocal+nghost,"pair:duCond");
-    memory->create(duMech,nlocal+nghost,"pair:duMech");
     for (int ii = 0; ii < nlocal+nghost; ii++) {
       duCond[ii] = 0.0;
       duMech[ii] = 0.0;
@@ -307,8 +307,6 @@ void PairDPDfdtEnergy::allocate()
 {
   allocated = 1;
   int n = atom->ntypes;
-  int nlocal = atom->nlocal;
-  int nghost = atom->nghost;
 
   memory->create(setflag,n+1,n+1,"pair:setflag");
   for (int i = 1; i <= n; i++)
@@ -322,10 +320,6 @@ void PairDPDfdtEnergy::allocate()
   memory->create(sigma,n+1,n+1,"pair:sigma");
   memory->create(kappa,n+1,n+1,"pair:kappa");
   memory->create(alpha,n+1,n+1,"pair:alpha");
-  if (!splitFDT_flag) {
-    memory->create(duCond,nlocal+nghost+1,"pair:duCond");
-    memory->create(duMech,nlocal+nghost+1,"pair:duMech");
-  }
 }
 
 /* ----------------------------------------------------------------------
@@ -589,6 +583,6 @@ void PairDPDfdtEnergy::unpack_reverse_comm(int n, int *list, double *buf)
 double PairDPDfdtEnergy::memory_usage()
 {
   double bytes = Pair::memory_usage();
-  if (duCond) bytes += (double)(atom->nlocal + atom->nghost) * 2 * sizeof(double);    // duCond + duMech
+  if (duCond) bytes += (double) nmax_dpd * 2 * sizeof(double);    // duCond + duMech
   return bytes;
 }

--- a/src/DPD-REACT/pair_dpd_fdt_energy.cpp
+++ b/src/DPD-REACT/pair_dpd_fdt_energy.cpp
@@ -583,3 +583,12 @@ void PairDPDfdtEnergy::unpack_reverse_comm(int n, int *list, double *buf)
     duMech[j] += buf[m++];
   }
 }
+
+/* ---------------------------------------------------------------------- */
+
+double PairDPDfdtEnergy::memory_usage()
+{
+  double bytes = Pair::memory_usage();
+  if (duCond) bytes += (double)(atom->nlocal + atom->nghost) * 2 * sizeof(double);    // duCond + duMech
+  return bytes;
+}

--- a/src/DPD-REACT/pair_dpd_fdt_energy.h
+++ b/src/DPD-REACT/pair_dpd_fdt_energy.h
@@ -46,6 +46,7 @@ class PairDPDfdtEnergy : public Pair {
   double **a0;
   double **sigma, **kappa, **alpha;
   double *duCond, *duMech;
+  int nmax_dpd;
 
   int seed;
   class RanMars *random;

--- a/src/DPD-REACT/pair_dpd_fdt_energy.h
+++ b/src/DPD-REACT/pair_dpd_fdt_energy.h
@@ -40,6 +40,7 @@ class PairDPDfdtEnergy : public Pair {
   double single(int, int, int, int, double, double, double, double &) override;
   int pack_reverse_comm(int, int, double *) override;
   void unpack_reverse_comm(int, int *, double *) override;
+  double memory_usage() override;
 
   double **cut;
   double **a0;

--- a/src/DPD-REACT/pair_exp6_rx.cpp
+++ b/src/DPD-REACT/pair_exp6_rx.cpp
@@ -78,6 +78,11 @@ PairExp6rx::PairExp6rx(LAMMPS *lmp) : Pair(lmp),
                                       fractionalWeighting(true)
 {
   writedata = 1;
+  nmax_exp6 = 0;
+  exp6_epsilon1 = exp6_alpha1 = exp6_rm1 = exp6_mixWtSite1 = nullptr;
+  exp6_epsilon2 = exp6_alpha2 = exp6_rm2 = exp6_mixWtSite2 = nullptr;
+  exp6_epsilonOld1 = exp6_alphaOld1 = exp6_rmOld1 = exp6_mixWtSite1old = nullptr;
+  exp6_epsilonOld2 = exp6_alphaOld2 = exp6_rmOld2 = exp6_mixWtSite2old = nullptr;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -102,6 +107,23 @@ PairExp6rx::~PairExp6rx()
     memory->destroy(coeffEps);
     memory->destroy(coeffRm);
   }
+
+  memory->destroy(exp6_epsilon1);
+  memory->destroy(exp6_alpha1);
+  memory->destroy(exp6_rm1);
+  memory->destroy(exp6_mixWtSite1);
+  memory->destroy(exp6_epsilon2);
+  memory->destroy(exp6_alpha2);
+  memory->destroy(exp6_rm2);
+  memory->destroy(exp6_mixWtSite2);
+  memory->destroy(exp6_epsilonOld1);
+  memory->destroy(exp6_alphaOld1);
+  memory->destroy(exp6_rmOld1);
+  memory->destroy(exp6_mixWtSite1old);
+  memory->destroy(exp6_epsilonOld2);
+  memory->destroy(exp6_alphaOld2);
+  memory->destroy(exp6_rmOld2);
+  memory->destroy(exp6_mixWtSite2old);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -153,31 +175,48 @@ void PairExp6rx::compute(int eflag, int vflag)
   const double shift = 1.05;
   double rin1, aRep, uin1, win1, uin1rep, rin1exp, rin6, rin6inv;
 
-  // Initialize the Exp6 parameter data for both the local
-  // and ghost atoms. Make the parameter data persistent
-  // and exchange like any other atom property later.
+  // Grow per-atom Exp6 parameter arrays if needed; wrap in local struct for access.
+
+  if (atom->nmax > nmax_exp6) {
+     memory->grow(exp6_epsilon1,     atom->nmax, "pair:exp6_epsilon1");
+     memory->grow(exp6_alpha1,       atom->nmax, "pair:exp6_alpha1");
+     memory->grow(exp6_rm1,          atom->nmax, "pair:exp6_rm1");
+     memory->grow(exp6_mixWtSite1,   atom->nmax, "pair:exp6_mixWtSite1");
+     memory->grow(exp6_epsilon2,     atom->nmax, "pair:exp6_epsilon2");
+     memory->grow(exp6_alpha2,       atom->nmax, "pair:exp6_alpha2");
+     memory->grow(exp6_rm2,          atom->nmax, "pair:exp6_rm2");
+     memory->grow(exp6_mixWtSite2,   atom->nmax, "pair:exp6_mixWtSite2");
+     memory->grow(exp6_epsilonOld1,  atom->nmax, "pair:exp6_epsilonOld1");
+     memory->grow(exp6_alphaOld1,    atom->nmax, "pair:exp6_alphaOld1");
+     memory->grow(exp6_rmOld1,       atom->nmax, "pair:exp6_rmOld1");
+     memory->grow(exp6_mixWtSite1old,atom->nmax, "pair:exp6_mixWtSite1old");
+     memory->grow(exp6_epsilonOld2,  atom->nmax, "pair:exp6_epsilonOld2");
+     memory->grow(exp6_alphaOld2,    atom->nmax, "pair:exp6_alphaOld2");
+     memory->grow(exp6_rmOld2,       atom->nmax, "pair:exp6_rmOld2");
+     memory->grow(exp6_mixWtSite2old,atom->nmax, "pair:exp6_mixWtSite2old");
+     nmax_exp6 = atom->nmax;
+  }
 
   PairExp6ParamDataType PairExp6ParamData;
+  PairExp6ParamData.epsilon1      = exp6_epsilon1;
+  PairExp6ParamData.alpha1        = exp6_alpha1;
+  PairExp6ParamData.rm1           = exp6_rm1;
+  PairExp6ParamData.mixWtSite1    = exp6_mixWtSite1;
+  PairExp6ParamData.epsilon2      = exp6_epsilon2;
+  PairExp6ParamData.alpha2        = exp6_alpha2;
+  PairExp6ParamData.rm2           = exp6_rm2;
+  PairExp6ParamData.mixWtSite2    = exp6_mixWtSite2;
+  PairExp6ParamData.epsilonOld1   = exp6_epsilonOld1;
+  PairExp6ParamData.alphaOld1     = exp6_alphaOld1;
+  PairExp6ParamData.rmOld1        = exp6_rmOld1;
+  PairExp6ParamData.mixWtSite1old = exp6_mixWtSite1old;
+  PairExp6ParamData.epsilonOld2   = exp6_epsilonOld2;
+  PairExp6ParamData.alphaOld2     = exp6_alphaOld2;
+  PairExp6ParamData.rmOld2        = exp6_rmOld2;
+  PairExp6ParamData.mixWtSite2old = exp6_mixWtSite2old;
 
   {
      const int np_total = nlocal + atom->nghost;
-
-     memory->create( PairExp6ParamData.epsilon1     , np_total, "PairExp6ParamData.epsilon1");
-     memory->create( PairExp6ParamData.alpha1       , np_total, "PairExp6ParamData.alpha1");
-     memory->create( PairExp6ParamData.rm1          , np_total, "PairExp6ParamData.rm1");
-     memory->create( PairExp6ParamData.mixWtSite1    , np_total, "PairExp6ParamData.mixWtSite1");
-     memory->create( PairExp6ParamData.epsilon2     , np_total, "PairExp6ParamData.epsilon2");
-     memory->create( PairExp6ParamData.alpha2       , np_total, "PairExp6ParamData.alpha2");
-     memory->create( PairExp6ParamData.rm2          , np_total, "PairExp6ParamData.rm2");
-     memory->create( PairExp6ParamData.mixWtSite2    , np_total, "PairExp6ParamData.mixWtSite2");
-     memory->create( PairExp6ParamData.epsilonOld1  , np_total, "PairExp6ParamData.epsilonOld1");
-     memory->create( PairExp6ParamData.alphaOld1    , np_total, "PairExp6ParamData.alphaOld1");
-     memory->create( PairExp6ParamData.rmOld1       , np_total, "PairExp6ParamData.rmOld1");
-     memory->create( PairExp6ParamData.mixWtSite1old , np_total, "PairExp6ParamData.mixWtSite1old");
-     memory->create( PairExp6ParamData.epsilonOld2  , np_total, "PairExp6ParamData.epsilonOld2");
-     memory->create( PairExp6ParamData.alphaOld2    , np_total, "PairExp6ParamData.alphaOld2");
-     memory->create( PairExp6ParamData.rmOld2       , np_total, "PairExp6ParamData.rmOld2");
-     memory->create( PairExp6ParamData.mixWtSite2old , np_total, "PairExp6ParamData.mixWtSite2old");
 
      for (i = 0; i < np_total; ++i)
      {
@@ -497,27 +536,6 @@ void PairExp6rx::compute(int eflag, int vflag)
     }
   }
   if (vflag_fdotr) virial_fdotr_compute();
-
-  // Release the local parameter data.
-  {
-     if (PairExp6ParamData.epsilon1    ) memory->destroy(PairExp6ParamData.epsilon1);
-     if (PairExp6ParamData.alpha1      ) memory->destroy(PairExp6ParamData.alpha1);
-     if (PairExp6ParamData.rm1         ) memory->destroy(PairExp6ParamData.rm1);
-     if (PairExp6ParamData.mixWtSite1   ) memory->destroy(PairExp6ParamData.mixWtSite1);
-     if (PairExp6ParamData.epsilon2    ) memory->destroy(PairExp6ParamData.epsilon2);
-     if (PairExp6ParamData.alpha2      ) memory->destroy(PairExp6ParamData.alpha2);
-     if (PairExp6ParamData.rm2         ) memory->destroy(PairExp6ParamData.rm2);
-     if (PairExp6ParamData.mixWtSite2   ) memory->destroy(PairExp6ParamData.mixWtSite2);
-     if (PairExp6ParamData.epsilonOld1 ) memory->destroy(PairExp6ParamData.epsilonOld1);
-     if (PairExp6ParamData.alphaOld1   ) memory->destroy(PairExp6ParamData.alphaOld1);
-     if (PairExp6ParamData.rmOld1      ) memory->destroy(PairExp6ParamData.rmOld1);
-     if (PairExp6ParamData.mixWtSite1old) memory->destroy(PairExp6ParamData.mixWtSite1old);
-     if (PairExp6ParamData.epsilonOld2 ) memory->destroy(PairExp6ParamData.epsilonOld2);
-     if (PairExp6ParamData.alphaOld2   ) memory->destroy(PairExp6ParamData.alphaOld2);
-     if (PairExp6ParamData.rmOld2      ) memory->destroy(PairExp6ParamData.rmOld2);
-     if (PairExp6ParamData.mixWtSite2old) memory->destroy(PairExp6ParamData.mixWtSite2old);
-  }
-
 }
 
 /* ----------------------------------------------------------------------
@@ -1266,4 +1284,13 @@ inline double PairExp6rx::expValue(double value) const
   else returnValue = exp(value);
 
   return returnValue;
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairExp6rx::memory_usage()
+{
+  double bytes = Pair::memory_usage();
+  if (exp6_epsilon1) bytes += (double) nmax_exp6 * 16 * sizeof(double);    // 16 per-atom param arrays
+  return bytes;
 }

--- a/src/DPD-REACT/pair_exp6_rx.h
+++ b/src/DPD-REACT/pair_exp6_rx.h
@@ -84,6 +84,14 @@ class PairExp6rx : public Pair {
   double *coeffAlpha, *coeffEps, *coeffRm;
   bool fractionalWeighting;
 
+  int nmax_exp6;
+  double *exp6_epsilon1, *exp6_alpha1, *exp6_rm1, *exp6_mixWtSite1;
+  double *exp6_epsilon2, *exp6_alpha2, *exp6_rm2, *exp6_mixWtSite2;
+  double *exp6_epsilonOld1, *exp6_alphaOld1, *exp6_rmOld1, *exp6_mixWtSite1old;
+  double *exp6_epsilonOld2, *exp6_alphaOld2, *exp6_rmOld2, *exp6_mixWtSite2old;
+
+  double memory_usage() override;
+
   [[nodiscard]] double func_rin(const double &) const;
   [[nodiscard]] double expValue(const double) const;
 };

--- a/src/DPD-REACT/pair_multi_lucy_rx.cpp
+++ b/src/DPD-REACT/pair_multi_lucy_rx.cpp
@@ -69,6 +69,8 @@ PairMultiLucyRX::PairMultiLucyRX(LAMMPS *lmp) : Pair(lmp),
 
   ntables = 0;
   tables = nullptr;
+  nmax = 0;
+  mixWtSite1old = mixWtSite2old = mixWtSite1 = mixWtSite2 = nullptr;
 
   comm_forward = 1;
   comm_reverse = 1;
@@ -90,6 +92,11 @@ PairMultiLucyRX::~PairMultiLucyRX()
     memory->destroy(cutsq);
     memory->destroy(tabindex);
   }
+
+  memory->destroy(mixWtSite1old);
+  memory->destroy(mixWtSite2old);
+  memory->destroy(mixWtSite1);
+  memory->destroy(mixWtSite2);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -126,18 +133,16 @@ void PairMultiLucyRX::compute(int eflag, int vflag)
   int jtable;
   double *rho = atom->rho;
 
-  double *mixWtSite1old = nullptr;
-  double *mixWtSite2old = nullptr;
-  double *mixWtSite1 = nullptr;
-  double *mixWtSite2 = nullptr;
+  if (atom->nmax > nmax) {
+    memory->grow(mixWtSite1old, atom->nmax, "PairMultiLucyRX::mixWtSite1old");
+    memory->grow(mixWtSite2old, atom->nmax, "PairMultiLucyRX::mixWtSite2old");
+    memory->grow(mixWtSite1, atom->nmax, "PairMultiLucyRX::mixWtSite1");
+    memory->grow(mixWtSite2, atom->nmax, "PairMultiLucyRX::mixWtSite2");
+    nmax = atom->nmax;
+  }
 
   {
     const int ntotal = nlocal + nghost;
-    memory->create(mixWtSite1old, ntotal, "PairMultiLucyRX::mixWtSite1old");
-    memory->create(mixWtSite2old, ntotal, "PairMultiLucyRX::mixWtSite2old");
-    memory->create(mixWtSite1, ntotal, "PairMultiLucyRX::mixWtSite1");
-    memory->create(mixWtSite2, ntotal, "PairMultiLucyRX::mixWtSite2");
-
     for (int i = 0; i < ntotal; ++i)
        getMixingWeights(i, mixWtSite1old[i], mixWtSite2old[i], mixWtSite1[i], mixWtSite2[i]);
   }
@@ -282,11 +287,6 @@ void PairMultiLucyRX::compute(int eflag, int vflag)
   }
 
   if (vflag_fdotr) virial_fdotr_compute();
-
-  memory->destroy(mixWtSite1old);
-  memory->destroy(mixWtSite2old);
-  memory->destroy(mixWtSite1);
-  memory->destroy(mixWtSite2);
 }
 
 /* ----------------------------------------------------------------------
@@ -1026,4 +1026,13 @@ void PairMultiLucyRX::unpack_reverse_comm(int n, int *list, double *buf)
     j = list[i];
     rho[j] += buf[m++];
   }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairMultiLucyRX::memory_usage()
+{
+  double bytes = Pair::memory_usage();
+  if (mixWtSite1old) bytes += (double) nmax * 4 * sizeof(double);    // 4 mixWtSite arrays
+  return bytes;
 }

--- a/src/DPD-REACT/pair_multi_lucy_rx.h
+++ b/src/DPD-REACT/pair_multi_lucy_rx.h
@@ -44,11 +44,13 @@ class PairMultiLucyRX : public Pair {
   void unpack_reverse_comm(int, int *, double *) override;
   void computeLocalDensity();
   double rho_0;
+  double memory_usage() override;
 
  protected:
   enum { LOOKUP, LINEAR };
 
   int nmax;
+  double *mixWtSite1old, *mixWtSite2old, *mixWtSite1, *mixWtSite2;
 
   int tabstyle, tablength;
   struct Table {

--- a/src/DPD-REACT/pair_table_rx.cpp
+++ b/src/DPD-REACT/pair_table_rx.cpp
@@ -49,6 +49,8 @@ PairTableRX::PairTableRX(LAMMPS *lmp) : PairTable(lmp)
   fractionalWeighting = true;
   site1 = nullptr;
   site2 = nullptr;
+  nmax_rx = 0;
+  mixWtSite1old = mixWtSite2old = mixWtSite1 = mixWtSite2 = nullptr;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -59,6 +61,11 @@ PairTableRX::~PairTableRX()
 
   delete [] site1;
   delete [] site2;
+
+  memory->destroy(mixWtSite1old);
+  memory->destroy(mixWtSite2old);
+  memory->destroy(mixWtSite1);
+  memory->destroy(mixWtSite2);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -96,18 +103,16 @@ void PairTableRX::compute(int eflag, int vflag)
   double *uCG = atom->uCG;
   double *uCGnew = atom->uCGnew;
 
-  double *mixWtSite1old = nullptr;
-  double *mixWtSite2old = nullptr;
-  double *mixWtSite1 = nullptr;
-  double *mixWtSite2 = nullptr;
+  if (atom->nmax > nmax_rx) {
+    memory->grow(mixWtSite1old, atom->nmax, "PairTableRx::mixWtSite1old");
+    memory->grow(mixWtSite2old, atom->nmax, "PairTableRx::mixWtSite2old");
+    memory->grow(mixWtSite1, atom->nmax, "PairTableRx::mixWtSite1");
+    memory->grow(mixWtSite2, atom->nmax, "PairTableRx::mixWtSite2");
+    nmax_rx = atom->nmax;
+  }
 
   {
     const int ntotal = atom->nlocal + atom->nghost;
-    memory->create(mixWtSite1old, ntotal, "PairTableRx::compute::mixWtSite1old");
-    memory->create(mixWtSite2old, ntotal, "PairTableRx::compute::mixWtSite2old");
-    memory->create(mixWtSite1, ntotal, "PairTableRx::compute::mixWtSite1");
-    memory->create(mixWtSite2, ntotal, "PairTableRx::compute::mixWtSite2");
-
     for (int i = 0; i < ntotal; ++i)
       getMixingWeights(i, mixWtSite1old[i], mixWtSite2old[i], mixWtSite1[i], mixWtSite2[i]);
   }
@@ -238,11 +243,6 @@ void PairTableRX::compute(int eflag, int vflag)
     f[i][2] += fz_i;
   }
   if (vflag_fdotr) virial_fdotr_compute();
-
-  memory->destroy(mixWtSite1old);
-  memory->destroy(mixWtSite2old);
-  memory->destroy(mixWtSite1);
-  memory->destroy(mixWtSite2);
 }
 
 /* ----------------------------------------------------------------------
@@ -576,4 +576,13 @@ void PairTableRX::getMixingWeights(int id, double &mixWtSite1old, double &mixWtS
     mixWtSite2old = nMoleculesOld2;
     mixWtSite2 = nMolecules2;
   }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairTableRX::memory_usage()
+{
+  double bytes = PairTable::memory_usage();
+  if (mixWtSite1old) bytes += (double) nmax_rx * 4 * sizeof(double);    // 4 mixWtSite arrays
+  return bytes;
 }

--- a/src/DPD-REACT/pair_table_rx.h
+++ b/src/DPD-REACT/pair_table_rx.h
@@ -40,6 +40,11 @@ class PairTableRX : public PairTable {
   int isite1, isite2;
   void getMixingWeights(int, double &, double &, double &, double &);
   bool fractionalWeighting;
+
+  int nmax_rx;
+  double *mixWtSite1old, *mixWtSite2old, *mixWtSite1, *mixWtSite2;
+
+  double memory_usage() override;
 };
 
 }    // namespace LAMMPS_NS

--- a/src/DRUDE/fix_drude.cpp
+++ b/src/DRUDE/fix_drude.cpp
@@ -528,3 +528,11 @@ void FixDrude::set_arrays(int i) {
     }
 }
 
+/* ---------------------------------------------------------------------- */
+
+double FixDrude::memory_usage()
+{
+  double bytes = (double) atom->nmax * sizeof(tagint);    // drudeid[nmax]
+  return bytes;
+}
+

--- a/src/DRUDE/fix_drude.h
+++ b/src/DRUDE/fix_drude.h
@@ -42,6 +42,7 @@ class FixDrude : public Fix {
 
   void grow_arrays(int nmax) override;
   void copy_arrays(int i, int j, int delflag) override;
+  double memory_usage() override;
   void set_arrays(int i) override;
   int pack_exchange(int i, double *buf) override;
   int unpack_exchange(int nlocal, double *buf) override;

--- a/src/EFF/fix_langevin_eff.cpp
+++ b/src/EFF/fix_langevin_eff.cpp
@@ -422,3 +422,12 @@ double FixLangevinEff::compute_scalar()
   MPI_Allreduce(&energy_me,&energy_all,1,MPI_DOUBLE,MPI_SUM,world);
   return -energy_all;
 }
+
+/* ---------------------------------------------------------------------- */
+
+double FixLangevinEff::memory_usage()
+{
+  double bytes = FixLangevin::memory_usage();
+  if (erforcelangevin) bytes += (double) atom->nmax * sizeof(double);    // erforcelangevin[nmax]
+  return bytes;
+}

--- a/src/EFF/fix_langevin_eff.h
+++ b/src/EFF/fix_langevin_eff.h
@@ -31,6 +31,7 @@ class FixLangevinEff : public FixLangevin {
   void end_of_step() override;
   double compute_scalar() override;
   void post_force(int) override;
+  double memory_usage() override;
 
  private:
   double *erforcelangevin;

--- a/src/EXTRA-COMPUTE/compute_rattlers_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_rattlers_atom.cpp
@@ -308,3 +308,12 @@ void ComputeRattlersAtom::unpack_forward_comm(int n, int first, double *buf)
     rattler[i] = buf[m++];
   }
 }
+
+/* ---------------------------------------------------------------------- */
+
+double ComputeRattlersAtom::memory_usage()
+{
+  double bytes = (double) nmax * sizeof(int);       // ncontacts[nmax]
+  bytes += (double) nmax * sizeof(double);          // rattler[nmax]
+  return bytes;
+}

--- a/src/EXTRA-COMPUTE/compute_rattlers_atom.h
+++ b/src/EXTRA-COMPUTE/compute_rattlers_atom.h
@@ -36,6 +36,7 @@ class ComputeRattlersAtom : public Compute {
   void unpack_forward_comm(int, int, double *) override;
   int pack_reverse_comm(int, int, double *) override;
   void unpack_reverse_comm(int, int *, double *) override;
+  double memory_usage() override;
 
  private:
   int cutstyle, ncontacts_rattler, max_tries, nmax, invoked_peratom;

--- a/src/EXTRA-COMPUTE/compute_slcsa_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_slcsa_atom.cpp
@@ -404,3 +404,10 @@ int ComputeSLCSAAtom::argmax(double arr[], int size)
 
   return maxIndex;
 }
+
+/* ---------------------------------------------------------------------- */
+
+double ComputeSLCSAAtom::memory_usage()
+{
+  return (double) nmax * ncols * sizeof(double);    // classification[nmax][ncols]
+}

--- a/src/EXTRA-COMPUTE/compute_slcsa_atom.h
+++ b/src/EXTRA-COMPUTE/compute_slcsa_atom.h
@@ -35,7 +35,7 @@ class ComputeSLCSAAtom : public Compute {
   void init() override;
   void init_list(int, class NeighList *) override;
   void compute_peratom() override;
-  //  double memory_usage() override;
+  double memory_usage() override;
   int compute_ncomps(int);
   int argmax(double *, int);
 

--- a/src/EXTRA-FIX/fix_nonaffine_displacement.cpp
+++ b/src/EXTRA-FIX/fix_nonaffine_displacement.cpp
@@ -801,3 +801,16 @@ void FixNonaffineDisplacement::grow_arrays(int nmax_new)
     memory->create(singular, nmax, "fix_nonaffine_displacement:singular");
   }
 }
+
+/* ---------------------------------------------------------------------- */
+
+double FixNonaffineDisplacement::memory_usage()
+{
+  double bytes = (double) nmax * size_peratom_cols * sizeof(double);    // array_atom
+  if (nad_style == D2MIN) {
+    bytes += (double) nmax * 3 * 3 * 3 * sizeof(double);    // X + Y + F[nmax][3][3]
+    bytes += (double) nmax * sizeof(double);                 // D2min[nmax]
+    bytes += (double) nmax * 2 * sizeof(int);                // norm + singular[nmax]
+  }
+  return bytes;
+}

--- a/src/EXTRA-FIX/fix_nonaffine_displacement.h
+++ b/src/EXTRA-FIX/fix_nonaffine_displacement.h
@@ -41,6 +41,7 @@ class FixNonaffineDisplacement : public Fix {
   int pack_reverse_comm(int, int, double *) override;
   void unpack_reverse_comm(int, int *, double *) override;
   void grow_arrays(int) override;
+  double memory_usage() override;
 
  private:
   double dtv;

--- a/src/EXTRA-FIX/fix_temp_csld.cpp
+++ b/src/EXTRA-FIX/fix_temp_csld.cpp
@@ -342,3 +342,10 @@ void *FixTempCSLD::extract(const char *str, int &dim)
   }
   return nullptr;
 }
+
+/* ---------------------------------------------------------------------- */
+
+double FixTempCSLD::memory_usage()
+{
+  return (double) nmax * 3 * sizeof(double);    // vhold[nmax][3]
+}

--- a/src/EXTRA-FIX/fix_temp_csld.h
+++ b/src/EXTRA-FIX/fix_temp_csld.h
@@ -37,6 +37,7 @@ class FixTempCSLD : public Fix {
   void write_restart(FILE *) override;
   void restart(char *buf) override;
   void *extract(const char *, int &) override;
+  double memory_usage() override;
 
  private:
   double t_start, t_stop, t_period, t_target;

--- a/src/EXTRA-FIX/fix_wall_flow.cpp
+++ b/src/EXTRA-FIX/fix_wall_flow.cpp
@@ -321,3 +321,10 @@ int FixWallFlow::unpack_exchange(int i, double *buf)
   current_segment[i] = static_cast<int>(buf[0]);
   return 1;
 }
+
+/* ---------------------------------------------------------------------- */
+
+double FixWallFlow::memory_usage()
+{
+  return (double) atom->nmax * sizeof(int);    // current_segment[nmax]
+}

--- a/src/EXTRA-FIX/fix_wall_flow.h
+++ b/src/EXTRA-FIX/fix_wall_flow.h
@@ -36,6 +36,7 @@ class FixWallFlow : public Fix {
 
   void grow_arrays(int) override;
   void copy_arrays(int, int, int) override;
+  double memory_usage() override;
 
   int pack_exchange(int, double *) override;
   int unpack_exchange(int, double *) override;

--- a/src/EXTRA-PAIR/pair_dispersion_d3.cpp
+++ b/src/EXTRA-PAIR/pair_dispersion_d3.cpp
@@ -1519,3 +1519,16 @@ void PairDispersionD3::unpack_reverse_comm(int n, int *list, double *buf)
     }
   }
 }
+
+/* ---------------------------------------------------------------------- */
+
+double PairDispersionD3::memory_usage()
+{
+  double bytes = Pair::memory_usage();
+  int n = atom->ntypes;
+  // c6ab[n+1][n+1][5][5][3] coefficient table
+  bytes += (double)(n+1)*(n+1)*5*5*3 * sizeof(double);
+  // per-atom coordination number and C6 derivative arrays
+  bytes += (double) nmax * 2 * sizeof(double);    // cn[nmax] + dc6[nmax]
+  return bytes;
+}

--- a/src/EXTRA-PAIR/pair_dispersion_d3.h
+++ b/src/EXTRA-PAIR/pair_dispersion_d3.h
@@ -62,6 +62,7 @@ class PairDispersionD3 : public Pair {
 
   int communicationStage;    // communication stage
 
+  double memory_usage() override;
   void allocate();
   virtual void set_funcpar(std::string &);
 

--- a/src/FEP/compute_fep.cpp
+++ b/src/FEP/compute_fep.cpp
@@ -618,3 +618,18 @@ void ComputeFEP::restore_qfev()
     }
   }
 }
+
+/* ---------------------------------------------------------------------- */
+
+double ComputeFEP::memory_usage()
+{
+  double bytes = (double) nmax * 3 * sizeof(double);    // f_orig[nmax][3]
+  bytes += (double) nmax * sizeof(double);              // peatom_orig[nmax]
+  bytes += (double) nmax * 6 * sizeof(double);          // pvatom_orig[nmax][6]
+  if (q_orig) bytes += (double) nmax * sizeof(double);  // q_orig[nmax] (when chgflag)
+  if (keatom_orig) {
+    bytes += (double) nmax * sizeof(double);            // keatom_orig[nmax]
+    bytes += (double) nmax * 6 * sizeof(double);        // kvatom_orig[nmax][6]
+  }
+  return bytes;
+}

--- a/src/FEP/compute_fep.h
+++ b/src/FEP/compute_fep.h
@@ -34,6 +34,7 @@ class ComputeFEP : public Compute {
   ~ComputeFEP() override;
   void init() override;
   void compute_vector() override;
+  double memory_usage() override;
 
  private:
   int npert;

--- a/src/FEP/compute_fep_ta.cpp
+++ b/src/FEP/compute_fep_ta.cpp
@@ -513,3 +513,17 @@ void ComputeFEPTA::restore_xfev()
     }
   }
 }
+
+/* ---------------------------------------------------------------------- */
+
+double ComputeFEPTA::memory_usage()
+{
+  double bytes = (double) nmax * 3 * 2 * sizeof(double);    // x_orig + f_orig [nmax][3]
+  bytes += (double) nmax * sizeof(double);                  // peatom_orig[nmax]
+  bytes += (double) nmax * 6 * sizeof(double);              // pvatom_orig[nmax][6]
+  if (keatom_orig) {
+    bytes += (double) nmax * sizeof(double);                // keatom_orig[nmax]
+    bytes += (double) nmax * 6 * sizeof(double);            // kvatom_orig[nmax][6]
+  }
+  return bytes;
+}

--- a/src/FEP/compute_fep_ta.h
+++ b/src/FEP/compute_fep_ta.h
@@ -34,6 +34,7 @@ class ComputeFEPTA : public Compute {
   ~ComputeFEPTA() override;
   void init() override;
   void compute_vector() override;
+  double memory_usage() override;
 
  private:
   int tailflag;

--- a/src/INTERLAYER/pair_ilp_graphene_hbn.cpp
+++ b/src/INTERLAYER/pair_ilp_graphene_hbn.cpp
@@ -1058,3 +1058,15 @@ double PairILPGrapheneHBN::single(int /*i*/, int /*j*/, int itype, int jtype, do
   philj = Vilp * Tap;
   return factor_lj * philj;
 }
+
+/* ---------------------------------------------------------------------- */
+
+double PairILPGrapheneHBN::memory_usage()
+{
+  double bytes = Pair::memory_usage();
+  bytes += (double) maxlocal * (sizeof(int) + sizeof(int *));    // ILP_numneigh + ILP_firstneigh
+  bytes += (double) nmax * 3 * sizeof(double);                   // normal[nmax][3]
+  bytes += (double) nmax * 9 * sizeof(double);                   // dnormdri[3][3][nmax]
+  bytes += (double) nmax * 27 * sizeof(double);                  // dnormal[3][3][3][nmax]
+  return bytes;
+}

--- a/src/INTERLAYER/pair_ilp_graphene_hbn.h
+++ b/src/INTERLAYER/pair_ilp_graphene_hbn.h
@@ -36,6 +36,7 @@ class PairILPGrapheneHBN : public Pair {
   void init_style() override;
   void calc_FvdW(int, int);
   double single(int, int, int, int, double, double, double, double &) override;
+  double memory_usage() override;
 
   static constexpr int NPARAMS_PER_LINE = 13;
 

--- a/src/INTERLAYER/pair_ilp_tmd.cpp
+++ b/src/INTERLAYER/pair_ilp_tmd.cpp
@@ -1012,3 +1012,15 @@ void PairILPTMD::calc_normal()
     }    // end of four cases of cont
   }      // end of i loop
 }
+
+/* ---------------------------------------------------------------------- */
+
+double PairILPTMD::memory_usage()
+{
+  double bytes = Pair::memory_usage();
+  bytes += (double) maxlocal * (sizeof(int) + sizeof(int *));    // ILP_numneigh + ILP_firstneigh
+  bytes += (double) nmax * 3 * sizeof(double);                   // normal[nmax][3]
+  bytes += (double) nmax * 9 * sizeof(double);                   // dnormdri[nmax][3][3]
+  bytes += (double) nmax * 54 * sizeof(double);                  // dnormal[nmax][3][Nnei=6][3]
+  return bytes;
+}

--- a/src/INTERLAYER/pair_ilp_tmd.h
+++ b/src/INTERLAYER/pair_ilp_tmd.h
@@ -28,6 +28,7 @@ class PairILPTMD : virtual public PairILPGrapheneHBN {
  public:
   PairILPTMD(class LAMMPS *);
   void settings(int, char **) override;
+  double memory_usage() override;
 
  protected:
   void ILP_neigh() override;

--- a/src/INTERLAYER/pair_kolmogorov_crespi_full.cpp
+++ b/src/INTERLAYER/pair_kolmogorov_crespi_full.cpp
@@ -1036,3 +1036,15 @@ double PairKolmogorovCrespiFull::single(int /*i*/, int /*j*/, int itype, int jty
     philj = Vkc - offset[itype][jtype];
   return factor_lj * philj;
 }
+
+/* ---------------------------------------------------------------------- */
+
+double PairKolmogorovCrespiFull::memory_usage()
+{
+  double bytes = Pair::memory_usage();
+  bytes += (double) maxlocal * (sizeof(int) + sizeof(int *));    // KC_numneigh + KC_firstneigh
+  bytes += (double) nmax * 3 * sizeof(double);                   // normal[nmax][3]
+  bytes += (double) nmax * 9 * sizeof(double);                   // dnormdri[3][3][nmax]
+  bytes += (double) nmax * 27 * sizeof(double);                  // dnormal[3][3][3][nmax]
+  return bytes;
+}

--- a/src/INTERLAYER/pair_kolmogorov_crespi_full.h
+++ b/src/INTERLAYER/pair_kolmogorov_crespi_full.h
@@ -39,6 +39,7 @@ class PairKolmogorovCrespiFull : public Pair {
   void calc_FRep(int, int);
   void calc_FvdW(int, int);
   double single(int, int, int, int, double, double, double, double &) override;
+  double memory_usage() override;
 
   static constexpr int NPARAMS_PER_LINE = 12;
 

--- a/src/KSPACE/msm.cpp
+++ b/src/KSPACE/msm.cpp
@@ -3402,13 +3402,40 @@ double MSM::memory_usage()
 {
   double bytes = 0;
 
-  // NOTE: Stan, fill in other memory allocations here
+  // per-atom grid assignment
+  bytes += (double) nmax * 3 * sizeof(double);    // part2grid[nmax][3]
 
-  // all Grid3d bufs
+  // per-level charge and energy grids
+  for (int n = 0; n < levels; n++) {
+    if (!active_flag[n]) continue;
+    double nbrick = (double)(nxhi_out[n]-nxlo_out[n]+1) *
+                   (nyhi_out[n]-nylo_out[n]+1) *
+                   (nzhi_out[n]-nzlo_out[n]+1);
+    bytes += 2.0 * nbrick * sizeof(double);    // qgrid + egrid
+    if (peratom_allocate_flag)
+      bytes += 6.0 * nbrick * sizeof(double);  // v0..v5 grids
+  }
 
+  // direct-space lookup tables: g + v0..v5 (7 arrays)
+  if (g_direct) bytes += (double) levels * nmax_direct * 7 * sizeof(double);
+
+  // direct-space top-level tables (same structure, top level = levels-1)
+  if (g_direct_top && levels > 0) {
+    int n = levels - 1;
+    int nx_top = betax[n] - alpha[n];
+    int ny_top = betay[n] - alpha[n];
+    int nz_top = betaz[n] - alpha[n];
+    int nx = 2*nx_top + 1;
+    int ny = 2*ny_top + 1;
+    int nz = 2*nz_top + 1;
+    double nmax_top = (double) 8*(nx+1)*(ny+1)*(nz+1);
+    bytes += nmax_top * 7 * sizeof(double);
+  }
+
+  // Grid3d communication buffers
   bytes += (double)(ngcall_buf1 + ngcall_buf2) * npergrid * sizeof(double);
 
-  for (int n=0; n<levels; n++)
+  for (int n = 0; n < levels; n++)
     if (active_flag[n])
       bytes += (double)(ngc_buf1[n] + ngc_buf2[n]) * npergrid * sizeof(double);
 

--- a/src/LATBOLTZ/fix_lb_fluid.cpp
+++ b/src/LATBOLTZ/fix_lb_fluid.cpp
@@ -4537,3 +4537,10 @@ double FixLbFluid::compute_vector(int n)
       return -1;
   }
 }
+
+//==========================================================================
+
+double FixLbFluid::memory_usage()
+{
+  return (double) atom->nmax * (3 + 1) * sizeof(double);    // hydroF[nmax][3] + massp[nmax]
+}

--- a/src/LATBOLTZ/fix_lb_fluid.h
+++ b/src/LATBOLTZ/fix_lb_fluid.h
@@ -47,6 +47,7 @@ class FixLbFluid : public Fix {
   void copy_arrays(int, int, int) override;
   int pack_exchange(int, double *) override;
   int unpack_exchange(int, double *) override;
+  double memory_usage() override;
 
   double compute_scalar() override;
   double compute_vector(int) override;

--- a/src/MANYBODY/pair_adp.cpp
+++ b/src/MANYBODY/pair_adp.cpp
@@ -1019,6 +1019,7 @@ void PairADP::unpack_reverse_comm(int n, int *list, double *buf)
 double PairADP::memory_usage()
 {
   double bytes = Pair::memory_usage();
-  bytes += (double)21 * nmax * sizeof(double);
+  // rho[nmax] + fp[nmax] + mu[nmax][3] + lambda[nmax][6]
+  bytes += (double) 11 * nmax * sizeof(double);
   return bytes;
 }

--- a/src/MANYBODY/pair_eam_he.cpp
+++ b/src/MANYBODY/pair_eam_he.cpp
@@ -235,3 +235,12 @@ void PairEAMHE::compute(int eflag, int vflag)
 
   if (vflag_fdotr) virial_fdotr_compute();
 }
+
+/* ---------------------------------------------------------------------- */
+
+double PairEAMHE::memory_usage()
+{
+  double bytes = PairEAMFS::memory_usage();
+  bytes += (double) nmax * sizeof(int);    // numforce[nmax]
+  return bytes;
+}

--- a/src/MANYBODY/pair_eam_he.h
+++ b/src/MANYBODY/pair_eam_he.h
@@ -29,6 +29,7 @@ class PairEAMHE : public PairEAMFS {
   PairEAMHE(class LAMMPS *);
 
   void compute(int, int) override;
+  double memory_usage() override;
 };
 
 }    // namespace LAMMPS_NS

--- a/src/MANYBODY/pair_meam_spline.cpp
+++ b/src/MANYBODY/pair_meam_spline.cpp
@@ -619,7 +619,20 @@ void PairMEAMSpline::unpack_reverse_comm(int /*n*/, int * /*list*/, double * /*b
 ------------------------------------------------------------------------- */
 double PairMEAMSpline::memory_usage()
 {
-  return nmax * sizeof(double);        // The Uprime_values array.
+  double bytes = (double) nmax * sizeof(double);    // Uprime_values array
+  if (nelements > 0) {
+    int nmultichoose2 = nelements*(nelements+1)/2;
+    for (int i = 0; i < nmultichoose2; i++) {
+      bytes += phis[i].memory_usage();
+      bytes += gs[i].memory_usage();
+    }
+    for (int i = 0; i < nelements; i++) {
+      bytes += Us[i].memory_usage();
+      bytes += rhos[i].memory_usage();
+      bytes += fs[i].memory_usage();
+    }
+  }
+  return bytes;
 }
 
 

--- a/src/MANYBODY/pair_meam_sw_spline.cpp
+++ b/src/MANYBODY/pair_meam_sw_spline.cpp
@@ -503,7 +503,15 @@ void PairMEAMSWSpline::unpack_reverse_comm(int /*n*/, int * /*list*/, double * /
 ------------------------------------------------------------------------- */
 double PairMEAMSWSpline::memory_usage()
 {
-  return nmax * sizeof(double);        // The Uprime_values array.
+  double bytes = (double) nmax * sizeof(double);    // Uprime_values array
+  bytes += phi.memory_usage();
+  bytes += rho.memory_usage();
+  bytes += f.memory_usage();
+  bytes += U.memory_usage();
+  bytes += g.memory_usage();
+  bytes += F.memory_usage();
+  bytes += G.memory_usage();
+  return bytes;
 }
 
 

--- a/src/MBX/fix_mbx.cpp
+++ b/src/MBX/fix_mbx.cpp
@@ -2035,3 +2035,13 @@ void FixMBX::add_monomer_atom_types(char *name, std::vector<std::string> &n)
   } else
     error->one(FLERR, "Unsupported molecule type in MBX");
 }
+
+/* ---------------------------------------------------------------------- */
+
+double FixMBX::memory_usage()
+{
+  double bytes = (double) atom->nmax * 3 * sizeof(int);    // mol_type + mol_anchor + mol_local
+  if (aspc_dip_hist) bytes += (double) atom->nmax * aspc_per_atom_size * sizeof(double);
+  if (mbx_dip) bytes += (double) atom->nmax * 9 * sizeof(double);    // mbx_dip[nmax][9]
+  return bytes;
+}

--- a/src/MBX/fix_mbx.h
+++ b/src/MBX/fix_mbx.h
@@ -172,6 +172,7 @@ class FixMBX : public Fix {
   void unpack_forward_comm(int, int, double *) override;
   int pack_exchange(int, double *) override;
   int unpack_exchange(int, double *) override;
+  double memory_usage() override;
 };
 
 }    // namespace LAMMPS_NS

--- a/src/MC/fix_tfmc.cpp
+++ b/src/MC/fix_tfmc.cpp
@@ -299,3 +299,11 @@ void FixTFMC::initial_integrate(int /*vflag*/)
     }
   }
 }
+
+/* ---------------------------------------------------------------------- */
+
+double FixTFMC::memory_usage()
+{
+  if (rotflag) return (double) nmax * 3 * sizeof(double);    // xd[nmax][3]
+  return 0.0;
+}

--- a/src/MC/fix_tfmc.h
+++ b/src/MC/fix_tfmc.h
@@ -31,6 +31,7 @@ class FixTFMC : public Fix {
   int setmask() override;
   void init() override;
   void initial_integrate(int) override;
+  double memory_usage() override;
 
  private:
   double d_max;

--- a/src/MC/pair_dsmc.cpp
+++ b/src/MC/pair_dsmc.cpp
@@ -518,3 +518,14 @@ int PairDSMC::convert_double_to_equivalent_int(double input_double)
   int output_int = static_cast<int>(input_double + random->uniform());
   return output_int;
 }
+
+/* ---------------------------------------------------------------------- */
+
+double PairDSMC::memory_usage()
+{
+  double bytes = Pair::memory_usage();
+  bytes += (double) max_particles * sizeof(int);                             // next_particle[max_particles]
+  bytes += (double) (atom->ntypes + 1) * max_particle_list * sizeof(int);   // particle_list[ntypes+1][max_particle_list]
+  bytes += (double) (atom->ntypes + 1) * total_ncells * 2 * sizeof(int);    // first + number [ntypes+1][total_ncells]
+  return bytes;
+}

--- a/src/MC/pair_dsmc.h
+++ b/src/MC/pair_dsmc.h
@@ -37,6 +37,7 @@ class PairDSMC : public Pair {
   void read_restart(FILE *) override;
   void write_restart_settings(FILE *) override;
   void read_restart_settings(FILE *) override;
+  double memory_usage() override;
 
  private:
   double cut_global;

--- a/src/MESONT/pair_mesocnt.cpp
+++ b/src/MESONT/pair_mesocnt.cpp
@@ -70,6 +70,8 @@ PairMesoCNT::PairMesoCNT(LAMMPS *lmp) : Pair(lmp)
   ghostneigh = 0;
 
   comm_forward = 3;
+  special_local_topo = nullptr;
+  nmax_mesocnt = 0;
 }
 
 /* ----------------------------------------------------------------------
@@ -114,6 +116,8 @@ PairMesoCNT::~PairMesoCNT()
     memory->destroy(gl_weights_finf);
     memory->destroy(gl_weights_fsemi);
   }
+
+  memory->destroy(special_local_topo);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -1016,8 +1020,11 @@ void PairMesoCNT::bond_neigh_topo()
   // create version of atom->special with local ids and correct images
 
   int atom1, atom2;
-  int **special_local;
-  memory->create(special_local, nlocal + nghost, 2, "pair:special_local");
+  if (atom->nmax > nmax_mesocnt) {
+    memory->grow(special_local_topo, atom->nmax, 2, "pair:special_local_topo");
+    nmax_mesocnt = atom->nmax;
+  }
+  int **special_local = special_local_topo;
 
   for (int i = 0; i < nlocal + nghost; i++) {
     atom1 = atom->map(special[i][0]);
@@ -1161,7 +1168,7 @@ void PairMesoCNT::bond_neigh_topo()
     if (numchainlist[i]) empty_neigh = false;
   }
 
-  memory->destroy(special_local);
+
 
   // count neighbor chain lengths per bond
 
@@ -2583,4 +2590,13 @@ void PairMesoCNT::gl_init_weights(int quad, double *gl_nodes, double *gl_weights
 
     gl_weights[i] = 2.0 / ((1.0 - x * x) * dlegendre * dlegendre);
   }
+}
+
+/* ---------------------------------------------------------------------- */
+
+double PairMesoCNT::memory_usage()
+{
+  double bytes = Pair::memory_usage();
+  if (special_local_topo) bytes += (double) nmax_mesocnt * 2 * sizeof(int);    // special_local_topo[nmax][2]
+  return bytes;
 }

--- a/src/MESONT/pair_mesocnt.h
+++ b/src/MESONT/pair_mesocnt.h
@@ -41,12 +41,15 @@ class PairMesoCNT : public Pair {
 
   int pack_forward_comm(int, int *, double *, int, int *) override;
   void unpack_forward_comm(int, int, double *) override;
+  double memory_usage() override;
 
  protected:
   int nend_types;
   int uinf_points, gamma_points, phi_points, usemi_points;
   int *end_types, *reduced_nlist, *numchainlist, *selfid;
   int **reduced_neighlist, **nchainlist, **endlist, **selfpos;
+  int **special_local_topo;
+  int nmax_mesocnt;
   int ***chainlist;
 
   bool segment_flag, neigh_flag;

--- a/src/MISC/pair_srp.cpp
+++ b/src/MISC/pair_srp.cpp
@@ -732,3 +732,12 @@ void PairSRP::read_restart_settings(FILE *fp)
   }
   MPI_Bcast(&cut_global,1,MPI_DOUBLE,0,world);
 }
+
+/* ---------------------------------------------------------------------- */
+
+double PairSRP::memory_usage()
+{
+  double bytes = Pair::memory_usage();
+  bytes += (double) maxcount * 2 * sizeof(int);    // segment[maxcount][2]
+  return bytes;
+}

--- a/src/MISC/pair_srp.h
+++ b/src/MISC/pair_srp.h
@@ -39,6 +39,7 @@ class PairSRP : public Pair {
   void read_restart(FILE *) override;
   void write_restart_settings(FILE *) override;
   void read_restart_settings(FILE *) override;
+  double memory_usage() override;
 
  protected:
   inline void onetwoexclude(int *&, int &, int *&, int *&, int **&);

--- a/src/ML-PACE/pair_pace.cpp
+++ b/src/ML-PACE/pair_pace.cpp
@@ -428,3 +428,12 @@ void *PairPACE::extract_peratom(const char *str, int &ncol)
 
   return nullptr;
 }
+
+/* ---------------------------------------------------------------------- */
+
+double PairPACE::memory_usage()
+{
+  double bytes = Pair::memory_usage();
+  if (flag_corerep_factor) bytes += (double) nmax_corerep * sizeof(double);    // corerep_factor[nmax_corerep]
+  return bytes;
+}

--- a/src/ML-PACE/pair_pace.h
+++ b/src/ML-PACE/pair_pace.h
@@ -49,6 +49,7 @@ class PairPACE : public Pair {
 
   void *extract(const char *, int &) override;
   void *extract_peratom(const char *, int &) override;
+  double memory_usage() override;
 
  protected:
   struct ACEImpl *aceimpl;

--- a/src/ML-RUNNER/pair_runner.cpp
+++ b/src/ML-RUNNER/pair_runner.cpp
@@ -1308,3 +1308,14 @@ void PairRuNNer::unpack_local_atomic_properties(int rank, int size, int natoms, 
     }
   }
 }
+
+/* ---------------------------------------------------------------------- */
+
+double PairRuNNer::memory_usage()
+{
+  double bytes = Pair::memory_usage();
+  // 7 per-atom double arrays: atomic_charge, hirshfeld_volume, electronegativity,
+  // lagrange_charges, de_dq, screening_de_dq, committee_storage
+  bytes += (double) nmax * 7 * sizeof(double);
+  return bytes;
+}

--- a/src/ML-RUNNER/pair_runner.h
+++ b/src/ML-RUNNER/pair_runner.h
@@ -52,6 +52,8 @@ class PairRuNNer : public Pair {
                                       tagint *tag, int nprop, double *global_properties,
                                       double *local_properties);
 
+  double memory_usage() override;
+
  private:
   double cflength;    // Length conversion factor.
   double cfenergy;    // Energy conversion factor.

--- a/src/OPENMP/fix_qeq_reaxff_omp.cpp
+++ b/src/OPENMP/fix_qeq_reaxff_omp.cpp
@@ -983,3 +983,14 @@ void FixQEqReaxFFOMP::dual_sparse_matvec(sparse_matrix *A, double *x, double *b)
     }
   } // omp parallel
 }
+
+/* ---------------------------------------------------------------------- */
+
+double FixQEqReaxFFOMP::memory_usage()
+{
+  double bytes = FixQEqReaxFF::memory_usage();
+  int size = nmax;
+  if (dual_enabled) size *= 2;
+  bytes += (double) comm->nthreads * size * sizeof(double);    // b_temp[nthreads][nmax]
+  return bytes;
+}

--- a/src/OPENMP/fix_qeq_reaxff_omp.h
+++ b/src/OPENMP/fix_qeq_reaxff_omp.h
@@ -43,6 +43,7 @@ class FixQEqReaxFFOMP : public FixQEqReaxFF {
   double aspc_omega;
   double *aspc_b;
 
+  double memory_usage() override;
   void allocate_storage() override;
   void deallocate_storage() override;
   void init_matvec() override;

--- a/src/PERI/pair_peri_eps.cpp
+++ b/src/PERI/pair_peri_eps.cpp
@@ -554,3 +554,12 @@ double PairPeriEPS::compute_DeviatoricForceStateNorm(int i)
     }
   return sqrt(norm);
 }
+
+/* ---------------------------------------------------------------------- */
+
+double PairPeriEPS::memory_usage()
+{
+  double bytes = PairPeri::memory_usage();
+  // TEMPORARY: deviatorPlasticExtTemp[nlocal][maxpartner] during compute()
+  return bytes;
+}

--- a/src/PERI/pair_peri_eps.cpp
+++ b/src/PERI/pair_peri_eps.cpp
@@ -170,7 +170,7 @@ void PairPeriEPS::compute(int eflag, int vflag)
 
   // grow bond forces array if necessary
 
-  int  maxpartner = 0;
+  maxpartner = 0;
   for (i = 0; i < nlocal; i++) maxpartner = MAX(maxpartner,npartner[i]);
 
   if (nlocal > nmax) {
@@ -560,6 +560,6 @@ double PairPeriEPS::compute_DeviatoricForceStateNorm(int i)
 double PairPeriEPS::memory_usage()
 {
   double bytes = PairPeri::memory_usage();
-  // TEMPORARY: deviatorPlasticExtTemp[nlocal][maxpartner] during compute()
+  bytes += (double) sizeof(double) * maxpartner * atom->nlocal;
   return bytes;
 }

--- a/src/PERI/pair_peri_eps.h
+++ b/src/PERI/pair_peri_eps.h
@@ -37,6 +37,8 @@ class PairPeriEPS : public PairPeri {
   void read_restart_settings(FILE *) override {}
   double compute_DeviatoricForceStateNorm(int);
   double memory_usage() override;
+ private:
+  int maxpartner;
 };
 
 }    // namespace LAMMPS_NS

--- a/src/PERI/pair_peri_eps.h
+++ b/src/PERI/pair_peri_eps.h
@@ -36,6 +36,7 @@ class PairPeriEPS : public PairPeri {
   void write_restart_settings(FILE *) override {}
   void read_restart_settings(FILE *) override {}
   double compute_DeviatoricForceStateNorm(int);
+  double memory_usage() override;
 };
 
 }    // namespace LAMMPS_NS

--- a/src/QTB/fix_qbmsst.cpp
+++ b/src/QTB/fix_qbmsst.cpp
@@ -1095,6 +1095,7 @@ double FixQBMSST::memory_usage()
   // fran memory usage
   bytes += (double)(atom->nmax* 3 * sizeof(double));
   bytes += (double)(4*N_f * sizeof(double));
+  bytes += (double) atoms_allocated * 3 * sizeof(double);    // old_velocity[atoms_allocated][3]
   return bytes;
 }
 

--- a/src/RIGID/fix_rigid.cpp
+++ b/src/RIGID/fix_rigid.cpp
@@ -2439,8 +2439,8 @@ double FixRigid::memory_usage()
   bytes += (double)maxvatom*6 * sizeof(double);    // vatom
   if (extended) {
     bytes += (double)nmax * sizeof(int);
-    if (orientflag) bytes = (double)nmax*orientflag * sizeof(double);
-    if (dorientflag) bytes = (double)nmax*3 * sizeof(double);
+    if (orientflag) bytes += (double)nmax*orientflag * sizeof(double);
+    if (dorientflag) bytes += (double)nmax*3 * sizeof(double);
   }
   return bytes;
 }

--- a/src/RIGID/fix_rigid_nh.cpp
+++ b/src/RIGID/fix_rigid_nh.cpp
@@ -1304,3 +1304,19 @@ void FixRigidNH::deallocate_order()
   delete[] wdti2;
   delete[] wdti4;
 }
+
+/* ---------------------------------------------------------------------- */
+
+double FixRigidNH::memory_usage()
+{
+  double bytes = FixRigid::memory_usage();
+  bytes += (double) nbody * 4 * sizeof(double);    // conjqm[nbody][4]
+  if (tstat_flag) {
+    bytes += (double) t_chain * 8 * sizeof(double);    // q/eta/eta_dot/f_eta * t/r
+  }
+  if (pstat_flag) {
+    bytes += (double) p_chain * 4 * sizeof(double);    // q_b/eta_b/eta_dot_b/f_eta_b
+  }
+  bytes += (double) t_order * 4 * sizeof(double);    // w/wdti1/wdti2/wdti4
+  return bytes;
+}

--- a/src/RIGID/fix_rigid_nh.h
+++ b/src/RIGID/fix_rigid_nh.h
@@ -77,6 +77,7 @@ class FixRigidNH : public FixRigid {
   void compute_press_target();
   void nh_epsilon_dot();
 
+  double memory_usage() override;
   void allocate_chain();
   void allocate_order();
   void deallocate_chain();

--- a/src/SPIN/fix_nve_spin.cpp
+++ b/src/SPIN/fix_nve_spin.cpp
@@ -733,3 +733,12 @@ void FixNVESpin::final_integrate()
   }
 
 }
+
+/* ---------------------------------------------------------------------- */
+
+double FixNVESpin::memory_usage()
+{
+  double bytes = (double) nlocal_max * 2 * sizeof(int);     // backward_stacks + forward_stacks
+  bytes += (double) nsectors * 2 * sizeof(int);             // stack_head + stack_foot
+  return bytes;
+}

--- a/src/SPIN/fix_nve_spin.h
+++ b/src/SPIN/fix_nve_spin.h
@@ -43,6 +43,7 @@ class FixNVESpin : public Fix {
 
   void setup_pre_neighbor() override;
   void pre_neighbor() override;
+  double memory_usage() override;
 
   int lattice_flag;    // lattice_flag = 0 if spins only
                        // lattice_flag = 1 if spin-lattice calc.

--- a/src/SPIN/fix_precession_spin.cpp
+++ b/src/SPIN/fix_precession_spin.cpp
@@ -631,3 +631,10 @@ void FixPrecessionSpin::post_force_respa(int vflag, int ilevel, int /*iloop*/)
 {
   if (ilevel == ilevel_respa) post_force(vflag);
 }
+
+/* ---------------------------------------------------------------------- */
+
+double FixPrecessionSpin::memory_usage()
+{
+  return (double) nlocal_max * sizeof(double);    // emag[nlocal_max]
+}

--- a/src/SPIN/fix_precession_spin.h
+++ b/src/SPIN/fix_precession_spin.h
@@ -38,6 +38,7 @@ class FixPrecessionSpin : public Fix {
   void post_force_respa(int, int, int) override;
   void min_post_force(int) override;
   double compute_scalar() override;
+  double memory_usage() override;
 
   int zeeman_flag, stt_flag, aniso_flag, cubic_flag, hexaniso_flag;
   void compute_single_precession(int, double *, double *);

--- a/src/SPIN/min_spin_cg.cpp
+++ b/src/SPIN/min_spin_cg.cpp
@@ -600,6 +600,15 @@ int MinSpinCG::adescent(double phi_0, double phi_j) {
     return 0;
 }
 
+/* ---------------------------------------------------------------------- */
+
+double MinSpinCG::memory_usage()
+{
+  double bytes = (double) 3 * nlocal_max * 3 * sizeof(double);     // g_old + g_cur + p_s [3*nlocal_max]
+  if (sp_copy) bytes += (double) nlocal_max * 3 * sizeof(double);  // sp_copy[nlocal_max][3]
+  return bytes;
+}
+
 /* ----------------------------------------------------------------------
    evaluate max timestep
 ---------------------------------------------------------------------- */

--- a/src/SPIN/min_spin_cg.h
+++ b/src/SPIN/min_spin_cg.h
@@ -33,6 +33,7 @@ class MinSpinCG : public Min {
   void reset_vectors() override;
   int modify_param(int, char **) override;
   int iterate(int) override;
+  double memory_usage() override;
 
  private:
   int local_iter;            // for neb

--- a/src/SPIN/min_spin_lbfgs.cpp
+++ b/src/SPIN/min_spin_lbfgs.cpp
@@ -719,6 +719,17 @@ int MinSpinLBFGS::adescent(double phi_0, double phi_j) {
     return 0;
 }
 
+double MinSpinLBFGS::memory_usage()
+{
+  double bytes = (double) 3 * nlocal_max * 3 * sizeof(double);     // g_old + g_cur + p_s [3*nlocal_max]
+  bytes += (double) num_mem * 2 * 3 * nlocal_max * sizeof(double); // ds + dy [num_mem][3*nlocal_max]
+  bytes += (double) num_mem * sizeof(double);                       // rho[num_mem]
+  if (sp_copy) bytes += (double) nlocal_max * 3 * sizeof(double);  // sp_copy[nlocal_max][3]
+  return bytes;
+}
+
+/* ---------------------------------------------------------------------- */
+
 double MinSpinLBFGS::maximum_rotation(double *p)
 {
   double norm2,norm2_global,scaling,alpha;

--- a/src/SPIN/min_spin_lbfgs.h
+++ b/src/SPIN/min_spin_lbfgs.h
@@ -33,6 +33,7 @@ class MinSpinLBFGS : public Min {
   int modify_param(int, char **) override;
   void reset_vectors() override;
   int iterate(int) override;
+  double memory_usage() override;
 
  private:
   int local_iter;            // for neb

--- a/src/SPIN/pair_spin.cpp
+++ b/src/SPIN/pair_spin.cpp
@@ -104,3 +104,12 @@ void PairSpin::init_style()
   nlocal_max = atom->nlocal;
   memory->grow(emag,nlocal_max,"pair/spin:emag");
 }
+
+/* ---------------------------------------------------------------------- */
+
+double PairSpin::memory_usage()
+{
+  double bytes = Pair::memory_usage();
+  bytes += (double) nlocal_max * sizeof(double);    // emag[nlocal_max]
+  return bytes;
+}

--- a/src/SPIN/pair_spin.h
+++ b/src/SPIN/pair_spin.h
@@ -32,6 +32,7 @@ class PairSpin : public Pair {
 
   void compute(int, int) override {}
   virtual void compute_single_pair(int, double *) {}
+  double memory_usage() override;
 
   // storing magnetic energies
 

--- a/src/compute_rdf.cpp
+++ b/src/compute_rdf.cpp
@@ -436,3 +436,13 @@ void ComputeRDF::compute_array()
     }
   }
 }
+
+/* ---------------------------------------------------------------------- */
+
+double ComputeRDF::memory_usage()
+{
+  double bytes = 0.0;
+  bytes += (double) npairs * nbin * 2 * sizeof(double);    // hist + histall
+  bytes += (double) nbin * (1 + 2*npairs) * sizeof(double);    // array
+  return bytes;
+}

--- a/src/compute_rdf.h
+++ b/src/compute_rdf.h
@@ -31,6 +31,7 @@ class ComputeRDF : public Compute {
   void init() override;
   void init_list(int, class NeighList *) override;
   void compute_array() override;
+  double memory_usage() override;
 
  private:
   int nbin;                // # of rdf bins

--- a/src/fix_langevin.cpp
+++ b/src/fix_langevin.cpp
@@ -756,8 +756,9 @@ void *FixLangevin::extract(const char *str, int &dim)
 double FixLangevin::memory_usage()
 {
   double bytes = 0.0;
-  if (tallyflag || osflag) bytes += (double) atom->nmax * 3 * sizeof(double);
-  if (tforce) bytes += (double) atom->nmax * sizeof(double);
+  if (flangevin_allocated) bytes += (double) atom->nmax * 3 * sizeof(double);    // flangevin[nmax][3]
+  if (tallyflag || osflag) bytes += (double) atom->nmax * 3 * sizeof(double);    // franprev[nmax][3]
+  if (tforce) bytes += (double) atom->nmax * sizeof(double);                     // tforce[nmax]
   return bytes;
 }
 

--- a/src/fix_property_atom.cpp
+++ b/src/fix_property_atom.cpp
@@ -556,23 +556,23 @@ double FixPropertyAtom::memory_usage()
   double bytes = 0.0;
   for (int m = 0; m < nvalue; m++) {
     if (styles[m] == MOLECULE)
-      bytes = atom->nmax * sizeof(tagint);
+      bytes += atom->nmax * sizeof(tagint);
     else if (styles[m] == CHARGE)
-      bytes = atom->nmax * sizeof(double);
+      bytes += atom->nmax * sizeof(double);
     else if (styles[m] == RMASS)
-      bytes = atom->nmax * sizeof(double);
+      bytes += atom->nmax * sizeof(double);
     else if (styles[m] == TEMPERATURE)
-      bytes = atom->nmax * sizeof(double);
+      bytes += atom->nmax * sizeof(double);
     else if (styles[m] == HEATFLOW)
-      bytes = atom->nmax * sizeof(double);
+      bytes += atom->nmax * sizeof(double);
     else if (styles[m] == IVEC)
-      bytes = atom->nmax * sizeof(int);
+      bytes += atom->nmax * sizeof(int);
     else if (styles[m] == DVEC)
-      bytes = atom->nmax * sizeof(double);
+      bytes += atom->nmax * sizeof(double);
     else if (styles[m] == IARRAY)
-      bytes = (size_t) atom->nmax * cols[m] * sizeof(int);
+      bytes += (size_t) atom->nmax * cols[m] * sizeof(int);
     else if (styles[m] == DARRAY)
-      bytes = (size_t) atom->nmax * cols[m] * sizeof(double);
+      bytes += (size_t) atom->nmax * cols[m] * sizeof(double);
   }
   return bytes;
 }

--- a/src/fix_wall_table.cpp
+++ b/src/fix_wall_table.cpp
@@ -470,3 +470,19 @@ void FixWallTable::uf_lookup(int m, double x, double &u, double &f)
         ((a * a * a - a) * tb.f2[itable] + (b * b * b - b) * tb.f2[itable + 1]) * tb.deltasq6;
   }
 }
+
+/* ---------------------------------------------------------------------- */
+
+double FixWallTable::memory_usage()
+{
+  double bytes = 0.0;
+  for (int m = 0; m < nwall; m++) {
+    const Table &tb = tables[m];
+    // input file data (rfile, efile, ffile) + spline coefficients (e2file, f2file)
+    bytes += (double) tb.ninput * 5 * sizeof(double);
+    // tabulated lookup arrays: r, e, de, f, df (+ e2, f2 for SPLINE)
+    bytes += (double) tablength * 5 * sizeof(double);
+    if (tabstyle == SPLINE) bytes += (double) tablength * 2 * sizeof(double);
+  }
+  return bytes;
+}

--- a/src/fix_wall_table.h
+++ b/src/fix_wall_table.h
@@ -32,6 +32,7 @@ class FixWallTable : public FixWall {
   void post_constructor() override;
   void precompute(int) override;
   void wall_particle(int, int, double) override;
+  double memory_usage() override;
 
  protected:
   double offset[6];

--- a/src/kspace.h
+++ b/src/kspace.h
@@ -195,7 +195,12 @@ class KSpace : protected Pointers {
   virtual int timing_3d(int, double &) { return 0; }
 
   virtual int modify_param(int, char **) { return 0; }
-  virtual double memory_usage() { return 0.0; }
+  virtual double memory_usage()
+  {
+    double bytes = (double) maxeatom * sizeof(double);
+    bytes += (double) maxvatom * 6 * sizeof(double);
+    return bytes;
+  }
 
   /* ----------------------------------------------------------------------
    compute gamma for MSM and pair styles

--- a/src/molecule.cpp
+++ b/src/molecule.cpp
@@ -4741,6 +4741,65 @@ void Molecule::check_labels()
   }
 }
 
+/* ---------------------------------------------------------------------- */
+
+double Molecule::memory_usage()
+{
+  double bytes = 0.0;
+
+  // per-atom coordinate and property arrays
+  if (xflag) bytes += (double) natoms * 3 * sizeof(double);
+  if (typeflag) bytes += (double) natoms * sizeof(int);
+  if (moleculeflag) bytes += (double) natoms * sizeof(tagint);
+  if (qflag) bytes += (double) natoms * sizeof(double);
+  if (radiusflag) bytes += (double) natoms * sizeof(double);
+  if (rmassflag) bytes += (double) natoms * sizeof(double);
+  if (muflag) bytes += (double) natoms * 3 * sizeof(double);
+
+  // connectivity counts (always allocated)
+  bytes += (double) natoms * 4 * sizeof(int);    // num_bond/angle/dihedral/improper
+  bytes += (double) natoms * 3 * sizeof(int);    // nspecial[natoms][3]
+
+  if (specialflag) bytes += (double) natoms * maxspecial * sizeof(tagint);
+
+  if (bondflag) {
+    bytes += (double) natoms * bond_per_atom * sizeof(int);
+    bytes += (double) natoms * bond_per_atom * sizeof(tagint);
+  }
+  if (angleflag) {
+    bytes += (double) natoms * angle_per_atom * sizeof(int);
+    bytes += (double) natoms * angle_per_atom * 3 * sizeof(tagint);
+  }
+  if (dihedralflag) {
+    bytes += (double) natoms * dihedral_per_atom * sizeof(int);
+    bytes += (double) natoms * dihedral_per_atom * 4 * sizeof(tagint);
+  }
+  if (improperflag) {
+    bytes += (double) natoms * improper_per_atom * sizeof(int);
+    bytes += (double) natoms * improper_per_atom * 4 * sizeof(tagint);
+  }
+
+  if (shakeflag) {
+    bytes += (double) natoms * sizeof(int);          // shake_flag
+    bytes += (double) natoms * 4 * sizeof(tagint);   // shake_atom[natoms][4]
+    bytes += (double) natoms * 3 * sizeof(int);      // shake_type[natoms][3]
+  }
+
+  if (bodyflag) {
+    bytes += (double) nibody * sizeof(int);
+    bytes += (double) ndbody * sizeof(double);
+  }
+
+  if (fragmentflag) bytes += (double) nfragments * natoms * sizeof(int);
+
+  // geometric displacement arrays (allocated lazily by compute_center/com/inertia)
+  if (centerflag) bytes += (double) natoms * 3 * sizeof(double);   // dx
+  if (comflag) bytes += (double) natoms * 3 * sizeof(double);      // dxcom
+  if (inertiaflag) bytes += (double) natoms * 3 * sizeof(double);  // dxbody
+
+  return bytes;
+}
+
 /* ------------------------------------------------------------------------------ */
 
 void Molecule::stats()

--- a/src/molecule.h
+++ b/src/molecule.h
@@ -144,6 +144,7 @@ class Molecule : protected Pointers {
   int findfragment(const char *);
   void check_attributes();
 
+  double memory_usage();
   void print(FILE *fp=stdout);
 
  private:

--- a/src/pair_table.cpp
+++ b/src/pair_table.cpp
@@ -1035,6 +1035,29 @@ double PairTable::single(int /*i*/, int /*j*/, int itype, int jtype, double rsq,
      no way to know which tables are active since pair::init() not yet called
 ------------------------------------------------------------------------- */
 
+double PairTable::memory_usage()
+{
+  double bytes = Pair::memory_usage();
+  for (int m = 0; m < ntables; m++) {
+    const Table *tb = &tables[m];
+    // input file data (rfile, efile, ffile, e2file, f2file)
+    bytes += (double) tb->ninput * 3 * sizeof(double);
+    if (tabstyle == SPLINE) bytes += (double) tb->ninput * 2 * sizeof(double);
+    // tabulated lookup arrays
+    if (tb->rsq) bytes += (double) tablength * sizeof(double);    // rsq
+    if (tb->e) bytes += (double) tablength * sizeof(double);      // e
+    if (tb->f) bytes += (double) tablength * sizeof(double);      // f
+    if (tb->de) bytes += (double) (tablength - 1) * sizeof(double);
+    if (tb->df) bytes += (double) (tablength - 1) * sizeof(double);
+    if (tb->drsq) bytes += (double) tablength * sizeof(double);   // BITMAP
+    if (tb->e2) bytes += (double) tablength * sizeof(double);
+    if (tb->f2) bytes += (double) tablength * sizeof(double);
+  }
+  return bytes;
+}
+
+/* ---------------------------------------------------------------------- */
+
 void *PairTable::extract(const char *str, int &dim)
 {
   if (strcmp(str, "cut_coul") != 0) return nullptr;

--- a/src/pair_table.h
+++ b/src/pair_table.h
@@ -39,6 +39,7 @@ class PairTable : public Pair {
   void read_restart_settings(FILE *) override;
   double single(int, int, int, int, double, double, double, double &) override;
   void *extract(const char *, int &) override;
+  double memory_usage() override;
 
   enum { LOOKUP, LINEAR, SPLINE, BITMAP };
 

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -5876,3 +5876,14 @@ int VarReader::read_peratom()
 
   return 0;
 }
+
+/* ---------------------------------------------------------------------- */
+
+double Variable::memory_usage()
+{
+  double bytes = (double) maxvar * sizeof(VecVar);
+  for (int i = 0; i < nvar; i++)
+    if (style[i] == VECTOR && vecs[i].nmax > 0)
+      bytes += (double) vecs[i].nmax * sizeof(double);
+  return bytes;
+}

--- a/src/variable.h
+++ b/src/variable.h
@@ -54,6 +54,7 @@ class Variable : protected Pointers {
 
   tagint int_between_brackets(char *&, int);
   double evaluate_boolean(char *);
+  double memory_usage();
 
  public:
   int nvar;        // # of defined variables


### PR DESCRIPTION
## Summary

This PR audits and corrects \`memory_usage()\` implementations across LAMMPS \`src/\` and package subdirectories. The goal is accurate per-style memory reporting for diagnostic purposes (\`info memory\` command). Only nmax/nlocal-scale allocations (arrays that grow with atom count) are in scope; small ntypes×ntypes coefficient arrays are intentionally omitted.

The audit also uncovered a class of performance issues where per-atom work arrays were destroyed and recreated from scratch every timestep (malloc/free per step) rather than grown once with \`memory->grow()\`. These are fixed in the same commits.

Changes across 15 commits:

**Memory accounting additions (missing or incorrect \`memory_usage()\`):**

- **Core \`src/\`**: fix \`=\`→\`+=\` accumulation bug in \`fix_property_atom\`; add \`memory_usage()\` to \`molecule\`, \`compute_rdf\`, \`fix_wall_table\`, \`pair_table\`, \`variable\`; add \`flangevin[nmax][3]\` to base \`FixLangevin\`
- **KSPACE**: add base-class \`kspace.h\` accounting for \`eatom\`/\`vatom\` per-atom buffers
- **MANYBODY**: new/corrected implementations for \`pair_comb3\`, \`pair_eim\`, \`pair_gnn\`, \`pair_nb3b_harmonic\`, \`pair_reaxff\`
- **RIGID**: fix \`=\`→\`+=\` bug in \`fix_rigid\` extended-particle branch; add \`fix_rigid_nh\`
- **EXTRA-PAIR**: add \`pair_dispersion_d3\` for \`cn\`/\`dc6[nmax]\`
- **EXTRA-FIX**: add \`fix_nonaffine_displacement\`, \`fix_temp_csld\`, \`fix_wall_flow\`
- **EXTRA-COMPUTE**: add \`compute_rattlers_atom\`, \`compute_slcsa_atom\`
- **SPIN**: add \`pair_spin\`, \`fix_precession_spin\`, \`fix_nve_spin\`, \`min_spin_cg\`, \`min_spin_lbfgs\`
- **MISC/MC**: add \`pair_srp\`, \`fix_tfmc\`, \`pair_dsmc\`
- **DRUDE/PERI**: add \`fix_drude\`, \`pair_peri_eps\`
- **LATBOLTZ/OPENMP**: add \`fix_lb_fluid\`, \`fix_qeq_reaxff_omp\`
- **BODY**: add \`pair_body_nparticle\`, \`pair_body_rounded_polygon\`, \`pair_body_rounded_polyhedron\`, \`fix_wall_body_polygon\`, \`fix_wall_body_polyhedron\`
- **EFF**: add \`fix_langevin_eff\` for \`erforcelangevin[nmax]\`
- **ML-PACE**: add \`pair_pace\` for \`corerep_factor[nmax_corerep]\`
- **APIP**: add \`fix_lambda_apip\` for \`peratom_stats[nmax][ncols]\`
- **BPM**: add \`bond_bpm_spring\` for \`dvol0[nmax]\`
- **COLLOID**: add \`pair_lubricateU\` for \`fl\`/\`Tl\`/\`xl[nmax][3]\`
- **DIELECTRIC**: add \`msm_dielectric\`, \`pppm_dielectric\` for \`efield[nmax][3]\`
- **FEP**: add \`compute_fep\`, \`compute_fep_ta\` for saved force/energy/virial arrays
- **INTERLAYER**: add \`pair_ilp_graphene_hbn\`, \`pair_ilp_tmd\`, \`pair_kolmogorov_crespi_full\` for \`normal\`/\`dnormdri\`/\`dnormal[nmax]\` arrays
- **ML-RUNNER**: add \`pair_runner\` for 7 per-atom arrays
- **MBX**: add \`fix_mbx\` for \`mol_type\`/\`mol_anchor\`/\`mol_local\`/\`aspc_dip_hist\`/\`mbx_dip\`
- **QTB**: add \`old_velocity\` to existing \`fix_qbmsst::memory_usage()\`

**Avoid per-step malloc/free of per-atom work arrays:**

- **DPD-REACT \`pair_dpd_fdt_energy\`**: \`duCond\`/\`duMech\` were destroyed and recreated every timestep with \`nlocal+nghost\` as size. Switch to \`memory->grow()\` against \`atom->nmax\` with a \`nmax_dpd\` tracking variable.
- **DPD-REACT \`pair_table_rx\`**: 4 \`mixWtSite*\` arrays malloc/freed every compute call. Same fix.
- **DPD-REACT \`pair_multi_lucy_rx\`**: 4 \`mixWtSite*\` arrays malloc/freed every compute call. Same fix. (Note: existing \`nmax\` member was never initialized; fixed.)
- **DPD-REACT \`pair_exp6_rx\`**: 16 arrays in a local \`PairExp6ParamDataType\` struct malloc/freed every compute call — the highest-cost instance. The code even had a comment "make the parameter data persistent" that was never acted on. Fixed using the same grow pattern; existing \`PairExp6ParamData.field[i]\` access sites are preserved via a local struct wrapper that aliases the class member pointers.
- **MESONT \`pair_mesocnt\`**: \`special_local[nlocal+nghost][2]\` int array malloc/freed every call to \`bond_neigh_topo()\`. Same fix.

All five styles also gain \`memory_usage()\` overrides reporting the now-persistent allocation.

## AI Tools Usage

This PR was developed with the assistance of Claude Code (claude-sonnet-4-6). All generated code was reviewed and the build was verified locally before submission.

**Backward Compatibility**

No functional changes. Memory use is purely diagnostic.

**Implementation Notes**

N/A

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
