### PR TITLE
GPU package: avoid NaN energies with chipStar (HIP SPIR-V)

### DIFF
--- a/cmake/Modules/Packages/GPU.cmake
+++ b/cmake/Modules/Packages/GPU.cmake
@@ -406,6 +406,11 @@ elseif(GPU_API STREQUAL "HIP")
   add_library(gpu STATIC ${GPU_LIB_SOURCES})
   target_include_directories(gpu PRIVATE ${LAMMPS_LIB_BINARY_DIR}/gpu)
   target_compile_definitions(gpu PRIVATE -DUSE_HIP -D_${GPU_PREC_SETTING})
+  # SPIR-V (chipStar) gives no warp-synchronous guarantee, so the device-side
+  # block-wide energy/virial reduction yields NaN; accumulate it on the host.
+  if(HIP_ARCH STREQUAL "spirv")
+    target_compile_definitions(gpu PRIVATE -DLAL_NO_BLOCK_REDUCE)
+  endif()
   if(GPU_DEBUG)
     target_compile_definitions(gpu PRIVATE -DUCL_DEBUG -DGERYON_KERNEL_DUMP)
   else()


### PR DESCRIPTION
The `lib/gpu` block-wide energy/virial reduction assumes warp-synchronous execution, which the SPIR-V/OpenCL model does not guarantee — producing NaN energies/stresses on chipStar/Intel GPUs (forces are unaffected). Enable the existing `LAL_NO_BLOCK_REDUCE` flag for `HIP_ARCH=spirv` to accumulate energy/virial on the host instead.

Verified on Intel PVC (Aurora) and Intel UHD 770: GPU pair-style unit tests go from 28 NaN failures to 0 (297/297 pass).