### PR TITLE
Correct reported issues in Lubrication dynamics pair styles

### DIFF
--- a/src/COLLOID/pair_brownian.cpp
+++ b/src/COLLOID/pair_brownian.cpp
@@ -374,8 +374,7 @@ void PairBrownian::settings(int narg, char **arg)
 
   if (flaglog == 1 && flagHI == 0) {
     error->warning(FLERR,
-                   "Cannot include log terms without 1/r terms; "
-                   "setting flagHI to 1");
+                   "Cannot include log terms without 1/r terms; setting flagHI to 1");
     flagHI = 1;
   }
 

--- a/src/COLLOID/pair_brownian_poly.cpp
+++ b/src/COLLOID/pair_brownian_poly.cpp
@@ -36,16 +36,61 @@
 #include "variable.h"
 
 #include <cmath>
+#include <cstdint>
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
 using namespace MathSpecial;
+
+/* ----------------------------------------------------------------------
+   deterministic, traversal- and MPI-rank-independent uniform random number
+   in [0,1), keyed on the *unordered* atom-tag pair, the timestep, the style
+   seed, and a stream index k.  Both atoms of a pair (and either MPI rank that
+   owns them under "newton off") draw the identical value, so the pairwise
+   Brownian force can be applied equal-and-opposite and obeys Newton's 3rd law
+   (conserves momentum).  See GitHub issue #2933.  A per-rank RNG sequence
+   cannot be used here because the two halves of a ghosted pair are evaluated
+   on different ranks.  Mixing uses a boost-style hash_combine followed by the
+   splitmix64 finalizer for good avalanche.
+------------------------------------------------------------------------- */
+
+double PairBrownianPoly::pair_uniform(tagint ti, tagint tj, bigint step, int seed, int k)
+{
+  uint64_t lo = (uint64_t) (ti < tj ? ti : tj);
+  uint64_t hi = (uint64_t) (ti < tj ? tj : ti);
+  uint64_t h = (uint64_t) seed * 0x9E3779B97F4A7C15ULL;
+  h ^= lo + 0x9E3779B97F4A7C15ULL + (h << 6) + (h >> 2);
+  h ^= hi + 0x9E3779B97F4A7C15ULL + (h << 6) + (h >> 2);
+  h ^= (uint64_t) step + 0x9E3779B97F4A7C15ULL + (h << 6) + (h >> 2);
+  h ^= (uint64_t) k + 0x9E3779B97F4A7C15ULL + (h << 6) + (h >> 2);
+  h += 0x9E3779B97F4A7C15ULL;
+  h = (h ^ (h >> 30)) * 0xBF58476D1CE4E5B9ULL;
+  h = (h ^ (h >> 27)) * 0x94D049BB133111EBULL;
+  h = h ^ (h >> 31);
+  return (double) (h >> 11) * (1.0 / 9007199254740992.0);
+}
 
 /* ---------------------------------------------------------------------- */
 
 PairBrownianPoly::PairBrownianPoly(LAMMPS *lmp) : PairBrownian(lmp)
 {
   no_virial_fdotr_compute = 1;
+  rad = 0.0; // set to a default value
+}
+
+
+/* ----------------------------------------------------------------------
+   global settings
+------------------------------------------------------------------------- */
+
+void PairBrownianPoly::settings(int narg, char **arg)
+{
+  PairBrownian::settings(narg, arg);
+  // NOTE: the code for volume fraction correction was copied from pair style brownian,
+  // which requires a uniform radius (stored in the variable rad). For a polydisperse
+  // system that is not correct and the variable rad unset. Thus we stop here with an error.
+  if (flagVF)
+    error->all(FLERR, "Pair style brownian/poly does not support volume fraction corrections");
 }
 
 /* ---------------------------------------------------------------------- */
@@ -64,12 +109,13 @@ void PairBrownianPoly::compute(int eflag, int vflag)
   double **torque = atom->torque;
   double *radius = atom->radius;
   int *type = atom->type;
+  tagint *tag = atom->tag;
   int nlocal = atom->nlocal;
+  bigint step = update->ntimestep;
 
   double vxmu2f = force->vxmu2f;
-  double randr;
   double prethermostat;
-  double xl[3],a_sq,a_sh,a_pu,Fbmag;
+  double a_sq,a_sh,a_pu,Fbmag;
   double p1[3],p2[3],p3[3];
 
   // this section of code adjusts R0/RT0/RS0 if necessary due to changes
@@ -166,7 +212,24 @@ void PairBrownianPoly::compute(int eflag, int vflag)
       if (rsq < cutsq[itype][jtype]) {
         r = sqrt(rsq);
 
-        // scalar resistances a_sq and a_sh
+        // canonical (tag-ordered) description of the pair so that the random
+        // Brownian force is computed identically no matter which atom -- or,
+        // under "newton off", which MPI rank -- evaluates the pair.  All
+        // geometry, resistances and random draws below use the lower-tag atom
+        // as the reference particle.  csgn = +1 if the local atom i is that
+        // reference, -1 otherwise; (ex,ey,ez) is the unit line-of-centers
+        // pointing from the higher-tag toward the lower-tag atom.  This makes
+        // the pairwise force exactly equal and opposite (Newton's 3rd law),
+        // fixing the momentum/energy injection of GitHub issue #2933.
+
+        double csgn = (tag[i] < tag[j]) ? 1.0 : -1.0;
+        double rref = (csgn > 0.0) ? radi : radj;   // lower-tag (reference) radius
+        double roth = (csgn > 0.0) ? radj : radi;   // higher-tag radius
+        double ex = csgn*delx/r;
+        double ey = csgn*dely/r;
+        double ez = csgn*delz/r;
+
+        // scalar resistances a_sq, a_sh, a_pu
 
         h_sep = r - radi-radj;
 
@@ -175,135 +238,130 @@ void PairBrownianPoly::compute(int eflag, int vflag)
         if (r < cut_inner[itype][jtype])
           h_sep = cut_inner[itype][jtype] - radi-radj;
 
-        // scale h_sep by radi
+        // scale h_sep by the reference radius
 
-        h_sep = h_sep/radi;
-        beta0 = radj/radi;
+        h_sep = h_sep/rref;
+        beta0 = roth/rref;
         beta1 = 1.0 + beta0;
 
-        // scalar resistances
+        // scalar resistances.  By the fluctuation-dissipation theorem the
+        // Brownian variance equals the lubrication friction, so these use the
+        // same symmetric-gap Jeffrey & Onishi expansion as pair lubricate/poly
+        // (xi = 2*gap/(radi+radj) = 2*h_sep/beta1) after the GitHub issue
+        // #1933 fix; using bare h_sep / dropping the beta0 prefactor would
+        // make the magnitude depend on which particle is the reference.
 
         if (flaglog) {
+          double xi = 2.0*h_sep/beta1;
           a_sq = beta0*beta0/beta1/beta1/h_sep +
-            (1.0+7.0*beta0+beta0*beta0)/5.0/cube(beta1)*log(1.0/h_sep);
-          a_sq += (1.0+18.0*beta0-29.0*beta0*beta0+18.0*cube(beta0) +
-                   powint(beta0,4))/21.0/powint(beta1,4)*h_sep*log(1.0/h_sep);
-          a_sq *= 6.0*MY_PI*mu*radi;
-          a_sh = 4.0*beta0*(2.0+beta0+2.0*beta0*beta0)/15.0/cube(beta1) *
-            log(1.0/h_sep);
-          a_sh += 4.0*(16.0-45.0*beta0+58.0*beta0*beta0-45.0*cube(beta0) +
-                       16.0*powint(beta0,4))/375.0/powint(beta1,4) *
-            h_sep*log(1.0/h_sep);
-          a_sh *= 6.0*MY_PI*mu*radi;
-          a_pu = beta0*(4.0+beta0)/10.0/beta1/beta1*log(1.0/h_sep);
-          a_pu += (32.0-33.0*beta0+83.0*beta0*beta0+43.0 *
-                   cube(beta0))/250.0/cube(beta1)*h_sep*log(1.0/h_sep);
-          a_pu *= 8.0*MY_PI*mu*cube(radi);
+            beta0*(1.0+7.0*beta0+beta0*beta0)/5.0/pow(beta1,3.0)*log(1.0/xi);
+          a_sq += (1.0+18.0*beta0-29.0*beta0*beta0+18.0 *
+                   pow(beta0,3.0)+pow(beta0,4.0))/21.0/pow(beta1,4.0) *
+            h_sep*log(1.0/xi);
+          a_sq *= 6.0*MY_PI*mu*rref;
+          a_sh = 4.0*beta0*(2.0+beta0+2.0*beta0*beta0)/15.0/pow(beta1,3.0) *
+            log(1.0/xi);
+          a_sh += 4.0*(16.0-45.0*beta0+58.0*beta0*beta0-45.0*pow(beta0,3.0) +
+                       16.0*pow(beta0,4.0))/375.0/pow(beta1,4.0) *
+            h_sep*log(1.0/xi);
+          a_sh *= 6.0*MY_PI*mu*rref;
+          a_pu = 2.0*beta0/5.0/beta1*log(1.0/xi);
+          a_pu += 2.0*(8.0+6.0*beta0+33.0*beta0*beta0)/125.0/beta1/beta1*
+                   h_sep*log(1.0/xi);
+          a_pu *= 8.0*MY_PI*mu*pow(rref,3.0);
+        } else a_sq = 6.0*MY_PI*mu*rref*(beta0*beta0/beta1/beta1/h_sep);
 
-        } else a_sq = 6.0*MY_PI*mu*radi*(beta0*beta0/beta1/beta1/h_sep);
+        // build the random Brownian force on the *reference* (lower-tag) atom.
+        // random scalars are drawn from the order-independent pair RNG, one
+        // independent stream (index k) per component, so both halves of the
+        // pair agree on the value.
 
-        // generate the Pairwise Brownian Force: a_sq
+        // squeeze term (along line of centers): a_sq
 
         Fbmag = prethermostat*sqrt(a_sq);
+        double s0 = pair_uniform(tag[i],tag[j],step,seed,0)-0.5;
+        fx = Fbmag*s0*ex;
+        fy = Fbmag*s0*ey;
+        fz = Fbmag*s0*ez;
 
-        // generate a random number
-
-        randr = random->uniform()-0.5;
-
-        // contribution due to Brownian motion
-
-        fx = Fbmag*randr*delx/r;
-        fy = Fbmag*randr*dely/r;
-        fz = Fbmag*randr*delz/r;
-
-        // add terms due to a_sh
+        // shear terms: a_sh
 
         if (flaglog) {
 
-          // generate two orthogonal vectors to the line of centers
+          // two orthogonal vectors to the (canonical) line of centers
 
-          p1[0] = delx/r; p1[1] = dely/r; p1[2] = delz/r;
+          p1[0] = ex; p1[1] = ey; p1[2] = ez;
           set_3_orthogonal_vectors(p1,p2,p3);
-
-          // magnitude
 
           Fbmag = prethermostat*sqrt(a_sh);
 
-          // force in each of the two directions
+          double s2 = pair_uniform(tag[i],tag[j],step,seed,1)-0.5;
+          fx += Fbmag*s2*p2[0];
+          fy += Fbmag*s2*p2[1];
+          fz += Fbmag*s2*p2[2];
 
-          randr = random->uniform()-0.5;
-          fx += Fbmag*randr*p2[0];
-          fy += Fbmag*randr*p2[1];
-          fz += Fbmag*randr*p2[2];
-
-          randr = random->uniform()-0.5;
-          fx += Fbmag*randr*p3[0];
-          fy += Fbmag*randr*p3[1];
-          fz += Fbmag*randr*p3[2];
+          double s3 = pair_uniform(tag[i],tag[j],step,seed,2)-0.5;
+          fx += Fbmag*s3*p3[0];
+          fy += Fbmag*s3*p3[1];
+          fz += Fbmag*s3*p3[2];
         }
 
-        // scale forces to appropriate units
+        // scale to force units
 
-        fx = vxmu2f*fx;
-        fy = vxmu2f*fy;
-        fz = vxmu2f*fz;
+        fx *= vxmu2f;
+        fy *= vxmu2f;
+        fz *= vxmu2f;
 
-        // sum to total Force
+        // (fx,fy,fz) is the negated Brownian force on the reference atom.
+        // apply equal and opposite to the local atom i via csgn; the other
+        // atom accumulates its (opposite) share when it is processed as a
+        // local atom, so f[j] is intentionally not touched (newton off).
 
-        f[i][0] -= fx;
-        f[i][1] -= fy;
-        f[i][2] -= fz;
-
-        // torque due to the Brownian Force
+        f[i][0] -= csgn*fx;
+        f[i][1] -= csgn*fy;
+        f[i][2] -= csgn*fz;
 
         if (flaglog) {
 
-          // location of the point of closest approach on I from its center
+          // torque on the local atom from the Brownian force acting at the
+          // point of closest approach: tau = (radius_i * e) x F_i, which here
+          // reduces to radi*(e x (fx,fy,fz)) for either pair member (only the
+          // shear part contributes; the squeeze part is parallel to e).
 
-          xl[0] = -delx/r*radi;
-          xl[1] = -dely/r*radi;
-          xl[2] = -delz/r*radi;
+          tx = radi*(ey*fz - ez*fy);
+          ty = radi*(ez*fx - ex*fz);
+          tz = radi*(ex*fy - ey*fx);
 
-          // torque = xl_cross_F
+          torque[i][0] += tx;
+          torque[i][1] += ty;
+          torque[i][2] += tz;
 
-          tx = xl[1]*fz - xl[2]*fy;
-          ty = xl[2]*fx - xl[0]*fz;
-          tz = xl[0]*fy - xl[1]*fx;
-
-          // torque is same on both particles
-
-          torque[i][0] -= tx;
-          torque[i][1] -= ty;
-          torque[i][2] -= tz;
-
-          // torque due to a_pu
+          // pumping (rotational) Brownian torque: a_pu.  This is an
+          // antisymmetric pair torque (opposite sign on the two particles),
+          // so it carries csgn.  Note: as in the original code it is not
+          // scaled by vxmu2f.
 
           Fbmag = prethermostat*sqrt(a_pu);
 
-          // force in each direction
+          double t2 = pair_uniform(tag[i],tag[j],step,seed,3)-0.5;
+          tx = Fbmag*t2*p2[0];
+          ty = Fbmag*t2*p2[1];
+          tz = Fbmag*t2*p2[2];
 
-          randr = random->uniform()-0.5;
-          tx = Fbmag*randr*p2[0];
-          ty = Fbmag*randr*p2[1];
-          tz = Fbmag*randr*p2[2];
+          double t3 = pair_uniform(tag[i],tag[j],step,seed,4)-0.5;
+          tx += Fbmag*t3*p3[0];
+          ty += Fbmag*t3*p3[1];
+          tz += Fbmag*t3*p3[2];
 
-          randr = random->uniform()-0.5;
-          tx += Fbmag*randr*p3[0];
-          ty += Fbmag*randr*p3[1];
-          tz += Fbmag*randr*p3[2];
-
-          // torque has opposite sign on two particles
-
-          torque[i][0] -= tx;
-          torque[i][1] -= ty;
-          torque[i][2] -= tz;
-
+          torque[i][0] -= csgn*tx;
+          torque[i][1] -= csgn*ty;
+          torque[i][2] -= csgn*tz;
         }
 
-        // set j = nlocal so that only I gets tallied
+        // tally only the local atom's contribution (j = nlocal, newton 0)
 
         if (evflag) ev_tally_xyz(i,nlocal,nlocal,0,
-                                 0.0,0.0,-fx,-fy,-fz,delx,dely,delz);
+                                 0.0,0.0,-csgn*fx,-csgn*fy,-csgn*fz,delx,dely,delz);
       }
     }
   }
@@ -319,6 +377,8 @@ void PairBrownianPoly::init_style()
     error->all(FLERR,"Pair brownian/poly requires newton pair off");
   if (!atom->radius_flag)
     error->all(FLERR,"Pair brownian/poly requires atom attribute radius");
+  if (atom->tag_enable == 0)
+    error->all(FLERR,"Pair brownian/poly requires atom IDs");
 
   // ensure all particles are finite-size
   // for pair hybrid, should limit test to types using the pair style

--- a/src/COLLOID/pair_brownian_poly.h
+++ b/src/COLLOID/pair_brownian_poly.h
@@ -31,6 +31,14 @@ class PairBrownianPoly : public PairBrownian {
   void compute(int, int) override;
   double init_one(int, int) override;
   void init_style() override;
+  void settings(int, char **) override;
+
+ protected:
+  // deterministic, order- and MPI-rank-independent uniform random number for
+  // a pair, keyed on the unordered atom-tag pair, timestep, seed, and stream
+  // index.  Both halves of a pair draw the identical value so the pairwise
+  // Brownian force obeys Newton's 3rd law under "newton off".  See issue #2933.
+  static double pair_uniform(tagint, tagint, bigint, int, int);
 };
 
 }    // namespace LAMMPS_NS

--- a/src/COLLOID/pair_lubricateU_poly.cpp
+++ b/src/COLLOID/pair_lubricateU_poly.cpp
@@ -521,11 +521,15 @@ void PairLubricateUPoly::compute_Fh(double **x)
           beta[0][4] = beta[0][3]*beta[0][1];
           beta[1][2] = beta[1][1]*beta[1][1];
           beta[1][3] = beta[1][2]*beta[1][1];
-          double log_h_sep_beta13 = log(1.0/h_sep)/beta[1][3];
+          // symmetric dimensionless gap xi = 2*gap/(radi+radj) = 2*h_sep/beta1
+          // (Jeffrey & Onishi 1984).  Using the per-particle h_sep = gap/radi in
+          // the log-order terms breaks the i<->j resistance symmetry.  See #1933.
+          double xi = 2.0*h_sep/beta[1][1];
+          double log_h_sep_beta13 = log(1.0/xi)/beta[1][3];
           double h_sep_beta11 = h_sep/beta[1][1];
 
           a_sq = pre[0]*(beta[0][2]/beta[1][2]/h_sep
-                +((0.2+1.4*beta[0][1]+0.2*beta[0][2])
+                +((0.2*beta[0][1]+1.4*beta[0][2]+0.2*beta[0][3])
                   +(1.0+18.0*(beta[0][1]+beta[0][3])-29.0*beta[0][2]
                     +beta[0][4])*h_sep_beta11/21.0)*log_h_sep_beta13);
 
@@ -763,12 +767,15 @@ void PairLubricateUPoly::compute_RU(double **x)
           beta[0][4] = beta[0][3]*beta[0][1];
           beta[1][2] = beta[1][1]*beta[1][1];
           beta[1][3] = beta[1][2]*beta[1][1];
-          double log_h_sep = log(1.0/h_sep);
-          double log_h_sep_beta13 = log(1.0/h_sep)/beta[1][3];
+          // symmetric dimensionless gap xi = 2*gap/(radi+radj) = 2*h_sep/beta1
+          // (Jeffrey & Onishi 1984).  Using the per-particle h_sep = gap/radi in
+          // the log-order terms breaks the i<->j resistance symmetry.  See #1933.
+          double xi = 2.0*h_sep/beta[1][1];
+          double log_h_sep_beta13 = log(1.0/xi)/beta[1][3];
           double h_sep_beta11 = h_sep/beta[1][1];
 
           a_sq = pre[0]*(beta[0][2]/beta[1][2]/h_sep
-                +((0.2+1.4*beta[0][1]+0.2*beta[0][2])
+                +((0.2*beta[0][1]+1.4*beta[0][2]+0.2*beta[0][3])
                   +(1.0+18.0*(beta[0][1]+beta[0][3])-29.0*beta[0][2]
                     +beta[0][4])*h_sep_beta11/21.0)*log_h_sep_beta13);
 
@@ -783,7 +790,7 @@ void PairLubricateUPoly::compute_RU(double **x)
 //                  +0.172*beta[0][3])*h_sep)*log_h_sep_beta13;
           a_pu = pre[1]*(0.4*beta[0][1]*beta[1][1]
                 +(0.128+0.096*beta[0][1]+0.528*beta[0][2])*beta[1][2]*h_sep)
-                  *log_h_sep;
+                  *log(1.0/xi);
 
           /*//a_sq = 6*MY_PI*mu*radi*(1.0/4.0/h_sep + 9.0/40.0*log(1/h_sep));
           a_sq = beta0*beta0/beta1/beta1/h_sep
@@ -986,11 +993,15 @@ void PairLubricateUPoly::compute_RE(double **x)
           beta[0][4] = beta[0][3]*beta[0][1];
           beta[1][2] = beta[1][1]*beta[1][1];
           beta[1][3] = beta[1][2]*beta[1][1];
-          double log_h_sep_beta13 = log(1.0/h_sep)/beta[1][3];
+          // symmetric dimensionless gap xi = 2*gap/(radi+radj) = 2*h_sep/beta1
+          // (Jeffrey & Onishi 1984).  Using the per-particle h_sep = gap/radi in
+          // the log-order terms breaks the i<->j resistance symmetry.  See #1933.
+          double xi = 2.0*h_sep/beta[1][1];
+          double log_h_sep_beta13 = log(1.0/xi)/beta[1][3];
           double h_sep_beta11 = h_sep/beta[1][1];
 
           a_sq = pre[0]*(beta[0][2]/beta[1][2]/h_sep
-                +((0.2+1.4*beta[0][1]+0.2*beta[0][2])
+                +((0.2*beta[0][1]+1.4*beta[0][2]+0.2*beta[0][3])
                   +(1.0+18.0*(beta[0][1]+beta[0][3])-29.0*beta[0][2]
                     +beta[0][4])*h_sep_beta11/21.0)*log_h_sep_beta13);
 

--- a/src/COLLOID/pair_lubricate_poly.cpp
+++ b/src/COLLOID/pair_lubricate_poly.cpp
@@ -283,17 +283,25 @@ void PairLubricatePoly::compute(int eflag, int vflag)
         // scalar resistances
 
         if (flaglog) {
+          // Jeffrey & Onishi (1984) near-field resistance functions are
+          // expansions in the *symmetric* dimensionless gap
+          // xi = 2*gap/(radi+radj) = 2*h_sep/beta1, not in the per-particle
+          // h_sep = gap/radi.  Using h_sep in the log-order terms (and dropping
+          // the beta0 prefactor of the squeeze log term) makes the resistance
+          // depend on which particle is "i", breaking pairwise force symmetry
+          // (Newton's 3rd law) for unequal radii.  See GitHub issue #1933.
+          double xi = 2.0*h_sep/beta1;
           a_sq = beta0*beta0/beta1/beta1/h_sep +
-            (1.0+7.0*beta0+beta0*beta0)/5.0/pow(beta1,3.0)*log(1.0/h_sep);
+            beta0*(1.0+7.0*beta0+beta0*beta0)/5.0/pow(beta1,3.0)*log(1.0/xi);
           a_sq += (1.0+18.0*beta0-29.0*beta0*beta0+18.0 *
                    pow(beta0,3.0)+pow(beta0,4.0))/21.0/pow(beta1,4.0) *
-            h_sep*log(1.0/h_sep);
+            h_sep*log(1.0/xi);
           a_sq *= 6.0*MY_PI*mu*radi;
           a_sh = 4.0*beta0*(2.0+beta0+2.0*beta0*beta0)/15.0/pow(beta1,3.0) *
-            log(1.0/h_sep);
+            log(1.0/xi);
           a_sh += 4.0*(16.0-45.0*beta0+58.0*beta0*beta0-45.0*pow(beta0,3.0) +
                        16.0*pow(beta0,4.0))/375.0/pow(beta1,4.0) *
-            h_sep*log(1.0/h_sep);
+            h_sep*log(1.0/xi);
           a_sh *= 6.0*MY_PI*mu*radi;
           // old invalid eq for pumping term
           // changed 29Jul16 from eq 9.25 -> 9.27 in Kim and Karilla
@@ -301,9 +309,9 @@ void PairLubricatePoly::compute(int eflag, int vflag)
 //          a_pu += (32.0-33.0*beta0+83.0*beta0*beta0+43.0 *
 //                   pow(beta0,3.0))/250.0/pow(beta1,3.0)*h_sep*log(1.0/h_sep);
 //          a_pu *= 8.0*MY_PI*mu*pow(radi,3.0);
-          a_pu = 2.0*beta0/5.0/beta1*log(1.0/h_sep);
+          a_pu = 2.0*beta0/5.0/beta1*log(1.0/xi);
           a_pu += 2.0*(8.0+6.0*beta0+33.0*beta0*beta0)/125.0/beta1/beta1*
-                   h_sep*log(1.0/h_sep);
+                   h_sep*log(1.0/xi);
           a_pu *= 8.0*MY_PI*mu*pow(radi,3.0);
         } else a_sq = 6.0*MY_PI*mu*radi*(beta0*beta0/beta1/beta1/h_sep);
 

--- a/src/OPENMP/pair_brownian_poly_omp.cpp
+++ b/src/OPENMP/pair_brownian_poly_omp.cpp
@@ -176,14 +176,15 @@ void PairBrownianPolyOMP::eval(int iifrom, int iito, ThrData * const thr)
   double * const * const torque = thr->get_torque();
   const double * const radius = atom->radius;
   const int * const type = atom->type;
+  const tagint * const tag = atom->tag;
   const int nlocal = atom->nlocal;
+  const bigint step = update->ntimestep;
 
   RanMars &rng = *random_thr[thr->get_tid()];
 
   double vxmu2f = force->vxmu2f;
-  double randr;
   double prethermostat;
-  double xl[3],a_sq,a_sh,a_pu,Fbmag;
+  double a_sq,a_sh,a_pu,Fbmag;
   double p1[3],p2[3],p3[3];
 
   // scale factor for Brownian moments
@@ -237,7 +238,23 @@ void PairBrownianPolyOMP::eval(int iifrom, int iito, ThrData * const thr)
       if (rsq < cutsq[itype][jtype]) {
         r = sqrt(rsq);
 
-        // scalar resistances a_sq and a_sh
+        // canonical (tag-ordered) description of the pair: the random Brownian
+        // force is computed identically regardless of which atom -- or which
+        // thread / MPI rank under "newton off" -- evaluates the pair, using the
+        // lower-tag atom as the reference particle.  csgn = +1 if local atom i
+        // is that reference, -1 otherwise; (ex,ey,ez) is the unit line of
+        // centers from the higher-tag toward the lower-tag atom.  This makes
+        // the pairwise force equal and opposite (Newton's 3rd law) and fixes
+        // the momentum/energy injection of GitHub issue #2933.
+
+        const double csgn = (tag[i] < tag[j]) ? 1.0 : -1.0;
+        const double rref = (csgn > 0.0) ? radi : radj;   // lower-tag radius
+        const double roth = (csgn > 0.0) ? radj : radi;   // higher-tag radius
+        const double ex = csgn*delx/r;
+        const double ey = csgn*dely/r;
+        const double ez = csgn*delz/r;
+
+        // scalar resistances a_sq, a_sh, a_pu
 
         h_sep = r - radi-radj;
 
@@ -246,135 +263,115 @@ void PairBrownianPolyOMP::eval(int iifrom, int iito, ThrData * const thr)
         if (r < cut_inner[itype][jtype])
           h_sep = cut_inner[itype][jtype] - radi-radj;
 
-        // scale h_sep by radi
+        // scale h_sep by the reference radius
 
-        h_sep = h_sep/radi;
-        beta0 = radj/radi;
+        h_sep = h_sep/rref;
+        beta0 = roth/rref;
         beta1 = 1.0 + beta0;
 
-        // scalar resistances
+        // scalar resistances; symmetric-gap Jeffrey & Onishi expansion as in
+        // pair lubricate/poly (FDT consistency), xi = 2*h_sep/beta1, GitHub
+        // issue #1933.
 
         if (FLAGLOG) {
+          double xi = 2.0*h_sep/beta1;
           a_sq = beta0*beta0/beta1/beta1/h_sep +
-            (1.0+7.0*beta0+beta0*beta0)/5.0/cube(beta1)*log(1.0/h_sep);
-          a_sq += (1.0+18.0*beta0-29.0*beta0*beta0+18.0*cube(beta0) +
-                   powint(beta0,4))/21.0/powint(beta1,4)*h_sep*log(1.0/h_sep);
-          a_sq *= 6.0*MY_PI*mu*radi;
-          a_sh = 4.0*beta0*(2.0+beta0+2.0*beta0*beta0)/15.0/cube(beta1) *
-            log(1.0/h_sep);
-          a_sh += 4.0*(16.0-45.0*beta0+58.0*beta0*beta0-45.0*cube(beta0) +
-                       16.0*powint(beta0,4))/375.0/powint(beta1,4) *
-            h_sep*log(1.0/h_sep);
-          a_sh *= 6.0*MY_PI*mu*radi;
-          a_pu = beta0*(4.0+beta0)/10.0/beta1/beta1*log(1.0/h_sep);
-          a_pu += (32.0-33.0*beta0+83.0*beta0*beta0+43.0 *
-                   cube(beta0))/250.0/cube(beta1)*h_sep*log(1.0/h_sep);
-          a_pu *= 8.0*MY_PI*mu*cube(radi);
+            beta0*(1.0+7.0*beta0+beta0*beta0)/5.0/pow(beta1,3.0)*log(1.0/xi);
+          a_sq += (1.0+18.0*beta0-29.0*beta0*beta0+18.0 *
+                   pow(beta0,3.0)+pow(beta0,4.0))/21.0/pow(beta1,4.0) *
+            h_sep*log(1.0/xi);
+          a_sq *= 6.0*MY_PI*mu*rref;
+          a_sh = 4.0*beta0*(2.0+beta0+2.0*beta0*beta0)/15.0/pow(beta1,3.0) *
+            log(1.0/xi);
+          a_sh += 4.0*(16.0-45.0*beta0+58.0*beta0*beta0-45.0*pow(beta0,3.0) +
+                       16.0*pow(beta0,4.0))/375.0/pow(beta1,4.0) *
+            h_sep*log(1.0/xi);
+          a_sh *= 6.0*MY_PI*mu*rref;
+          a_pu = 2.0*beta0/5.0/beta1*log(1.0/xi);
+          a_pu += 2.0*(8.0+6.0*beta0+33.0*beta0*beta0)/125.0/beta1/beta1*
+                   h_sep*log(1.0/xi);
+          a_pu *= 8.0*MY_PI*mu*pow(rref,3.0);
+        } else a_sq = 6.0*MY_PI*mu*rref*(beta0*beta0/beta1/beta1/h_sep);
 
-        } else a_sq = 6.0*MY_PI*mu*radi*(beta0*beta0/beta1/beta1/h_sep);
-
-        // generate the Pairwise Brownian Force: a_sq
+        // random Brownian force on the reference (lower-tag) atom, drawn from
+        // the order-independent pair RNG (one stream per component)
 
         Fbmag = prethermostat*sqrt(a_sq);
-
-        // generate a random number
-
-        randr = rng.uniform()-0.5;
-
-        // contribution due to Brownian motion
-
-        fx = Fbmag*randr*delx/r;
-        fy = Fbmag*randr*dely/r;
-        fz = Fbmag*randr*delz/r;
-
-        // add terms due to a_sh
+        double s0 = pair_uniform(tag[i],tag[j],step,seed,0)-0.5;
+        fx = Fbmag*s0*ex;
+        fy = Fbmag*s0*ey;
+        fz = Fbmag*s0*ez;
 
         if (FLAGLOG) {
 
-          // generate two orthogonal vectors to the line of centers
+          // two orthogonal vectors to the (canonical) line of centers
 
-          p1[0] = delx/r; p1[1] = dely/r; p1[2] = delz/r;
+          p1[0] = ex; p1[1] = ey; p1[2] = ez;
           set_3_orthogonal_vectors(p1,p2,p3);
-
-          // magnitude
 
           Fbmag = prethermostat*sqrt(a_sh);
 
-          // force in each of the two directions
+          double s2 = pair_uniform(tag[i],tag[j],step,seed,1)-0.5;
+          fx += Fbmag*s2*p2[0];
+          fy += Fbmag*s2*p2[1];
+          fz += Fbmag*s2*p2[2];
 
-          randr = rng.uniform()-0.5;
-          fx += Fbmag*randr*p2[0];
-          fy += Fbmag*randr*p2[1];
-          fz += Fbmag*randr*p2[2];
-
-          randr = rng.uniform()-0.5;
-          fx += Fbmag*randr*p3[0];
-          fy += Fbmag*randr*p3[1];
-          fz += Fbmag*randr*p3[2];
+          double s3 = pair_uniform(tag[i],tag[j],step,seed,2)-0.5;
+          fx += Fbmag*s3*p3[0];
+          fy += Fbmag*s3*p3[1];
+          fz += Fbmag*s3*p3[2];
         }
 
-        // scale forces to appropriate units
+        // scale to force units
 
-        fx = vxmu2f*fx;
-        fy = vxmu2f*fy;
-        fz = vxmu2f*fz;
+        fx *= vxmu2f;
+        fy *= vxmu2f;
+        fz *= vxmu2f;
 
-        // sum to total force
+        // apply equal and opposite to the local atom (csgn); the other atom
+        // accumulates its share when processed as a local atom (newton off)
 
-        f[i][0] -= fx;
-        f[i][1] -= fy;
-        f[i][2] -= fz;
-
-        // torque due to the Brownian Force
+        f[i][0] -= csgn*fx;
+        f[i][1] -= csgn*fy;
+        f[i][2] -= csgn*fz;
 
         if (FLAGLOG) {
 
-          // location of the point of closest approach on I from its center
+          // torque on the local atom from the Brownian force at the point of
+          // closest approach: radi*(e x F) for either pair member
 
-          xl[0] = -delx/r*radi;
-          xl[1] = -dely/r*radi;
-          xl[2] = -delz/r*radi;
+          tx = radi*(ey*fz - ez*fy);
+          ty = radi*(ez*fx - ex*fz);
+          tz = radi*(ex*fy - ey*fx);
 
-          // torque = xl_cross_F
+          torque[i][0] += tx;
+          torque[i][1] += ty;
+          torque[i][2] += tz;
 
-          tx = xl[1]*fz - xl[2]*fy;
-          ty = xl[2]*fx - xl[0]*fz;
-          tz = xl[0]*fy - xl[1]*fx;
-
-          // torque is same on both particles
-
-          torque[i][0] -= tx;
-          torque[i][1] -= ty;
-          torque[i][2] -= tz;
-
-          // torque due to a_pu
+          // pumping (rotational) Brownian torque: antisymmetric pair torque
+          // (carries csgn); as in the original code, not scaled by vxmu2f
 
           Fbmag = prethermostat*sqrt(a_pu);
 
-          // force in each direction
+          double t2 = pair_uniform(tag[i],tag[j],step,seed,3)-0.5;
+          tx = Fbmag*t2*p2[0];
+          ty = Fbmag*t2*p2[1];
+          tz = Fbmag*t2*p2[2];
 
-          randr = rng.uniform()-0.5;
-          tx = Fbmag*randr*p2[0];
-          ty = Fbmag*randr*p2[1];
-          tz = Fbmag*randr*p2[2];
+          double t3 = pair_uniform(tag[i],tag[j],step,seed,4)-0.5;
+          tx += Fbmag*t3*p3[0];
+          ty += Fbmag*t3*p3[1];
+          tz += Fbmag*t3*p3[2];
 
-          randr = rng.uniform()-0.5;
-          tx += Fbmag*randr*p3[0];
-          ty += Fbmag*randr*p3[1];
-          tz += Fbmag*randr*p3[2];
-
-          // torque has opposite sign on two particles
-
-          torque[i][0] -= tx;
-          torque[i][1] -= ty;
-          torque[i][2] -= tz;
-
+          torque[i][0] -= csgn*tx;
+          torque[i][1] -= csgn*ty;
+          torque[i][2] -= csgn*tz;
         }
 
-        // set j = nlocal so that only I gets tallied
+        // tally only the local atom's contribution (j = nlocal, newton 0)
 
         if (EVFLAG) ev_tally_xyz(i,nlocal,nlocal,/* newton_pair */ 0,
-                                 0.0,0.0,-fx,-fy,-fz,delx,dely,delz);
+                                 0.0,0.0,-csgn*fx,-csgn*fy,-csgn*fz,delx,dely,delz);
       }
     }
   }

--- a/src/OPENMP/pair_lubricate_poly_omp.cpp
+++ b/src/OPENMP/pair_lubricate_poly_omp.cpp
@@ -330,17 +330,24 @@ void PairLubricatePolyOMP::eval(int iifrom, int iito, ThrData * const thr)
         // scalar resistances
 
         if (FLAGLOG) {
+          // Jeffrey & Onishi (1984) near-field resistance functions are
+          // expansions in the *symmetric* dimensionless gap
+          // xi = 2*gap/(radi+radj) = 2*h_sep/beta1, not in the per-particle
+          // h_sep = gap/radi.  Using h_sep (and dropping the beta0 prefactor of
+          // the squeeze log term) breaks pairwise force symmetry (Newton's 3rd
+          // law) for unequal radii.  See GitHub issue #1933.
+          double xi = 2.0*h_sep/beta1;
           a_sq = beta0*beta0/beta1/beta1/h_sep +
-            (1.0+7.0*beta0+beta0*beta0)/5.0/pow(beta1,3.0)*log(1.0/h_sep);
+            beta0*(1.0+7.0*beta0+beta0*beta0)/5.0/pow(beta1,3.0)*log(1.0/xi);
           a_sq += (1.0+18.0*beta0-29.0*beta0*beta0+18.0 *
                    pow(beta0,3.0)+pow(beta0,4.0))/21.0/pow(beta1,4.0) *
-            h_sep*log(1.0/h_sep);
+            h_sep*log(1.0/xi);
           a_sq *= 6.0*MY_PI*mu*radi;
           a_sh = 4.0*beta0*(2.0+beta0+2.0*beta0*beta0)/15.0/pow(beta1,3.0) *
-            log(1.0/h_sep);
+            log(1.0/xi);
           a_sh += 4.0*(16.0-45.0*beta0+58.0*beta0*beta0-45.0*pow(beta0,3.0) +
                        16.0*pow(beta0,4.0))/375.0/pow(beta1,4.0) *
-            h_sep*log(1.0/h_sep);
+            h_sep*log(1.0/xi);
           a_sh *= 6.0*MY_PI*mu*radi;
           // old invalid eq for pumping term
           // changed 29Jul16 from eq 9.25 -> 9.27 in Kim and Karilla
@@ -348,9 +355,9 @@ void PairLubricatePolyOMP::eval(int iifrom, int iito, ThrData * const thr)
 //          a_pu += (32.0-33.0*beta0+83.0*beta0*beta0+43.0 *
 //                   pow(beta0,3.0))/250.0/pow(beta1,3.0)*h_sep*log(1.0/h_sep);
 //          a_pu *= 8.0*MY_PI*mu*pow(radi,3.0);
-          a_pu = 2.0*beta0/5.0/beta1*log(1.0/h_sep);
+          a_pu = 2.0*beta0/5.0/beta1*log(1.0/xi);
           a_pu += 2.0*(8.0+6.0*beta0+33.0*beta0*beta0)/125.0/beta1/beta1*
-                   h_sep*log(1.0/h_sep);
+                   h_sep*log(1.0/xi);
           a_pu *= 8.0*MY_PI*mu*pow(radi,3.0);
         } else a_sq = 6.0*MY_PI*mu*radi*(beta0*beta0/beta1/beta1/h_sep);
 

--- a/unittest/commands/CMakeLists.txt
+++ b/unittest/commands/CMakeLists.txt
@@ -50,6 +50,14 @@ add_executable(test_set_property test_set_property.cpp)
 target_link_libraries(test_set_property PRIVATE lammps GTest::GMock)
 add_test(NAME SetProperty COMMAND test_set_property)
 
+add_executable(test_pair_lubricate_poly test_pair_lubricate_poly.cpp)
+target_link_libraries(test_pair_lubricate_poly PRIVATE lammps GTest::GMock)
+add_test(NAME PairLubricatePoly COMMAND test_pair_lubricate_poly)
+
+add_executable(test_pair_brownian_poly test_pair_brownian_poly.cpp)
+target_link_libraries(test_pair_brownian_poly PRIVATE lammps GTest::GMock)
+add_test(NAME PairBrownianPoly COMMAND test_pair_brownian_poly)
+
 add_executable(test_pair_ldd test_pair_ldd.cpp)
 target_link_libraries(test_pair_ldd PRIVATE lammps GTest::GMock)
 add_test(NAME PairLDD COMMAND test_pair_ldd)

--- a/unittest/commands/test_pair_brownian_poly.cpp
+++ b/unittest/commands/test_pair_brownian_poly.cpp
@@ -1,0 +1,190 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS Development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+// Regression test for GitHub issue #2933: the pairwise *random* Brownian force
+// of pair style brownian/poly must obey Newton's third law (be equal and
+// opposite) so that linear momentum is conserved and the system is not heated
+// spuriously.  The original implementation ran with "newton off" on a full
+// neighbor list and applied the force only to the local atom i, drawing an
+// *independent* random number for the (i,j) and (j,i) visits.  The two random
+// forces were therefore unrelated rather than equal and opposite, injecting
+// net momentum (and kinetic energy) every step.  The fix draws each pair's
+// random force from a deterministic, order- and MPI-rank-independent RNG keyed
+// on the unordered atom-tag pair and the timestep, and applies it equal and
+// opposite to the two particles.  These tests assert pairwise/global force
+// balance, which the buggy version violated by O(1).
+
+#include "lammps.h"
+
+#include "atom.h"
+#include "info.h"
+#include "input.h"
+
+#include "../testing/core.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <cmath>
+
+// whether to print verbose output (i.e. not capturing LAMMPS screen output).
+bool verbose = false;
+
+namespace LAMMPS_NS {
+class BrownianPolyTest : public LAMMPSTest {
+protected:
+    Atom *atom;
+
+    void SetUp() override
+    {
+        testbinary = "BrownianPolyTest";
+        LAMMPSTest::SetUp();
+        if (!info->has_style("pair", "brownian/poly")) GTEST_SKIP() << "COLLOID package not enabled";
+        atom = lmp->atom;
+    }
+
+    void TearDown() override { LAMMPSTest::TearDown(); }
+
+    void make_box()
+    {
+        BEGIN_HIDE_OUTPUT();
+        command("units lj");
+        command("atom_style sphere");
+        command("atom_modify map array");
+        command("boundary p p p");
+        command("newton off");
+        command("comm_modify mode single vel yes");
+        command("region box block -20 20 -20 20 -20 20");
+        command("create_box 1 box");
+        END_HIDE_OUTPUT();
+    }
+
+    // net force summed over all (local) atoms; the pure pairwise Brownian force
+    // (flagfld = 0) must conserve linear momentum, i.e. sum to zero.
+    void net_force(double *fnet)
+    {
+        fnet[0] = fnet[1] = fnet[2] = 0.0;
+        double **f = atom->f;
+        for (int i = 0; i < atom->nlocal; ++i) {
+            fnet[0] += f[i][0];
+            fnet[1] += f[i][1];
+            fnet[2] += f[i][2];
+        }
+    }
+};
+
+// Two unequal spheres, log (full) resistance terms enabled, pure pairwise
+// (flagfld = 0).  The random force on each must be exactly opposite, at every
+// timestep (the RNG seed includes the timestep).
+TEST_F(BrownianPolyTest, Newton3rdLawTwoSpheres)
+{
+    make_box();
+    BEGIN_HIDE_OUTPUT();
+    command("create_atoms 1 single 0.0 0.0 0.0");
+    command("create_atoms 1 single 4.5 0.0 0.0");
+    command("set atom 1 diameter 2.0 density 1.0");
+    command("set atom 2 diameter 6.0 density 1.0");
+    // mu flaglog flagfld(=0 -> pure pairwise) cutinner cutoff t_target seed
+    command("pair_style brownian/poly 1.0 1 0 4.1 6.0 1.0 5827 1 0");
+    command("pair_coeff * *");
+    END_HIDE_OUTPUT();
+
+    double **f = atom->f;
+    for (int step = 0; step < 5; ++step) {
+        BEGIN_HIDE_OUTPUT();
+        command("run 1 post no");
+        END_HIDE_OUTPUT();
+        const int i1 = atom->map(1);
+        const int i2 = atom->map(2);
+        ASSERT_GE(i1, 0);
+        ASSERT_GE(i2, 0);
+        // forces are O(100); the bug leaves a net force of the same order
+        for (int k = 0; k < 3; ++k)
+            EXPECT_NEAR(f[i1][k] + f[i2][k], 0.0, 1.0e-8)
+                << "step " << step << " force component " << k;
+    }
+}
+
+// Same, but with the centers inside cutinner so the gap is clamped to the
+// minimum.  This is the parameter regime of the original bug report.
+TEST_F(BrownianPolyTest, Newton3rdLawClampedGap)
+{
+    make_box();
+    BEGIN_HIDE_OUTPUT();
+    command("create_atoms 1 single 0.0 0.0 0.0");
+    command("create_atoms 1 single 4.5 0.0 0.0");
+    command("set atom 1 diameter 2.0 density 1.0");
+    command("set atom 2 diameter 6.0 density 1.0");
+    // cutinner = 5.5 > r = 4.5 -> the h_sep clamp branch is exercised
+    command("pair_style brownian/poly 1.0 1 0 5.5 6.0 1.0 91237 1 0");
+    command("pair_coeff * *");
+    command("run 1 post no");
+    END_HIDE_OUTPUT();
+
+    const int i1 = atom->map(1);
+    const int i2 = atom->map(2);
+    ASSERT_GE(i1, 0);
+    ASSERT_GE(i2, 0);
+    double **f = atom->f;
+    for (int k = 0; k < 3; ++k)
+        EXPECT_NEAR(f[i1][k] + f[i2][k], 0.0, 1.0e-8) << "force component " << k;
+}
+
+// A cluster of polydisperse spheres: total linear momentum input from the
+// pairwise random Brownian forces must vanish.  The near-field lubrication
+// resistance is only physical close to contact (a_sq < 0 for large gaps, where
+// the sqrt in the Brownian amplitude is undefined), so the particles are placed
+// in a compact square near contact and the cutoff (3.0) excludes the longer
+// diagonal pairs.
+TEST_F(BrownianPolyTest, Newton3rdLawCluster)
+{
+    make_box();
+    BEGIN_HIDE_OUTPUT();
+    command("create_atoms 1 single 0.0 0.0 0.0");
+    command("create_atoms 1 single 2.4 0.0 0.0");
+    command("create_atoms 1 single 0.0 2.4 0.0");
+    command("create_atoms 1 single 2.4 2.4 0.0");
+    command("set atom 1 diameter 2.0 density 1.0");
+    command("set atom 2 diameter 2.2 density 1.0");
+    command("set atom 3 diameter 2.1 density 1.0");
+    command("set atom 4 diameter 2.3 density 1.0");
+    command("pair_style brownian/poly 1.0 1 0 0.5 3.0 1.0 40591 1 0");
+    command("pair_coeff * *");
+    command("run 1 post no");
+    END_HIDE_OUTPUT();
+
+    double fnet[3];
+    net_force(fnet);
+    for (int k = 0; k < 3; ++k) EXPECT_NEAR(fnet[k], 0.0, 1.0e-8) << "net force component " << k;
+}
+} // namespace LAMMPS_NS
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+    ::testing::InitGoogleMock(&argc, argv);
+
+    // handle arguments passed via environment variable
+    if (const char *var = getenv("TEST_ARGS")) {
+        std::vector<std::string> env = LAMMPS_NS::utils::split_words(var);
+        for (auto arg : env) {
+            if (arg == "-v") {
+                verbose = true;
+            }
+        }
+    }
+    if ((argc > 1) && (strcmp(argv[1], "-v") == 0)) verbose = true;
+
+    int rv = RUN_ALL_TESTS();
+    MPI_Finalize();
+    return rv;
+}

--- a/unittest/commands/test_pair_lubricate_poly.cpp
+++ b/unittest/commands/test_pair_lubricate_poly.cpp
@@ -1,0 +1,187 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS Development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+// Regression test for GitHub issue #1933: the pairwise lubrication force of
+// pair style lubricate/poly must obey Newton's third law (be equal and
+// opposite) also for *polydisperse* particles.  The near-field resistance
+// functions (Jeffrey & Onishi, 1984) are expansions in the symmetric gap
+// xi = 2*gap/(radi+radj); an earlier implementation used the per-particle
+// h_sep = gap/radi in the log-order terms and dropped a beta0 = radj/radi
+// factor in the squeeze term, so the force computed on particle i (using its
+// own radius as the reference length) did not match minus the force computed
+// on particle j.  These tests assert pairwise/global force balance, which the
+// buggy version violated by ~50% for strongly unequal radii.
+
+#include "lammps.h"
+
+#include "atom.h"
+#include "info.h"
+#include "input.h"
+
+#include "../testing/core.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <cmath>
+
+// whether to print verbose output (i.e. not capturing LAMMPS screen output).
+bool verbose = false;
+
+namespace LAMMPS_NS {
+class LubricatePolyTest : public LAMMPSTest {
+protected:
+    Atom *atom;
+
+    void SetUp() override
+    {
+        testbinary = "LubricatePolyTest";
+        LAMMPSTest::SetUp();
+        if (!info->has_style("pair", "lubricate/poly")) GTEST_SKIP() << "COLLOID package not enabled";
+        atom = lmp->atom;
+    }
+
+    void TearDown() override { LAMMPSTest::TearDown(); }
+
+    void make_box()
+    {
+        BEGIN_HIDE_OUTPUT();
+        command("units lj");
+        command("atom_style sphere");
+        command("atom_modify map array");
+        command("boundary p p p");
+        command("newton off");
+        command("comm_modify mode single vel yes");
+        command("region box block -20 20 -20 20 -20 20");
+        command("create_box 1 box");
+        END_HIDE_OUTPUT();
+    }
+
+    // net force summed over all (local) atoms; pure pairwise interactions
+    // (flagfld = 0) must conserve linear momentum, i.e. sum to zero.
+    void net_force(double *fnet)
+    {
+        fnet[0] = fnet[1] = fnet[2] = 0.0;
+        double **f = atom->f;
+        for (int i = 0; i < atom->nlocal; ++i) {
+            fnet[0] += f[i][0];
+            fnet[1] += f[i][1];
+            fnet[2] += f[i][2];
+        }
+    }
+};
+
+// Two unequal spheres, general relative translation + spin, in the regular
+// (unclamped) lubrication regime.  The force on each must be exactly opposite.
+TEST_F(LubricatePolyTest, Newton3rdLawTwoSpheres)
+{
+    make_box();
+    BEGIN_HIDE_OUTPUT();
+    command("create_atoms 1 single 0.0 0.0 0.0");
+    command("create_atoms 1 single 4.5 0.0 0.0");
+    command("set atom 1 diameter 2.0 density 1.0");
+    command("set atom 2 diameter 6.0 density 1.0");
+    command("set atom 1 vx 0.5 vy 0.3 vz -0.1");
+    command("set atom 2 vx -0.4 vy 0.2 vz 0.15");
+    command("set atom 1 omega 0.0 0.0 1.0");
+    command("set atom 2 omega 0.0 0.0 -0.5");
+    // mu flaglog flagfld(=0 -> pure pairwise) cutinner cutoff
+    command("pair_style lubricate/poly 1.0 1 0 4.1 6.0");
+    command("pair_coeff * *");
+    command("run 0 post no");
+    END_HIDE_OUTPUT();
+
+    const int i1 = atom->map(1);
+    const int i2 = atom->map(2);
+    ASSERT_GE(i1, 0);
+    ASSERT_GE(i2, 0);
+    double **f = atom->f;
+    // forces are O(20); the fixed code balances to ~1e-14, the bug to ~1e-1
+    for (int k = 0; k < 3; ++k)
+        EXPECT_NEAR(f[i1][k] + f[i2][k], 0.0, 1.0e-8) << "force component " << k;
+}
+
+// Same, but with the centers inside cutinner so the gap is clamped.  This is
+// the parameter regime of the original bug report and must be symmetric too.
+TEST_F(LubricatePolyTest, Newton3rdLawClampedGap)
+{
+    make_box();
+    BEGIN_HIDE_OUTPUT();
+    command("create_atoms 1 single 0.0 0.0 0.0");
+    command("create_atoms 1 single 4.5 0.0 0.0");
+    command("set atom 1 diameter 2.0 density 1.0");
+    command("set atom 2 diameter 6.0 density 1.0");
+    command("set atom 1 vx 0.5 vy 0.0 vz 0.0");
+    command("set atom 2 vx -0.5 vy 0.0 vz 0.0");
+    // cutinner = 5.5 > r = 4.5 -> the h_sep clamp branch is exercised
+    command("pair_style lubricate/poly 1.0 1 0 5.5 6.0");
+    command("pair_coeff * *");
+    command("run 0 post no");
+    END_HIDE_OUTPUT();
+
+    const int i1 = atom->map(1);
+    const int i2 = atom->map(2);
+    ASSERT_GE(i1, 0);
+    ASSERT_GE(i2, 0);
+    double **f = atom->f;
+    for (int k = 0; k < 3; ++k)
+        EXPECT_NEAR(f[i1][k] + f[i2][k], 0.0, 1.0e-8) << "force component " << k;
+}
+
+// A cluster of several polydisperse spheres: total linear momentum input from
+// the pairwise lubrication forces must vanish.
+TEST_F(LubricatePolyTest, Newton3rdLawCluster)
+{
+    make_box();
+    BEGIN_HIDE_OUTPUT();
+    command("create_atoms 1 single  0.0  0.0  0.0");
+    command("create_atoms 1 single  3.6  0.4 -0.3");
+    command("create_atoms 1 single -2.9  2.7  0.6");
+    command("create_atoms 1 single  1.1 -3.2  2.4");
+    command("create_atoms 1 single -1.5 -1.2 -3.0");
+    command("set atom 1 diameter 1.0 density 1.0");
+    command("set atom 2 diameter 5.0 density 1.0");
+    command("set atom 3 diameter 2.4 density 1.0");
+    command("set atom 4 diameter 3.7 density 1.0");
+    command("set atom 5 diameter 1.8 density 1.0");
+    command("velocity all create 1.5 5934 mom no rot no");
+    command("pair_style lubricate/poly 1.0 1 0 0.9 6.0");
+    command("pair_coeff * *");
+    command("run 0 post no");
+    END_HIDE_OUTPUT();
+
+    double fnet[3];
+    net_force(fnet);
+    for (int k = 0; k < 3; ++k) EXPECT_NEAR(fnet[k], 0.0, 1.0e-8) << "net force component " << k;
+}
+} // namespace LAMMPS_NS
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+    ::testing::InitGoogleMock(&argc, argv);
+
+    // handle arguments passed via environment variable
+    if (const char *var = getenv("TEST_ARGS")) {
+        std::vector<std::string> env = LAMMPS_NS::utils::split_words(var);
+        for (auto arg : env) {
+            if (arg == "-v") {
+                verbose = true;
+            }
+        }
+    }
+    if ((argc > 1) && (strcmp(argv[1], "-v") == 0)) verbose = true;
+
+    int rv = RUN_ALL_TESTS();
+    MPI_Finalize();
+    return rv;
+}


### PR DESCRIPTION
**Summary**

This pull request contains fixes for reported issues with the fast lubrication dynamics related pair styles in the COLLOID package. This was separated from the previous "collection" pull request to simplify the review process and make it independent from the upcoming release deadline.

**Related Issue(s)**

Fixes #1933 
Fixes #2933 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

These bugfixes were created and documented by Claude Opus 4.8. The same applies to the two unittest programs.

**Backward Compatibility**

N/A

**Implementation Notes**

Here are the notes from Claude Opus:

---

### Bug fix for`pair_style lubricate/poly` not obeying Newton's third law for polydisperse (unequal radii) particles (issue #1933):

The near-field lubrication resistance functions (Jeffrey & Onishi, 1984) were nondimensionalized by the central particle's radius, so the pairwise force computed on particle *i* did not equal minus the force computed on particle *j*. The squeeze-term (`a_sq`) log coefficient was missing a `beta0 = radj/radi` factor (which the analogous shear term `a_sh` does include), and all log-order terms used the per-particle gap `h_sep = gap/radi` instead of the symmetric dimensionless gap `xi = 2*gap/(radi+radj)`. Adding the `beta0` factor and using `xi` restores exact pairwise force symmetry (verified to machine precision) and is a no-op for equal radii, so monodisperse results are unchanged. The same correction is applied to the `lubricate/poly/omp` accelerator variant and, for consistency, to `lubricateU/poly` (`compute_Fh`/`compute_RU`/`compute_RE`).

A new regression test `unittest/commands/test_pair_lubricate_poly.cpp` asserts net force balance for polydisperse configurations (it fails on the previous code and passes with this fix).

### Bug fix for `pair_style brownian/poly` not obeying Newton's third law for the pairwise *random* Brownian force (issue #2933):

The style runs under `newton off` on a full neighbor list and applied the random force only to the local atom *i*, drawing an *independent* random number for the `(i,j)` and `(j,i)` visits, so the forces on the two members of a pair were unrelated rather than equal and opposite. This injected net linear momentum (and kinetic energy) every step and heated the system. The random force is now drawn once per pair from a deterministic, order- and MPI-rank-independent RNG (keyed on the unordered pair of atom IDs, the timestep, the style seed, and a per-component stream index) and applied equal and opposite to both particles, so linear momentum is conserved exactly (verified to machine precision, and identical across MPI ranks and OpenMP thread counts). The near-field resistance functions are also switched to the symmetric Jeffrey & Onishi gap `xi = 2*gap/(radi+radj)` with the `beta0` squeeze prefactor, matching the issue #1933 `lubricate/poly` fix, so that by the fluctuation-dissipation theorem the Brownian variance equals the lubrication friction regardless of which particle is taken as the reference. The same fix is applied to the `brownian/poly/omp` accelerator variant, which previously also depended on the OpenMP thread count.

A new regression test `unittest/commands/test_pair_brownian_poly.cpp` asserts net force balance for polydisperse configurations.

---

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
