### PR TITLE
Add fix tprpmd for constant-potential path-integral dynamics

### DIFF
--- a/doc/src/Howto_replica.rst
+++ b/doc/src/Howto_replica.rst
@@ -17,6 +17,7 @@ These are the relevant commands:
 * :doc:`temper/npt <temper_npt>` for parallel tempering extended for NPT
 * :doc:`temper/grem <temper_grem>` for parallel tempering with generalized replica exchange (gREM)
 * :doc:`fix pimd <fix_pimd>` for path-integral molecular dynamics (PIMD)
+* :doc:`fix tprpmd <fix_tprpmd>` for constant-potential thermostatted ring-polymer molecular dynamics
 
 NEB is a method for finding transition states and barrier potential energies.
 HD, PRD, and TAD are methods for performing accelerated dynamics to find and
@@ -26,9 +27,10 @@ sampling.  PIMD runs different replicas whose individual particles in different
 replicas are coupled together by springs to model a system of ring-polymers which
 can represent the quantum nature of atom cores.
 
-These commands can only be used if LAMMPS was built with the REPLICA
-package.  See the :doc:`Build package <Build_package>` page for more
-info.
+The command-style replica methods above require LAMMPS to be built with
+the REPLICA package.  The ``fix tprpmd`` style instead lives in the
+EXTRA-FIX package, but it uses the same multi-partition launch model.
+See the :doc:`Build package <Build_package>` page for more info.
 
 In all these cases, you must run with one or more processors per
 replica.  The processors assigned to each replica are determined at

--- a/doc/src/fix_tprpmd.rst
+++ b/doc/src/fix_tprpmd.rst
@@ -1,0 +1,111 @@
+.. index:: fix tprpmd
+
+fix tprpmd command
+==================
+
+.. versionadded:: 15Jun2026
+
+Syntax
+""""""
+
+.. parsed-literal::
+
+   fix ID group-ID tprpmd method = tp-pimd or tp-rpmd or tprpmd ensemble uvt thermostat NHC temp T Tdamp tau_T \
+       tchain Nc tloop Nloop mu Mustart Mustop Mudamp ne Ne0 dedn source [keyword value ...]
+
+where the supported optional keywords are::
+
+   keyword = integrator or drag or fmass or fmmode or sp or lj or tau or ne_velocity or removecom
+
+Examples
+""""""""
+
+.. code-block:: LAMMPS
+
+   fix 1 all tprpmd method tp-rpmd ensemble uvt thermostat NHC temp 300.0 Tdamp 100.0 \
+          tchain 3 tloop 1 mu 0.0 0.0 100.0 ne 1.0 dedn v_dEdN
+
+   mpirun -np 8 lmp -partition 8x1 -in in.electron_tprpmd
+
+Description
+"""""""""""
+
+``fix tprpmd`` implements thermostatted ring-polymer molecular dynamics
+with a constant-potential electronic degree of freedom.  The path-integral
+replicas are distributed across LAMMPS partitions, so the number of beads
+is set implicitly by ``universe->nworlds`` and the job must be launched
+with the :doc:`-partition <Run_options>` command-line switch.
+
+This fix supports the uVT ensemble and a Nose-Hoover chain thermostat.
+The required keywords are:
+
+* ``method`` = ``tp-pimd`` or ``tp-rpmd`` (``tprpmd`` accepted as alias)
+* ``ensemble uvt``
+* ``thermostat NHC``
+* ``temp`` and ``Tdamp`` for the ionic thermostat
+* ``tchain`` and ``tloop`` for the thermostat-chain length and sub-cycling
+* ``mu``, ``ne``, and ``dedn`` for the constant-potential electronic coordinate
+
+``tp-pimd`` selects thermodynamic path-integral molecular dynamics
+with thermostats applied to all normal modes, including the centroid.
+``tp-rpmd`` selects thermostatted path-integral RPMD-style dynamics
+where the centroid mode is left unthermostatted and thermostats are
+applied only to internal modes.  ``tprpmd`` is accepted as an alias
+for ``tp-rpmd`` for compatibility.
+For ``tp-rpmd`` with a single bead, the unique nuclear centroid mode
+remains unthermostatted, while the shared electronic uVT variable
+continues to use the Nose-Hoover chain.
+
+The ``dedn`` source may be supplied as an equal-style variable
+(``v_name``), a global compute (``c_ID``), or a global fix (``f_ID``).
+If the source provides a global vector, an entry can be selected with
+the usual ``[index]`` syntax.
+
+The ``integrator`` keyword selects either ``obabo`` or ``baoab``.
+The ``fmmode`` and ``fmass`` keywords control the fictitious-mass
+preconditioning used for the ring-polymer normal modes.  The ``sp``
+keyword scales Planck's constant.  For ``lj`` units, the ``lj`` keyword
+supplies the reduced-unit conversion factors in the order
+``epsilon sigma mass hplanck mvv2e``.
+
+The electronic coordinate is exposed through the global fix vector.
+The first 10 entries are the path-integral energy and estimator outputs,
+followed by ``4*tchain`` thermostat entries and then six uVT entries:
+``Ne``, ``Ne_dot``, ``dEdN``, ``mu``, the electronic kinetic energy, and
+the electronic potential contribution.  Thus, for ``tchain 3``,
+``Ne``, ``Ne_dot``, ``dEdN``, and ``mu`` are ``f_ID[23]`` through
+``f_ID[26]``.
+These six electronic outputs are reported as global values and are not
+normalized by the number of atoms when used in thermo output.  The
+``dEdN`` entry is the bead-averaged value used to update the global
+electronic coordinate.
+
+The fix writes restart data for the thermostat state and electronic
+degree of freedom, so simulations may be continued with
+:doc:`read_restart <read_restart>` followed by the same ``fix tprpmd``
+command.
+
+Restrictions
+""""""""""""
+
+This fix currently supports only 3d systems.
+
+This fix requires an atom map, e.g. ``atom_modify map yes``.
+
+This fix requires one partition per bead.  In other words, the bead
+count must match ``universe->nworlds``.
+
+This fix is a complete time integrator.  No other time-integration fix
+should be applied to the same atoms.
+
+Pressure control is not supported by this fix.
+
+This fix is part of the EXTRA-FIX package.  It is only enabled if
+LAMMPS was built with that package.  See the :doc:`Build package
+<Build_package>` page for more info.
+
+Related commands
+""""""""""""""""
+
+:doc:`fix pimd <fix_pimd>`, :doc:`fix uvt <fix_uvt>`,
+:doc:`read_restart <read_restart>`, :doc:`run_style <run_style>`

--- a/doc/src/fix_tprpmd.rst
+++ b/doc/src/fix_tprpmd.rst
@@ -3,7 +3,7 @@
 fix tprpmd command
 ==================
 
-.. versionadded:: 15Jun2026
+.. versionadded:: TBD
 
 Syntax
 """"""

--- a/examples/PACKAGES/uvt/README
+++ b/examples/PACKAGES/uvt/README
@@ -1,0 +1,16 @@
+This directory contains minimal regression examples for the
+``fix tprpmd`` style in the EXTRA-FIX package.
+
+Files:
+
+- ``in.electron_tprpmd`` runs a quadratic toy model with an analytic
+  constant-potential equilibrium using a two-bead TP-RPMD integrator.
+- ``in.electron_tprpmd_restart`` continues from the restart written by
+  ``in.electron_tprpmd`` and can be used to check restart continuity.
+
+Build LAMMPS with the EXTRA-FIX package enabled before running these
+examples.
+
+Run ``in.electron_tprpmd`` with a partitioned launch, for example
+``mpirun -np 2 lmp -partition 2x1 -in in.electron_tprpmd``, before
+running ``in.electron_tprpmd_restart`` with the same partition layout.

--- a/examples/PACKAGES/uvt/in.electron_tprpmd
+++ b/examples/PACKAGES/uvt/in.electron_tprpmd
@@ -1,0 +1,66 @@
+# Quadratic toy model regression for TP-RPMD at constant potential.
+#
+# Launch this example with one partition per bead, e.g.
+#
+#   mpirun -np 2 lmp -partition 2x1 -in in.electron_tprpmd
+#
+# The electronic generalized coordinate Ne is coupled to
+#
+#   dE/dN = k * (Ne - N0)
+#
+# so the analytic equilibrium is
+#
+#   Ne* = N0 + mu/k
+
+units           lj
+atom_style      atomic
+atom_modify     map yes
+boundary        p p p
+
+lattice         sc 0.7
+region          box block 0 2 0 2 0 2
+create_box      1 box
+create_atoms    1 box
+
+mass            1 1.0
+pair_style      zero 2.5
+pair_coeff      * *
+
+neighbor        0.3 bin
+neigh_modify    every 1 delay 0 check yes
+
+timestep        0.002
+
+# Give each bead a small initial offset to exercise the inter-partition path.
+variable        beadshift universe 0.0 0.15
+displace_atoms  all move ${beadshift} 0.0 0.0 units box
+velocity        all create 0.8 97531 mom yes rot no dist gaussian
+
+variable        mu_target equal 1.5
+variable        k_quad    equal 3.0
+variable        N0_quad   equal 1.2
+variable        Ne_init   equal 1.8
+variable        Ne_target equal v_N0_quad + v_mu_target/v_k_quad
+print           "Quadratic toy model target Ne* = ${Ne_target}"
+
+# Per-partition world id for partition-specific restart filenames.
+# In a 2-bead TP-RPMD run, partition 0 gets 0, partition 1 gets 1.
+variable        worldid   universe 0 1
+
+# For tchain 3, Ne, Ne_dot, dEdN, and mu are f_cp[23:26].
+# These electronic outputs are global values and are not normalized by natoms.
+variable        dEdN      equal v_k_quad*(f_cp[23]-v_N0_quad)
+
+fix             cp all tprpmd method tp-rpmd ensemble uvt thermostat NHC &
+                integrator obabo temp 0.8 Tdamp 0.2 tchain 3 tloop 1 &
+                mu ${mu_target} ${mu_target} 0.2 ne ${Ne_init} &
+                ne_velocity 0.0 &
+                dedn v_dEdN
+
+thermo          50
+thermo_style    custom step temp etotal f_cp[23] f_cp[24] f_cp[25] f_cp[26]
+thermo_modify   flush yes
+
+run             1000
+
+write_restart   tprpmd.restart.${worldid}

--- a/examples/PACKAGES/uvt/in.electron_tprpmd_restart
+++ b/examples/PACKAGES/uvt/in.electron_tprpmd_restart
@@ -1,0 +1,29 @@
+# Restart regression for the TP-RPMD quadratic constant-potential toy model.
+#
+# Run with the same partition layout used for in.electron_tprpmd, e.g.
+#
+#   mpirun -np 2 lmp -partition 2x1 -in in.electron_tprpmd_restart
+
+# Per-partition world id must match in.electron_tprpmd:
+# partition 0 reads tprpmd.restart.0, partition 1 reads tprpmd.restart.1
+variable        worldid   universe 0 1
+read_restart    tprpmd.restart.${worldid}
+
+variable        mu_target equal 1.5
+variable        k_quad    equal 3.0
+variable        N0_quad   equal 1.2
+variable        Ne_init   equal 1.8
+# The electronic outputs f_cp[23:26] are global values and are not normalized by natoms.
+variable        dEdN      equal v_k_quad*(f_cp[23]-v_N0_quad)
+
+fix             cp all tprpmd method tp-rpmd ensemble uvt thermostat NHC &
+                integrator obabo temp 0.8 Tdamp 0.2 tchain 3 tloop 1 &
+                mu ${mu_target} ${mu_target} 0.2 ne ${Ne_init} &
+                ne_velocity 0.0 &
+                dedn v_dEdN
+
+thermo          50
+thermo_style    custom step temp etotal f_cp[23] f_cp[24] f_cp[25] f_cp[26]
+thermo_modify   flush yes
+
+run             100

--- a/src/EXTRA-FIX/fix_tprpmd.cpp
+++ b/src/EXTRA-FIX/fix_tprpmd.cpp
@@ -1,0 +1,1748 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "fix_tprpmd.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "compute.h"
+#include "domain.h"
+#include "error.h"
+#include "force.h"
+#include "group.h"
+#include "input.h"
+#include "math_const.h"
+#include "math_special.h"
+#include "memory.h"
+#include "modify.h"
+#include "universe.h"
+#include "update.h"
+#include "variable.h"
+
+#include <cmath>
+#include <cstring>
+
+using namespace LAMMPS_NS;
+using namespace FixConst;
+using MathConst::MY_2PI;
+using MathConst::MY_PI;
+using MathConst::MY_SQRT2;
+using MathConst::THIRD;
+using MathSpecial::powint;
+
+enum { TPPIMD, TPRPMD };
+enum { PHYSICAL, NORMAL };
+enum { BAOAB, OBABO };
+enum { ISO, ANISO, TRICLINIC };
+enum { NHC };
+enum { MTTK, BZP };
+enum { NVE, NVT, NPH, NPT, UVT };
+enum { SINGLE_PROC, MULTI_PROC };
+
+/* ---------------------------------------------------------------------- */
+
+FixTPRPMD::FixTPRPMD(LAMMPS *lmp, int narg, char **arg) :
+    Fix(lmp, narg, arg), mass(nullptr), plansend(nullptr), planrecv(nullptr), tagsend(nullptr),
+    tagrecv(nullptr), bufsend(nullptr), bufrecv(nullptr), bufbeads(nullptr), bufsorted(nullptr),
+    bufsortedall(nullptr), tagsendall(nullptr),
+    tagrecvall(nullptr), bufsendall(nullptr), bufrecvall(nullptr), counts(nullptr),
+    displacements(nullptr), lam(nullptr), M_x2xp(nullptr), M_xp2x(nullptr), modeindex(nullptr), tau_k(nullptr), _omega_k(nullptr), Lan_s(nullptr),
+    Lan_c(nullptr), xc(nullptr), xcall(nullptr),
+    x_unwrap(nullptr), id_pe(nullptr), id_press(nullptr), c_pe(nullptr), c_press(nullptr),
+    eta(nullptr), eta_dot(nullptr), eta_dotdot(nullptr), eta_mass(nullptr), Ne_dot(nullptr),
+    Ne_mass(nullptr), Ne(nullptr), u_start(0.0), u_stop(0.0), u_current(0.0), u_target(0.0),
+    dedn_name(nullptr), dedn_which(ArgInfo::NONE), dedn_index(0), dedn_var(-1),
+    dedn_compute(nullptr), dedn_fix(nullptr), dedn_current(0.0)
+{
+  restart_global = 1;
+  time_integrate = 1;
+  global_freq = 1;
+  vector_flag = 1;
+  extvector = -1;
+  size_vector = 10;
+
+  ntotal = 0;
+  maxlocal = maxunwrap = maxxc = 0;
+  sizeplan = 0;
+
+  method = TPRPMD;
+  ensemble = UVT;
+  integrator = OBABO;
+  thermostat = NHC;
+  lj_epsilon = 1;
+  lj_sigma = 1;
+  lj_mass = 1;
+  other_planck = 1;
+  other_mvv2e = 1;
+  fmass = 1.0;
+  np = universe->nworlds;
+  inverse_np = 1.0 / np;
+  sp = 1.0;
+  temp = 298.15;
+  tau = 1.0;
+  pilescale = 1.0;
+  tstat_flag = 1;
+  ustat_flag = 1;
+  mapflag = 1;
+  removecomflag = 1;
+  fmmode = PHYSICAL;
+  pote = tote = totke = total_spring_energy = 0.0;
+  centroid_vir = vir = vir_ = 0.0;
+  ke_bead = se_bead = pe_bead = tote = t_prim = t_vir = t_cv = p_prim = p_md = p_cv = 0.0;
+
+  mtchain = 3;
+  nc_tchain = 1;
+  t_period = 0.0;
+  u_period = 0.0;
+  drag = 0.0;
+  mu = -3.5;
+
+  if (domain->dimension != 3) error->universe_all(FLERR, "Fix tprpmd requires a 3d system");
+  if (narg < 4) utils::missing_cmd_args(FLERR, std::string("fix ") + style, error);
+
+  bool mu_seen = false;
+  bool ne_seen = false;
+  bool dedn_seen = false;
+
+  for (int i = 3; i < narg;) {
+    if (strcmp(arg[i], "method") == 0) {
+      if (i + 2 > narg) utils::missing_cmd_args(FLERR, fmt::format("fix {} method", style), error);
+      if (strcmp(arg[i + 1], "tp-pimd") == 0)
+        method = TPPIMD;
+      else if (strcmp(arg[i + 1], "tp-rpmd") == 0)
+        method = TPRPMD;
+      else if (strcmp(arg[i + 1], "tprpmd") == 0)
+        method = TPRPMD;
+      else
+        error->all(FLERR, "Fix {} only supports method tp-pimd or tp-rpmd", style);
+      i += 2;
+    } else if (strcmp(arg[i], "ensemble") == 0) {
+      if (i + 2 > narg)
+        utils::missing_cmd_args(FLERR, fmt::format("fix {} ensemble", style), error);
+      if (strcmp(arg[i + 1], "uvt") != 0)
+        error->all(FLERR, "Fix {} only supports ensemble uvt", style);
+      i += 2;
+    } else if (strcmp(arg[i], "thermostat") == 0) {
+      if (i + 2 > narg)
+        utils::missing_cmd_args(FLERR, fmt::format("fix {} thermostat", style), error);
+      if (strcmp(arg[i + 1], "NHC") != 0)
+        error->all(FLERR, "Fix {} only supports thermostat NHC", style);
+      i += 2;
+    } else if (strcmp(arg[i], "integrator") == 0) {
+      if (i + 2 > narg)
+        utils::missing_cmd_args(FLERR, fmt::format("fix {} integrator", style), error);
+      if (strcmp(arg[i + 1], "obabo") == 0)
+        integrator = OBABO;
+      else if (strcmp(arg[i + 1], "baoab") == 0)
+        integrator = BAOAB;
+      else
+        error->all(FLERR, "Unknown integrator parameter for fix {}", style);
+      i += 2;
+    } else if (strcmp(arg[i], "temp") == 0) {
+      if (i + 2 > narg) utils::missing_cmd_args(FLERR, fmt::format("fix {} temp", style), error);
+      temp = utils::numeric(FLERR, arg[i + 1], false, lmp);
+      if (temp < 0.0) error->all(FLERR, "Invalid temp value for fix {}", style);
+      i += 2;
+    } else if (strcmp(arg[i], "Tdamp") == 0) {
+      if (i + 2 > narg) utils::missing_cmd_args(FLERR, fmt::format("fix {} Tdamp", style), error);
+      t_period = utils::numeric(FLERR, arg[i + 1], false, lmp);
+      i += 2;
+    } else if (strcmp(arg[i], "tchain") == 0) {
+      if (i + 2 > narg) utils::missing_cmd_args(FLERR, fmt::format("fix {} tchain", style), error);
+      mtchain = utils::inumeric(FLERR, arg[i + 1], false, lmp);
+      i += 2;
+    } else if (strcmp(arg[i], "tloop") == 0) {
+      if (i + 2 > narg) utils::missing_cmd_args(FLERR, fmt::format("fix {} tloop", style), error);
+      nc_tchain = utils::inumeric(FLERR, arg[i + 1], false, lmp);
+      i += 2;
+    } else if (strcmp(arg[i], "drag") == 0) {
+      if (i + 2 > narg) utils::missing_cmd_args(FLERR, fmt::format("fix {} drag", style), error);
+      drag = utils::numeric(FLERR, arg[i + 1], false, lmp);
+      i += 2;
+    } else if (strcmp(arg[i], "fmass") == 0) {
+      if (i + 2 > narg) utils::missing_cmd_args(FLERR, fmt::format("fix {} fmass", style), error);
+      fmass = utils::numeric(FLERR, arg[i + 1], false, lmp);
+      if (fmass < 0.0 || fmass > np) error->all(FLERR, "Invalid fmass value for fix {}", style);
+      i += 2;
+    } else if (strcmp(arg[i], "fmmode") == 0) {
+      if (i + 2 > narg)
+        utils::missing_cmd_args(FLERR, fmt::format("fix {} fmmode", style), error);
+      if (strcmp(arg[i + 1], "physical") == 0)
+        fmmode = PHYSICAL;
+      else if (strcmp(arg[i + 1], "normal") == 0)
+        fmmode = NORMAL;
+      else
+        error->all(FLERR, "Unknown fictitious mass mode for fix {}", style);
+      i += 2;
+    } else if (strcmp(arg[i], "sp") == 0) {
+      if (i + 2 > narg) utils::missing_cmd_args(FLERR, fmt::format("fix {} sp", style), error);
+      sp = utils::numeric(FLERR, arg[i + 1], false, lmp);
+      if (sp < 0.0) error->all(FLERR, "Invalid sp value for fix {}", style);
+      i += 2;
+    } else if (strcmp(arg[i], "lj") == 0) {
+      if (i + 6 > narg) utils::missing_cmd_args(FLERR, fmt::format("fix {} lj", style), error);
+      lj_epsilon = utils::numeric(FLERR, arg[i + 1], false, lmp);
+      lj_sigma = utils::numeric(FLERR, arg[i + 2], false, lmp);
+      lj_mass = utils::numeric(FLERR, arg[i + 3], false, lmp);
+      other_planck = utils::numeric(FLERR, arg[i + 4], false, lmp);
+      other_mvv2e = utils::numeric(FLERR, arg[i + 5], false, lmp);
+      i += 6;
+    } else if (strcmp(arg[i], "tau") == 0) {
+      if (i + 2 > narg) utils::missing_cmd_args(FLERR, fmt::format("fix {} tau", style), error);
+      tau = utils::numeric(FLERR, arg[i + 1], false, lmp);
+      i += 2;
+    } else if (strcmp(arg[i], "mu") == 0) {
+      if (i + 4 > narg) utils::missing_cmd_args(FLERR, fmt::format("fix {} mu", style), error);
+      mu_seen = true;
+      u_start = utils::numeric(FLERR, arg[i + 1], false, lmp);
+      u_stop = utils::numeric(FLERR, arg[i + 2], false, lmp);
+      u_target = u_start;
+      mu = u_target;
+      u_period = utils::numeric(FLERR, arg[i + 3], false, lmp);
+      i += 4;
+    } else if (strcmp(arg[i], "ne") == 0) {
+      if (i + 2 > narg) utils::missing_cmd_args(FLERR, fmt::format("fix {} ne", style), error);
+      ne_seen = true;
+      if (!Ne) Ne = new double[1];
+      *Ne = utils::numeric(FLERR, arg[i + 1], false, lmp);
+      i += 2;
+    } else if (strcmp(arg[i], "ne_velocity") == 0) {
+      if (i + 2 > narg)
+        utils::missing_cmd_args(FLERR, fmt::format("fix {} ne_velocity", style), error);
+      if (!Ne_dot) Ne_dot = new double[1];
+      *Ne_dot = utils::numeric(FLERR, arg[i + 1], false, lmp);
+      i += 2;
+    } else if (strcmp(arg[i], "dedn") == 0) {
+      if (i + 2 > narg) utils::missing_cmd_args(FLERR, fmt::format("fix {} dedn", style), error);
+      dedn_seen = true;
+      parse_dedn_source(arg[i + 1]);
+      i += 2;
+    } else if (strcmp(arg[i], "removecom") == 0) {
+      if (i + 2 > narg)
+        utils::missing_cmd_args(FLERR, fmt::format("fix {} removecom", style), error);
+      removecomflag = utils::logical(FLERR, arg[i + 1], false, lmp);
+      i += 2;
+    } else if ((strcmp(arg[i], "barostat") == 0) || (strcmp(arg[i], "iso") == 0) ||
+               (strcmp(arg[i], "aniso") == 0) || (strcmp(arg[i], "taup") == 0) ||
+               (strcmp(arg[i], "fixedpoint") == 0)) {
+      error->all(FLERR, "Pressure control is not supported by fix {}", style);
+    } else if ((strcmp(arg[i], "seed") == 0) || (strcmp(arg[i], "PILE_L_temp") == 0)) {
+      error->all(FLERR, "Legacy thermostat options are not supported by fix {}", style);
+    } else {
+      error->all(FLERR, "Unknown keyword {} for fix {}", arg[i], style);
+    }
+  }
+
+  if (!mu_seen) error->all(FLERR, "Missing mu keyword for fix {}", style);
+  if (!ne_seen) error->all(FLERR, "Missing ne keyword for fix {}", style);
+  if (!dedn_seen) error->all(FLERR, "Missing dedn keyword for fix {}", style);
+  if (t_period <= 0.0) error->all(FLERR, "Temperature damping for fix {} must be > 0.0", style);
+  if (u_period <= 0.0) error->all(FLERR, "Chemical-potential damping for fix {} must be > 0.0", style);
+
+  if (tstat_flag) {
+    int ich;
+    eta = new double[mtchain];
+    eta_dot = new double[mtchain + 1];
+    eta_dot[mtchain] = 0.0;
+    eta_dotdot = new double[mtchain];
+    for (ich = 0; ich < mtchain; ich++) eta[ich] = eta_dot[ich] = eta_dotdot[ich] = 0.0;
+    eta_mass = new double[mtchain];
+    size_vector += 4 * mtchain;
+  }
+
+  if (!Ne_dot) {
+    Ne_dot = new double[1];
+    *Ne_dot = 0.0;
+  }
+  Ne_mass = new double[1];
+  *Ne_mass = 0.0;
+  size_vector += 6;
+  extlist = new int[size_vector];
+  for (int i = 0; i < size_vector; i++) extlist[i] = 1;
+  for (int i = size_vector - 6; i < size_vector; i++) extlist[i] = 0;
+  u_freq = 1.0 / u_period;
+  u_current = u_start;
+
+  id_pe = utils::strdup(std::string(id) + "_pimd_pe");
+  modify->add_compute(fmt::format("{} all pe", id_pe));
+
+  id_press = utils::strdup(std::string(id) + "_pimd_press");
+  modify->add_compute(fmt::format("{} all pressure NULL virial", id_press));
+
+  ntotal = atom->natoms;
+  nreplica = np;
+
+  if (mass == nullptr) mass = new double[atom->ntypes + 1];
+  for (int i = 1; i <= atom->ntypes; i++) mass[i] = atom->mass[i] * fmass;
+
+  fixedpoint[0] = 0.5 * (domain->boxlo[0] + domain->boxhi[0]);
+  fixedpoint[1] = 0.5 * (domain->boxlo[1] + domain->boxhi[1]);
+  fixedpoint[2] = 0.5 * (domain->boxlo[2] + domain->boxhi[2]);
+}
+
+/* ---------------------------------------------------------------------- */
+
+FixTPRPMD::~FixTPRPMD()
+{
+  modify->delete_compute(id_pe);
+  modify->delete_compute(id_press);
+  delete[] id_pe;
+  delete[] id_press;
+  delete[] extlist;
+  delete[] mass;
+  delete[] _omega_k;
+  delete[] Lan_c;
+  delete[] Lan_s;
+  delete[] tau_k;
+  delete[] plansend;
+  delete[] planrecv;
+  delete[] modeindex;
+  memory->destroy(xcall);
+  if (cmode == SINGLE_PROC) {
+    memory->destroy(bufsorted);
+    memory->destroy(bufsortedall);
+    memory->destroy(counts);
+    memory->destroy(displacements);
+  }
+
+  if (cmode == MULTI_PROC) {
+    memory->destroy(bufsendall);
+    memory->destroy(bufrecvall);
+    memory->destroy(tagsendall);
+    memory->destroy(tagrecvall);
+    memory->destroy(counts);
+    memory->destroy(displacements);
+  }
+  memory->destroy(M_x2xp);
+  memory->destroy(M_xp2x);
+  memory->destroy(xc);
+  memory->destroy(x_unwrap);
+  memory->destroy(bufsend);
+  memory->destroy(bufrecv);
+  memory->destroy(tagsend);
+  memory->destroy(tagrecv);
+  memory->destroy(bufbeads);
+
+  if (thermostat == NHC) {
+    if (tstat_flag) {
+      delete [] eta;
+      delete [] eta_dot;
+      delete [] eta_dotdot;
+      delete [] eta_mass;
+    }
+    if (ustat_flag) {
+      delete [] Ne;
+      delete [] Ne_dot;
+      delete [] Ne_mass;
+    }
+  }
+  delete[] dedn_name;
+}
+
+/* ---------------------------------------------------------------------- */
+
+bool FixTPRPMD::nuclear_thermostat_off() const
+{
+  return method == TPRPMD && np != 1 && universe->iworld == 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+bool FixTPRPMD::ne_thermostat_participates() const
+{
+  if (!ustat_flag) return false;
+  if (method != TPRPMD) return true;
+  return (np == 1) ? true : (universe->iworld != 0);
+}
+
+/* ---------------------------------------------------------------------- */
+
+bool FixTPRPMD::nhc_chain_active() const
+{
+  return !nuclear_thermostat_off() || ne_thermostat_participates();
+}
+
+/* ---------------------------------------------------------------------- */
+
+double FixTPRPMD::chain0_target_energy() const
+{
+  return nuclear_thermostat_off() ? 0.0 : static_cast<double>(np) * ke_target;
+}
+
+/* ---------------------------------------------------------------------- */
+
+double FixTPRPMD::ne_kinetic_current_share() const
+{
+  if (!ne_thermostat_participates()) return 0.0;
+  return 0.5 * inverse_np * (*Ne_mass) * (*Ne_dot) * (*Ne_dot);
+}
+
+/* ---------------------------------------------------------------------- */
+
+int FixTPRPMD::setmask()
+{
+  int mask = 0;
+  mask |= POST_FORCE;
+  mask |= INITIAL_INTEGRATE;
+  mask |= FINAL_INTEGRATE;
+  mask |= END_OF_STEP;
+  return mask;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::init()
+{
+  if (atom->map_style == Atom::MAP_NONE)
+    error->all(FLERR, "Fix tprpmd requires an atom map, see atom_modify");
+
+  if (comm->nprocs != 1)
+    error->all(FLERR, "Fix tprpmd currently requires one MPI rank per bead");
+
+  if (universe->me == 0 && universe->uscreen)
+    fprintf(universe->uscreen, "Fix tprpmd: initializing Path-Integral ...\n");
+
+  // prepare the constants
+
+  masstotal = group->mass(igroup);
+
+  double planck;
+  if (strcmp(update->unit_style, "lj") == 0) {
+    double planck_star = sqrt(lj_epsilon) * sqrt(lj_mass) * lj_sigma * sqrt(other_mvv2e);
+    planck = other_planck / planck_star;
+  } else {
+    planck = force->hplanck;
+  }
+  planck *= sp;
+  hbar = planck / (MY_2PI);
+  kt = force->boltz * temp;
+  beta = 1.0 / kt;
+  double _fbond = 1.0 * np * np / (beta * beta * hbar * hbar);
+
+  dedn_var = -1;
+  dedn_compute = nullptr;
+  dedn_fix = nullptr;
+
+  if (dedn_index < 0)
+    error->all(FLERR, "Illegal dedn index {} for fix {}", dedn_index, style);
+
+  if (dedn_which == ArgInfo::VARIABLE) {
+    dedn_var = input->variable->find(dedn_name);
+    if (dedn_var < 0) error->all(FLERR, "Variable {} for fix {} does not exist", dedn_name, style);
+    if (dedn_index == 0) {
+      if (!input->variable->equalstyle(dedn_var))
+        error->all(FLERR, "Variable {} for fix {} is not equal-style", dedn_name, style);
+    } else if (!input->variable->vectorstyle(dedn_var)) {
+      error->all(FLERR, "Variable {} for fix {} is not vector-style", dedn_name, style);
+    }
+  } else if (dedn_which == ArgInfo::COMPUTE) {
+    dedn_compute = modify->get_compute_by_id(dedn_name);
+    if (!dedn_compute) error->all(FLERR, "Compute {} for fix {} does not exist", dedn_name, style);
+    if (dedn_index == 0) {
+      if (!dedn_compute->scalar_flag)
+        error->all(FLERR, "Compute {} for fix {} does not compute a scalar", dedn_name, style);
+    } else {
+      if (!dedn_compute->vector_flag)
+        error->all(FLERR, "Compute {} for fix {} does not compute a vector", dedn_name, style);
+      if (dedn_compute->size_vector > 0 && dedn_index > dedn_compute->size_vector)
+        error->all(FLERR, "Compute {} for fix {} vector index {} is out of range", dedn_name, style,
+                   dedn_index);
+    }
+  } else if (dedn_which == ArgInfo::FIX) {
+    dedn_fix = modify->get_fix_by_id(dedn_name);
+    if (!dedn_fix) error->all(FLERR, "Fix {} for fix {} does not exist", dedn_name, style);
+    if (dedn_index == 0) {
+      if (!dedn_fix->scalar_flag)
+        error->all(FLERR, "Fix {} for fix {} does not compute a scalar", dedn_name, style);
+    } else {
+      if (!dedn_fix->vector_flag)
+        error->all(FLERR, "Fix {} for fix {} does not compute a vector", dedn_name, style);
+      if (dedn_fix->size_vector > 0 && dedn_index > dedn_fix->size_vector)
+        error->all(FLERR, "Fix {} for fix {} vector index {} is out of range", dedn_name, style,
+                   dedn_index);
+    }
+  } else {
+    error->all(FLERR, "dedn for fix {} must be a variable, compute, or fix reference", style);
+  }
+
+  omega_np = np / (hbar * beta) * sqrt(force->mvv2e);
+  beta_np = 1.0 / force->boltz / temp * inverse_np;
+  fbond = _fbond * force->mvv2e;
+
+  if ((universe->me == 0) && (universe->uscreen))
+    fprintf(universe->uscreen,
+            "Fix tprpmd: -P/(beta^2 * hbar^2) = %20.7lE (kcal/mol/A^2)\n\n", fbond);
+
+  me = comm->me;
+  nprocs = comm->nprocs;
+  cmode = (nprocs == 1) ? SINGLE_PROC : MULTI_PROC;
+
+  nprocs_universe = universe->nprocs;
+  nreplica = universe->nworlds;
+  ireplica = universe->iworld;
+  mapflag = (nreplica == 1) ? 0 : 1;
+
+  int *iroots = new int[nreplica];
+  MPI_Group uworldgroup, rootgroup;
+  for (int i = 0; i < nreplica; i++) iroots[i] = universe->root_proc[i];
+  MPI_Comm_group(universe->uworld, &uworldgroup);
+  MPI_Group_incl(uworldgroup, nreplica, iroots, &rootgroup);
+  MPI_Comm_create(universe->uworld, rootgroup, &rootworld);
+  if (rootgroup != MPI_GROUP_NULL) MPI_Group_free(&rootgroup);
+  if (uworldgroup != MPI_GROUP_NULL) MPI_Group_free(&uworldgroup);
+  delete[] iroots;
+
+  ntotal = atom->natoms;
+  if (atom->nmax > maxlocal) reallocate();
+  if (atom->nmax > maxunwrap) reallocate_x_unwrap();
+  if (atom->nmax > maxxc) reallocate_xc();
+
+  if (integrator == OBABO) {
+    dtf = 0.5 * update->dt * force->ftm2v;
+    dtv = 0.5 * update->dt;
+    dtv2 = dtv * dtv;
+    dtv3 = THIRD * dtv2 * dtv * force->ftm2v;
+    dthalf = 0.5 * update->dt;
+    dt4 = 0.25 * update->dt;
+    dt8 = 0.125 * update->dt;
+  } else if (integrator == BAOAB) {
+    dtf = 0.5 * update->dt * force->ftm2v;
+    dtv = 0.5 * update->dt;
+    dtv2 = dtv * dtv;
+    dtv3 = THIRD * dtv2 * dtv * force->ftm2v;
+    dthalf = 0.5 * update->dt;
+    dt4 = 0.25 * update->dt;
+    dt8 = 0.125 * update->dt;
+  } else {
+    error->universe_all(FLERR, "Unknown integrator parameter for fix tprpmd");
+  }
+
+  comm_init();
+  if (mass == nullptr) mass = new double[atom->ntypes + 1];
+  if (xcall == nullptr) memory->create(xcall, ntotal * 3, "FixTPRPMD:xcall");
+  nmpimd_init();
+  nhc_init();
+
+  c_pe = modify->get_compute_by_id(id_pe);
+  if (!c_pe)
+    error->universe_all(
+        FLERR, fmt::format("Could not find fix {} potential energy compute ID {}", style, id_pe));
+
+  c_press = modify->get_compute_by_id(id_press);
+  if (!c_press)
+    error->universe_all(
+        FLERR, fmt::format("Could not find fix {} pressure compute ID {}", style, id_press));
+
+  t_prim = t_vir = t_cv = p_cv = p_md = 0.0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::setup(int vflag)
+{
+  int nlocal = atom->nlocal;
+  double **x = atom->x;
+  imageint *image = atom->image;
+
+  compute_mu_target();
+  *Ne_mass = tdof * force->boltz * temp / (u_freq * u_freq);
+
+  if (mapflag) {
+    for (int i = 0; i < nlocal; i++) domain->unmap(x[i], image[i]);
+  }
+
+  inter_replica_comm(x);
+  if (cmode == SINGLE_PROC)
+    nmpimd_transform(bufsortedall, x, M_x2xp[universe->iworld]);
+  else if (cmode == MULTI_PROC)
+    nmpimd_transform(bufbeads, x, M_x2xp[universe->iworld]);
+  collect_xc();
+  compute_spring_energy();
+  compute_t_prim();
+  compute_p_prim();
+  inter_replica_comm(x);
+  if (cmode == SINGLE_PROC)
+    nmpimd_transform(bufsortedall, x, M_xp2x[universe->iworld]);
+  else if (cmode == MULTI_PROC)
+    nmpimd_transform(bufbeads, x, M_xp2x[universe->iworld]);
+  if (mapflag) {
+    for (int i = 0; i < nlocal; i++) domain->unmap_inv(x[i], image[i]);
+  }
+
+  post_force(vflag);
+  compute_totke();
+  end_of_step();
+  c_pe->addstep(update->ntimestep + 1);
+  c_press->addstep(update->ntimestep + 1);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::initial_integrate(int /*vflag*/)
+{
+  double *Ne = this->Ne;
+  int nlocal = atom->nlocal;
+  double **x = atom->x;
+  imageint *image = atom->image;
+  if (mapflag) {
+    for (int i = 0; i < nlocal; i++) domain->unmap(x[i], image[i]);
+  }
+  if (integrator == OBABO) {
+    if (tstat_flag) {
+      o_step();
+      if (removecomflag) remove_com_motion();
+    }
+    b_step();
+    inter_replica_comm(x);
+    if (cmode == SINGLE_PROC)
+      nmpimd_transform(bufsortedall, x, M_x2xp[universe->iworld]);
+    else if (cmode == MULTI_PROC)
+      nmpimd_transform(bufbeads, x, M_x2xp[universe->iworld]);
+    qc_step();
+    a_step();
+    qc_step();
+    a_step();
+  } else if (integrator == BAOAB) {
+    b_step();
+    inter_replica_comm(x);
+    if (cmode == SINGLE_PROC)
+      nmpimd_transform(bufsortedall, x, M_x2xp[universe->iworld]);
+    else if (cmode == MULTI_PROC)
+      nmpimd_transform(bufbeads, x, M_x2xp[universe->iworld]);
+    qc_step();
+    a_step();
+    if (tstat_flag) {
+      o_step();
+      if (removecomflag) remove_com_motion();
+    }
+    qc_step();
+    a_step();
+  } else {
+    error->universe_all(FLERR,
+                        "Unknown integrator parameter for fix tprpmd. Only obabo and baoab "
+                        "integrators are supported!");
+  }
+  collect_xc();
+
+  compute_spring_energy();
+  compute_t_prim();
+  compute_p_prim();
+  inter_replica_comm(x);
+  if (cmode == SINGLE_PROC)
+    nmpimd_transform(bufsortedall, x, M_xp2x[universe->iworld]);
+  else if (cmode == MULTI_PROC)
+    nmpimd_transform(bufbeads, x, M_xp2x[universe->iworld]);
+
+  if (mapflag) {
+    for (int i = 0; i < nlocal; i++) { domain->unmap_inv(x[i], image[i]); }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::final_integrate()
+{
+  b_step();
+
+  if (integrator == OBABO) {
+    if (tstat_flag) {
+      o_step();
+      if (removecomflag) remove_com_motion();
+    }
+  } else if (integrator == BAOAB) {
+
+  } else {
+    error->universe_all(FLERR, "Unknown integrator parameter for fix tprpmd");
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::post_force(int /*flag*/)
+{
+  int nlocal = atom->nlocal;
+  double **x = atom->x;
+  double **f = atom->f;
+  imageint *image = atom->image;
+  tagint *tag = atom->tag;
+
+  if (atom->nmax > maxunwrap) reallocate_x_unwrap();
+  if (atom->nmax > maxxc) reallocate_xc();
+  for (int i = 0; i < nlocal; i++) {
+    x_unwrap[i][0] = x[i][0];
+    x_unwrap[i][1] = x[i][1];
+    x_unwrap[i][2] = x[i][2];
+  }
+  if (mapflag) {
+    for (int i = 0; i < nlocal; i++) { domain->unmap(x_unwrap[i], image[i]); }
+  }
+  for (int i = 0; i < nlocal; i++) {
+    xc[i][0] = xcall[3 * (tag[i] - 1) + 0];
+    xc[i][1] = xcall[3 * (tag[i] - 1) + 1];
+    xc[i][2] = xcall[3 * (tag[i] - 1) + 2];
+  }
+
+  compute_vir();
+  compute_xf_vir();
+  compute_cvir();
+  compute_t_vir();
+
+  compute_pote();
+  inter_replica_comm(f);
+  if (cmode == SINGLE_PROC)
+    nmpimd_transform(bufsortedall, f, M_x2xp[universe->iworld]);
+  else if (cmode == MULTI_PROC)
+    nmpimd_transform(bufbeads, f, M_x2xp[universe->iworld]);
+
+  // Sample the FD dE/dN signal once per force evaluation and reuse it
+  // throughout the rest of this MD step.
+  if (ustat_flag) refresh_dedn_cache();
+
+  c_pe->addstep(update->ntimestep + 1);
+  c_press->addstep(update->ntimestep + 1);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::end_of_step()
+{
+  compute_totke();
+  compute_p_cv();
+  compute_tote();
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::collect_xc()
+{
+  int nlocal = atom->nlocal;
+  double **x = atom->x;
+  tagint *tag = atom->tag;
+  if (ireplica == 0) {
+    if (cmode == SINGLE_PROC) {
+      for (int i = 0; i < nlocal; i++) {
+        xcall[3 * i + 0] = xcall[3 * i + 1] = xcall[3 * i + 2] = 0.0;
+      }
+    } else if (cmode == MULTI_PROC) {
+      for (int i = 0; i < ntotal; i++) {
+        xcall[3 * i + 0] = xcall[3 * i + 1] = xcall[3 * i + 2] = 0.0;
+      }
+    }
+
+    const double sqrtnp = sqrt((double) np);
+    for (int i = 0; i < nlocal; i++) {
+      xcall[3 * (tag[i] - 1) + 0] = x[i][0] / sqrtnp;
+      xcall[3 * (tag[i] - 1) + 1] = x[i][1] / sqrtnp;
+      xcall[3 * (tag[i] - 1) + 2] = x[i][2] / sqrtnp;
+    }
+
+    if (cmode == MULTI_PROC) {
+      MPI_Allreduce(MPI_IN_PLACE, xcall, ntotal * 3, MPI_DOUBLE, MPI_SUM, world);
+    }
+  }
+  MPI_Bcast(xcall, ntotal * 3, MPI_DOUBLE, 0, universe->uworld);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::b_step()
+{
+  // The force here is the external potential contribution in normal-mode space;
+  // the harmonic ring-polymer propagation is handled separately in the A/QC steps.
+  int n = atom->nlocal;
+  int *type = atom->type;
+  double **v = atom->v;
+  double **f = atom->f;
+
+  for (int i = 0; i < n; i++) {
+    double dtfm = dtf / mass[type[i]];
+    v[i][0] += dtfm * f[i][0];
+    v[i][1] += dtfm * f[i][1];
+    v[i][2] += dtfm * f[i][2];
+  }
+
+  if (ustat_flag) {
+    double dtfm = dthalf / *Ne_mass;
+    if (universe->iworld == 0) *Ne_dot += dtfm * (-dedn_current + u_target);
+    MPI_Bcast(Ne_dot, 1, MPI_DOUBLE, 0, universe->uworld);
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::qc_step()
+{
+  int nlocal = atom->nlocal;
+  double **x = atom->x;
+  double **v = atom->v;
+  double *Ne = this->Ne;
+  if (universe->iworld == 0) {
+    for (int i = 0; i < nlocal; i++) {
+      x[i][0] += dtv * v[i][0];
+      x[i][1] += dtv * v[i][1];
+      x[i][2] += dtv * v[i][2];
+    }
+    if (ustat_flag) *Ne += dtv * (*Ne_dot);
+  }
+  if (ustat_flag) MPI_Bcast(Ne, 1, MPI_DOUBLE, 0, universe->uworld);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::a_step()
+{
+  // Use the analytical harmonic-oscillator update for the non-centroid modes.
+  int n = atom->nlocal;
+  double **x = atom->x;
+  double **v = atom->v;
+  double x0, x1, x2, v0, v1, v2;    // three components of x[i] and v[i]
+
+  if (universe->iworld != 0) {
+    for (int i = 0; i < n; i++) {
+      x0 = x[i][0];
+      x1 = x[i][1];
+      x2 = x[i][2];
+      v0 = v[i][0];
+      v1 = v[i][1];
+      v2 = v[i][2];
+      x[i][0] = Lan_c[universe->iworld] * x0 +
+          1.0 / _omega_k[universe->iworld] * Lan_s[universe->iworld] * v0;
+      x[i][1] = Lan_c[universe->iworld] * x1 +
+          1.0 / _omega_k[universe->iworld] * Lan_s[universe->iworld] * v1;
+      x[i][2] = Lan_c[universe->iworld] * x2 +
+          1.0 / _omega_k[universe->iworld] * Lan_s[universe->iworld] * v2;
+      v[i][0] = -1.0 * _omega_k[universe->iworld] * Lan_s[universe->iworld] * x0 +
+          Lan_c[universe->iworld] * v0;
+      v[i][1] = -1.0 * _omega_k[universe->iworld] * Lan_s[universe->iworld] * x1 +
+          Lan_c[universe->iworld] * v1;
+      v[i][2] = -1.0 * _omega_k[universe->iworld] * Lan_s[universe->iworld] * x2 +
+          Lan_c[universe->iworld] * v2;
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::nhc_init()
+{
+  if (kt <= 0.0 || hbar <= 0.0)
+    error->universe_all(FLERR, "Fix tprpmd requires positive kt and hbar in nhc_init");
+
+  const double beta_local = 1.0 / kt;
+  const double _omega_np = np / beta_local / hbar;
+  double _omega_np_dt_half = _omega_np * update->dt * 0.5;
+
+  _omega_k = new double[np];
+  Lan_c = new double[np];
+  Lan_s = new double[np];
+  if (fmmode == PHYSICAL) {
+    for (int i = 0; i < np; i++) {
+      _omega_k[i] = _omega_np * sqrt(lam[i]) / sqrt(fmass);
+      Lan_c[i] = cos(sqrt(lam[i]) * _omega_np_dt_half);
+      Lan_s[i] = sin(sqrt(lam[i]) * _omega_np_dt_half);
+    }
+  } else if (fmmode == NORMAL) {
+    for (int i = 0; i < np; i++) {
+      _omega_k[i] = _omega_np / sqrt(fmass);
+      Lan_c[i] = cos(_omega_np_dt_half);
+      Lan_s[i] = sin(_omega_np_dt_half);
+    }
+  } else {
+    error->universe_all(FLERR, "Unknown fmmode setting; only physical and normal are supported!");
+  }
+
+  if (tstat_flag) {
+    t_freq = 1.0 / t_period;
+    tdrag_factor = 1.0 - (update->dt * t_freq * drag / nc_tchain);
+  }
+
+  if (ustat_flag) {
+    u_freq = 1.0 / u_period;
+  }
+
+  int fix_dof = 0;
+  for (auto &ifix : modify->get_fix_list())
+    if (ifix->dof_flag){
+      fix_dof += ifix->dof(igroup);
+    }
+  int extra_dof = domain->dimension;
+  tdof = domain->dimension * group->count(igroup);
+  tdof -= extra_dof + fix_dof;
+
+  ke_target = tdof * force->boltz * temp;
+
+  if (tstat_flag) {
+    const double chain0_target = chain0_target_energy();
+    const double chain_target = nhc_chain_active() ? static_cast<double>(np) * force->boltz * temp : 0.0;
+    eta_mass[0] = chain0_target / (t_freq * t_freq);
+    for (int ich = 1; ich < mtchain; ich++) {
+      eta_mass[ich] = (np == 1) ? chain_target / (t_freq * t_freq)
+                                : chain_target / (_omega_np * _omega_np);
+      if (eta_mass[ich] > 0.0)
+        eta_dotdot[ich] =
+            (eta_mass[ich - 1] * eta_dot[ich - 1] * eta_dot[ich - 1] - chain_target) /
+            eta_mass[ich];
+      else
+        eta_dotdot[ich] = 0.0;
+    }
+    if (!nhc_chain_active()) {
+      for (int ich = 1; ich < mtchain; ich++) eta_dotdot[ich] = 0;
+    }
+  }
+
+  if (ustat_flag) *Ne_mass = tdof * force->boltz * temp / (u_freq * u_freq);
+
+  std::string out = "Initializing TP path-integral Nose-Hoover thermostat chain...\n";
+  out += "  Bead ID    |    omega    |    tau\n";
+  tau_k = new double[np];
+  tau_k[0] = tau;
+  for (int i = 1; i < np; i++) tau_k[i] = 0.5 / pilescale / _omega_k[i];
+  for (int i = 0; i < np; i++) {
+    out += fmt::format("      {:d}     {:.8e} {:.8e}\n", i, _omega_k[i], tau_k[i]);
+  }
+  out += "  NHC thermostat successfully initialized!\n\n";
+  if (universe->me == 0) utils::logmesg(lmp, out);
+}
+
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::o_step()
+{
+  if (tstat_flag) {
+    if (ustat_flag) {
+      compute_mu_target();
+      nhc_mu_integrate();
+    }
+    else nhc_temp_integrate();
+  }
+}
+
+void FixTPRPMD::nhc_temp_integrate()
+{
+  int ich;
+  double expfac;
+  int *type = atom->type;
+  double **v = atom->v;
+  int nlocal = atom->nlocal;
+  double kecurrent = 0, t_current;
+
+  for (int i = 0; i < nlocal; i++) {
+    kecurrent += (v[i][0] * v[i][0] + v[i][1] * v[i][1] + v[i][2] * v[i][2]) * mass[type[i]];
+  }
+  kecurrent *= force->mvv2e;
+
+  t_current = kecurrent / force->boltz / tdof;
+
+  if (nuclear_thermostat_off()) return;
+
+  const double chain0_target = chain0_target_energy();
+  const double chain_target = nhc_chain_active() ? static_cast<double>(np) * force->boltz * temp : 0.0;
+  if (eta_mass[0] > 0.0)
+    eta_dotdot[0] = (kecurrent - chain0_target) / eta_mass[0];
+  else eta_dotdot[0] = 0.0;
+
+  double ncfac = 1.0/nc_tchain;
+  for (int iloop = 0; iloop < nc_tchain; iloop++) {
+
+    for (ich = mtchain-1; ich > 0; ich--) {
+      expfac = exp(-ncfac*dt8*eta_dot[ich+1]);
+      eta_dot[ich] *= expfac;
+      eta_dot[ich] += eta_dotdot[ich] * ncfac*dt4;
+      eta_dot[ich] *= tdrag_factor;
+      eta_dot[ich] *= expfac;
+    }
+
+    expfac = exp(-ncfac*dt8*eta_dot[1]);
+    eta_dot[0] *= expfac;
+    eta_dot[0] += eta_dotdot[0] * ncfac*dt4;
+    eta_dot[0] *= tdrag_factor;
+    eta_dot[0] *= expfac;
+
+    factor_eta = exp(-ncfac*dthalf*eta_dot[0]);
+    nh_v_temp();
+
+    // rescale temperature due to velocity scaling
+    // should not be necessary to explicitly recompute the temperature
+
+    t_current *= factor_eta*factor_eta;
+    kecurrent = tdof * force->boltz * t_current;
+
+    if (eta_mass[0] > 0.0)
+      eta_dotdot[0] = (kecurrent - chain0_target) / eta_mass[0];
+    else eta_dotdot[0] = 0.0;
+
+    for (ich = 0; ich < mtchain; ich++)
+      eta[ich] += ncfac*dthalf*eta_dot[ich];
+
+    eta_dot[0] *= expfac;
+    eta_dot[0] += eta_dotdot[0] * ncfac*dt4;
+    eta_dot[0] *= expfac;
+
+    for (ich = 1; ich < mtchain; ich++) {
+      expfac = exp(-ncfac*dt8*eta_dot[ich+1]);
+      eta_dot[ich] *= expfac;
+      eta_dotdot[ich] = (eta_mass[ich-1]*eta_dot[ich-1]*eta_dot[ich-1] - chain_target) /
+          eta_mass[ich];
+      eta_dot[ich] += eta_dotdot[ich] * ncfac*dt4;
+      eta_dot[ich] *= expfac;
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::nhc_mu_integrate()
+{
+  int ich;
+  double expfac;
+  int *type = atom->type;
+  double **v = atom->v;
+  int nlocal = atom->nlocal;
+  double kecurrent = 0, t_current;
+
+  for (int i = 0; i < nlocal; i++) {
+    kecurrent += (v[i][0] * v[i][0] + v[i][1] * v[i][1] + v[i][2] * v[i][2]) * mass[type[i]];
+  }
+  kecurrent *= force->mvv2e;
+
+  t_current = kecurrent / force->boltz / tdof;
+
+  const double chain0_target = chain0_target_energy();
+  const double chain_target = nhc_chain_active() ? static_cast<double>(np) * force->boltz * temp : 0.0;
+  if (method == TPRPMD && np != 1 && universe->iworld == 0)
+    ;
+  else {
+    if (eta_mass[0] > 0.0)
+      eta_dotdot[0] = (kecurrent + ne_kinetic_current_share() - chain0_target) / eta_mass[0];
+    else eta_dotdot[0] = 0.0;
+  }
+
+  double ncfac = 1.0 / nc_tchain;
+  for (int iloop = 0; iloop < nc_tchain; iloop++) {
+
+    if (method == TPRPMD && np != 1 && universe->iworld == 0)
+      ;
+    else {
+
+      for (ich = mtchain - 1; ich > 0; ich--) {
+        expfac = exp(-ncfac * dt8 * eta_dot[ich + 1]);
+        eta_dot[ich] *= expfac;
+        eta_dot[ich] += eta_dotdot[ich] * ncfac * dt4;
+        eta_dot[ich] *= tdrag_factor;
+        eta_dot[ich] *= expfac;
+      }
+
+      expfac = exp(-ncfac * dt8 * eta_dot[1]);
+      eta_dot[0] *= expfac;
+      eta_dot[0] += eta_dotdot[0] * ncfac * dt4;
+      eta_dot[0] *= tdrag_factor;
+      eta_dot[0] *= expfac;
+
+      factor_eta = exp(-ncfac * dthalf * eta_dot[0]);
+      nh_v_temp();
+    }
+
+    double eta_dot_k = eta_dot[0], eta_dot_ave = 0;
+    MPI_Barrier(universe->uworld);
+    MPI_Allreduce(&eta_dot_k, &eta_dot_ave, 1, MPI_DOUBLE, MPI_SUM, universe->uworld);
+
+    if (method == TPRPMD && np != 1) {
+      eta_dot_ave = eta_dot_ave / (static_cast<double>(np) - 1);
+    } else {
+      eta_dot_ave *= inverse_np;
+    }
+    MPI_Barrier(universe->uworld);
+    MPI_Bcast(&eta_dot_ave, 1, MPI_DOUBLE, 0, universe->uworld);
+
+    *Ne_dot *= exp(-ncfac * dthalf * eta_dot_ave);
+
+    // rescale temperature due to velocity scaling
+    // should not be necessary to explicitly recompute the temperature
+    if (method == TPRPMD && np != 1 && universe->iworld == 0)
+      ;
+    else {
+      t_current *= factor_eta * factor_eta;
+      kecurrent = tdof * force->boltz * t_current;
+
+      if (eta_mass[0] > 0.0)
+        eta_dotdot[0] =
+            (kecurrent + ne_kinetic_current_share() - chain0_target) / eta_mass[0];
+      else eta_dotdot[0] = 0.0;
+
+      for (ich = 0; ich < mtchain; ich++)
+        eta[ich] += ncfac * dthalf * eta_dot[ich];
+
+      eta_dot[0] *= expfac;
+      eta_dot[0] += eta_dotdot[0] * ncfac * dt4;
+      eta_dot[0] *= expfac;
+
+      for (ich = 1; ich < mtchain; ich++) {
+        expfac = exp(-ncfac * dt8 * eta_dot[ich + 1]);
+        eta_dot[ich] *= expfac;
+        eta_dotdot[ich] =
+            (eta_mass[ich - 1] * eta_dot[ich - 1] * eta_dot[ich - 1] - chain_target) /
+            eta_mass[ich];
+        eta_dot[ich] += eta_dotdot[ich] * ncfac * dt4;
+        eta_dot[ich] *= expfac;
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::nh_v_temp()
+{
+  double **v = atom->v;
+  int *mask = atom->mask;
+  int nlocal = atom->nlocal;
+
+  for (int i = 0; i < nlocal; i++) {
+    if (mask[i] & groupbit) {
+      v[i][0] *= factor_eta;
+      v[i][1] *= factor_eta;
+      v[i][2] *= factor_eta;
+    }
+  }
+}
+
+/* ----------------------------------------------------------------------
+   Normal-mode ring-polymer operations
+   ------------------------------------------------------------------------- */
+
+void FixTPRPMD::nmpimd_init()
+{
+  memory->create(M_x2xp, np, np, "fix_feynman:M_x2xp");
+  memory->create(M_xp2x, np, np, "fix_feynman:M_xp2x");
+
+  lam = (double *) memory->smalloc(sizeof(double) * np, "FixTPRPMD::lam");
+
+  // Set up  eigenvalues
+  for (int i = 0; i < np; i++) {
+    double sin_tmp = sin(i * MY_PI / np);
+    lam[i] = 4 * sin_tmp * sin_tmp;
+  }
+
+  for (int i = 0; i < np; i++) {
+    if (!std::isfinite(lam[i])) error->universe_all(FLERR, "Fix tprpmd encountered invalid lambda");
+  }
+
+  // Set up eigenvectors for degenerated modes
+  const double sqrtnp = sqrt((double) np);
+  for (int j = 0; j < np; j++) {
+    for (int i = 1; i < int(np / 2) + 1; i++) {
+      M_x2xp[i][j] = MY_SQRT2 * cos(MY_2PI * double(i) * double(j) / double(np)) / sqrtnp;
+    }
+    for (int i = int(np / 2) + 1; i < np; i++) {
+      M_x2xp[i][j] = MY_SQRT2 * sin(MY_2PI * double(i) * double(j) / double(np)) / sqrtnp;
+    }
+  }
+
+  // Set up eigenvectors for non-degenerated modes
+  for (int i = 0; i < np; i++) {
+    M_x2xp[0][i] = 1.0 / sqrtnp;
+    if (np % 2 == 0) M_x2xp[np / 2][i] = 1.0 / sqrtnp * powint(-1.0, i);
+  }
+
+  // Set up Ut
+  for (int i = 0; i < np; i++)
+    for (int j = 0; j < np; j++) { M_xp2x[i][j] = M_x2xp[j][i]; }
+
+  // Set up fictitious masses
+  int iworld = universe->iworld;
+  for (int i = 1; i <= atom->ntypes; i++) {
+    mass[i] = atom->mass[i];
+    mass[i] *= fmass;
+    if (iworld) {
+      if (fmmode == PHYSICAL) {
+        mass[i] *= 1.0;
+      } else if (fmmode == NORMAL) {
+        mass[i] *= lam[iworld];
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::nmpimd_transform(double **src, double **des, double *vector)
+{
+  if (cmode == SINGLE_PROC) {
+    for (int i = 0; i < ntotal; i++) {
+      for (int d = 0; d < 3; d++) {
+        bufsorted[i][d] = 0.0;
+        for (int j = 0; j < nreplica; j++) {
+          bufsorted[i][d] += src[j * ntotal + i][d] * vector[j];
+        }
+      }
+    }
+    for (int i = 0; i < ntotal; i++) {
+      tagint tagtmp = atom->tag[i];
+      for (int d = 0; d < 3; d++) { des[i][d] = bufsorted[tagtmp - 1][d]; }
+    }
+  } else if (cmode == MULTI_PROC) {
+    int n = atom->nlocal;
+    int m = 0;
+
+    for (int i = 0; i < n; i++)
+      for (int d = 0; d < 3; d++) {
+        des[i][d] = 0.0;
+        for (int j = 0; j < np; j++) { des[i][d] += (src[j][m] * vector[j]); }
+        m++;
+      }
+  }
+}
+
+/* ----------------------------------------------------------------------
+   Comm operations
+   ------------------------------------------------------------------------- */
+
+void FixTPRPMD::comm_init()
+{
+  if (np != universe->nworlds) error->all(FLERR, "Fix tprpmd: np must equal universe->nworlds");
+
+  int nlocal = atom->nlocal;
+  if (cmode == SINGLE_PROC) {
+    memory->destroy(counts);
+    memory->destroy(displacements);
+    memory->create(counts, nreplica, "FixTPRPMD:counts");
+    memory->create(displacements, nreplica, "FixTPRPMD:displacements");
+    for (int i = 0; i < nreplica; i++) counts[i] = 3 * nlocal;
+    displacements[0] = 0;
+    for (int i = 0; i < nreplica - 1; i++) displacements[i + 1] = displacements[i] + counts[i];
+  }
+
+  if (sizeplan) {
+    delete[] plansend;
+    delete[] planrecv;
+  }
+
+  sizeplan = np - 1;
+  plansend = new int[sizeplan];
+  planrecv = new int[sizeplan];
+  modeindex = new int[sizeplan];
+  for (int i = 0; i < sizeplan; i++) {
+    int isend = ireplica + i + 1;
+    if (isend >= nreplica) isend -= nreplica;
+
+    int irecv = ireplica - (i + 1);
+    if (irecv < 0) irecv += nreplica;
+
+    plansend[i] = universe->root_proc[isend];
+    planrecv[i] = universe->root_proc[irecv];
+    modeindex[i] = irecv;
+  }
+
+  x_next = (universe->iworld + 1 + universe->nworlds) % (universe->nworlds);
+  x_last = (universe->iworld - 1 + universe->nworlds) % (universe->nworlds);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::reallocate_xc()
+{
+  maxxc = atom->nmax;
+  memory->destroy(xc);
+  memory->create(xc, maxxc, 3, "FixTPRPMD:xc");
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::reallocate_x_unwrap()
+{
+  maxunwrap = atom->nmax;
+  memory->destroy(x_unwrap);
+  memory->create(x_unwrap, maxunwrap, 3, "FixTPRPMD:x_unwrap");
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::reallocate()
+{
+  maxlocal = atom->nmax;
+  ntotal = atom->natoms;
+  if (cmode == SINGLE_PROC) {
+    memory->destroy(bufsorted);
+    memory->destroy(bufsortedall);
+    memory->create(bufsorted, ntotal, 3, "FixTPRPMD:bufsorted");
+    memory->create(bufsortedall, nreplica * ntotal, 3, "FixTPRPMD:bufsortedall");
+  } else if (cmode == MULTI_PROC) {
+    memory->destroy(bufsend);
+    memory->destroy(bufrecv);
+    memory->destroy(tagsend);
+    memory->destroy(tagrecv);
+    memory->destroy(bufbeads);
+    memory->create(bufsend, maxlocal, 3, "FixTPRPMD:bufsend");
+    memory->create(bufrecv, maxlocal, 3, "FixTPRPMD:bufrecv");
+    memory->create(tagsend, maxlocal, "FixTPRPMD:tagsend");
+    memory->create(tagrecv, maxlocal, "FixTPRPMD:tagrecv");
+    memory->create(bufbeads, nreplica, maxlocal * 3, "FixTPRPMD:bufbeads");
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::inter_replica_comm(double **ptr)
+{
+  MPI_Request requests[2];
+  MPI_Status statuses[2];
+  if (atom->nmax > maxlocal) reallocate();
+  int nlocal = atom->nlocal;
+  tagint *tag = atom->tag;
+  int i, m;
+
+  // communicate values from the other beads
+  if (cmode == SINGLE_PROC) {
+    m = 0;
+    for (i = 0; i < nlocal; i++) {
+      tagint tagtmp = tag[i];
+      bufsorted[tagtmp - 1][0] = ptr[i][0];
+      bufsorted[tagtmp - 1][1] = ptr[i][1];
+      bufsorted[tagtmp - 1][2] = ptr[i][2];
+      m++;
+    }
+    MPI_Allgatherv(bufsorted[0], 3 * m, MPI_DOUBLE, bufsortedall[0], counts, displacements,
+                   MPI_DOUBLE, universe->uworld);
+  } else if (cmode == MULTI_PROC) {
+    for (i = 0; i < nlocal; i++) {
+      bufbeads[ireplica][3 * i + 0] = ptr[i][0];
+      bufbeads[ireplica][3 * i + 1] = ptr[i][1];
+      bufbeads[ireplica][3 * i + 2] = ptr[i][2];
+    }
+    m = 0;
+    for (i = 0; i < nlocal; i++) {
+      tagsend[m] = tag[i];
+      bufsend[m][0] = ptr[i][0];
+      bufsend[m][1] = ptr[i][1];
+      bufsend[m][2] = ptr[i][2];
+      m++;
+    }
+    MPI_Gather(&m, 1, MPI_INT, counts, 1, MPI_INT, 0, world);
+    displacements[0] = 0;
+    for (i = 0; i < nprocs - 1; i++) displacements[i + 1] = displacements[i] + counts[i];
+    MPI_Gatherv(tagsend, m, MPI_LMP_TAGINT, tagsendall, counts, displacements, MPI_LMP_TAGINT, 0,
+                world);
+    for (i = 0; i < nprocs; i++) counts[i] *= 3;
+    for (i = 0; i < nprocs - 1; i++) displacements[i + 1] = displacements[i] + counts[i];
+    MPI_Gatherv(bufsend[0], 3 * m, MPI_DOUBLE, bufsendall[0], counts, displacements, MPI_DOUBLE, 0,
+                world);
+    for (int iplan = 0; iplan < sizeplan; iplan++) {
+      if (me == 0) {
+        MPI_Irecv(bufrecvall[0], 3 * ntotal, MPI_DOUBLE, planrecv[iplan], 0, universe->uworld,
+                  &requests[0]);
+        MPI_Irecv(tagrecvall, ntotal, MPI_LMP_TAGINT, planrecv[iplan], 0, universe->uworld,
+                  &requests[1]);
+        MPI_Send(bufsendall[0], 3 * ntotal, MPI_DOUBLE, plansend[iplan], 0, universe->uworld);
+        MPI_Send(tagsendall, ntotal, MPI_LMP_TAGINT, plansend[iplan], 0, universe->uworld);
+        MPI_Waitall(2, requests, statuses);
+      }
+      MPI_Bcast(tagrecvall, ntotal, MPI_LMP_TAGINT, 0, world);
+      MPI_Bcast(bufrecvall[0], 3 * ntotal, MPI_DOUBLE, 0, world);
+      for (i = 0; i < ntotal; i++) {
+        m = atom->map(tagrecvall[i]);
+        if (m < 0 || m >= nlocal) continue;
+        bufbeads[modeindex[iplan]][3 * m + 0] = bufrecvall[i][0];
+        bufbeads[modeindex[iplan]][3 * m + 1] = bufrecvall[i][1];
+        bufbeads[modeindex[iplan]][3 * m + 2] = bufrecvall[i][2];
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::remove_com_motion()
+{
+  if (universe->iworld == 0) {
+    double **v = atom->v;
+    int *mask = atom->mask;
+    int nlocal = atom->nlocal;
+    if (dynamic) masstotal = group->mass(igroup);
+    double vcm[3];
+    group->vcm(igroup, masstotal, vcm);
+    for (int i = 0; i < nlocal; i++) {
+      if (mask[i] & groupbit) {
+        v[i][0] -= vcm[0];
+        v[i][1] -= vcm[1];
+        v[i][2] -= vcm[2];
+      }
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::compute_xf_vir()
+{
+  int nlocal = atom->nlocal;
+  double xf = 0.0;
+  vir_ = 0.0;
+  for (int i = 0; i < nlocal; i++) {
+    for (int j = 0; j < 3; j++) { xf += x_unwrap[i][j] * atom->f[i][j]; }
+  }
+  MPI_Allreduce(&xf, &vir_, 1, MPI_DOUBLE, MPI_SUM, universe->uworld);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::compute_cvir()
+{
+  int nlocal = atom->nlocal;
+  double xcf = 0.0;
+  centroid_vir = 0.0;
+  for (int i = 0; i < nlocal; i++) {
+    for (int j = 0; j < 3; j++) { xcf += (x_unwrap[i][j] - xc[i][j]) * atom->f[i][j]; }
+  }
+  MPI_Allreduce(&xcf, &centroid_vir, 1, MPI_DOUBLE, MPI_SUM, universe->uworld);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::compute_vir()
+{
+  double volume = domain->xprd * domain->yprd * domain->zprd;
+  c_press->compute_vector();
+  virial[0] = c_press->vector[0] * volume;
+  virial[1] = c_press->vector[1] * volume;
+  virial[2] = c_press->vector[2] * volume;
+  virial[3] = c_press->vector[3] * volume;
+  virial[4] = c_press->vector[4] * volume;
+  virial[5] = c_press->vector[5] * volume;
+  for (int i = 0; i < 6; i++) virial[i] /= universe->procs_per_world[universe->iworld];
+  double vir_bead = (virial[0] + virial[1] + virial[2]);
+  MPI_Allreduce(&vir_bead, &vir, 1, MPI_DOUBLE, MPI_SUM, universe->uworld);
+  MPI_Allreduce(MPI_IN_PLACE, &virial[0], 6, MPI_DOUBLE, MPI_SUM, universe->uworld);
+}
+
+void FixTPRPMD::compute_totke()
+{
+  double kine = 0.0;
+  totke = ke_bead = 0.0;
+  int nlocal = atom->nlocal;
+  int *type = atom->type;
+  for (int i = 0; i < nlocal; i++) {
+    for (int j = 0; j < 3; j++) { kine += 0.5 * mass[type[i]] * atom->v[i][j] * atom->v[i][j]; }
+  }
+  kine *= force->mvv2e;
+  MPI_Allreduce(&kine, &ke_bead, 1, MPI_DOUBLE, MPI_SUM, world);
+  MPI_Allreduce(&ke_bead, &totke, 1, MPI_DOUBLE, MPI_SUM, universe->uworld);
+  totke /= universe->procs_per_world[universe->iworld];
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::compute_spring_energy()
+{
+  spring_energy = 0.0;
+  total_spring_energy = se_bead = 0.0;
+
+  double **x = atom->x;
+  double *_mass = atom->mass;
+  int *type = atom->type;
+  int nlocal = atom->nlocal;
+
+  for (int i = 0; i < nlocal; i++) {
+    spring_energy += 0.5 * _mass[type[i]] * fbond * lam[universe->iworld] *
+        (x[i][0] * x[i][0] + x[i][1] * x[i][1] + x[i][2] * x[i][2]);
+  }
+  MPI_Allreduce(&spring_energy, &se_bead, 1, MPI_DOUBLE, MPI_SUM, world);
+  MPI_Allreduce(&se_bead, &total_spring_energy, 1, MPI_DOUBLE, MPI_SUM, universe->uworld);
+  total_spring_energy /= universe->procs_per_world[universe->iworld];
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::compute_pote()
+{
+  pe_bead = 0.0;
+  pote = 0.0;
+  c_pe->compute_scalar();
+  pe_bead = c_pe->scalar;
+  double pot_energy_partition = pe_bead / universe->procs_per_world[universe->iworld];
+  MPI_Allreduce(&pot_energy_partition, &pote, 1, MPI_DOUBLE, MPI_SUM, universe->uworld);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::compute_tote()
+{
+  tote = totke + pote + total_spring_energy;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::compute_t_prim()
+{
+  t_prim = 1.5 * atom->natoms * np * force->boltz * temp - total_spring_energy * inverse_np;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::compute_t_vir()
+{
+  t_vir = -0.5 * inverse_np * vir_;
+  t_cv = 1.5 * atom->natoms * force->boltz * temp - 0.5 * inverse_np * centroid_vir;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::compute_p_prim()
+{
+  double inv_volume = 1.0 / (domain->xprd * domain->yprd * domain->zprd);
+  p_prim = atom->natoms * np * force->boltz * temp * inv_volume -
+      1.0 / 1.5 * inv_volume * total_spring_energy;
+  p_prim *= force->nktv2p;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::compute_p_cv()
+{
+  double inv_volume = 1.0 / (domain->xprd * domain->yprd * domain->zprd);
+  p_md = THIRD * inv_volume * (totke + vir);
+  if (universe->iworld == 0) {
+    p_cv = THIRD * inv_volume * ((2.0 * ke_bead - centroid_vir) * force->nktv2p + vir) / np;
+  }
+  MPI_Bcast(&p_cv, 1, MPI_DOUBLE, 0, universe->uworld);
+}
+
+/* ----------------------------------------------------------------------
+   pack entire state of Fix into one write
+------------------------------------------------------------------------- */
+
+void FixTPRPMD::write_restart(FILE *fp)
+{
+  int nsize = size_restart_global();
+
+  double *list;
+  memory->create(list, nsize, "FixTPRPMD:list");
+
+  pack_restart_data(list);
+
+  if (comm->me == 0) {
+    int size = nsize * sizeof(double);
+    fwrite(&size, sizeof(int), 1, fp);
+    fwrite(list, sizeof(double), nsize, fp);
+  }
+
+  memory->destroy(list);
+}
+/* ---------------------------------------------------------------------- */
+
+int FixTPRPMD::size_restart_global()
+{
+  int nsize = 2;
+  if (tstat_flag) nsize += 1 + 2 * mtchain;
+  if (ustat_flag) nsize += 2;
+  return nsize;
+}
+
+/* ---------------------------------------------------------------------- */
+
+int FixTPRPMD::pack_restart_data(double *list)
+{
+  int n = 0;
+  list[n++] = tstat_flag;
+  if (tstat_flag) {
+    list[n++] = mtchain;
+    for (int ich = 0; ich < mtchain; ich++) list[n++] = eta[ich];
+    for (int ich = 0; ich < mtchain; ich++) list[n++] = eta_dot[ich];
+  }
+  list[n++] = ustat_flag;
+  if (ustat_flag) {
+    list[n++] = *Ne;
+    list[n++] = *Ne_dot;
+  }
+  return n;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::restart(char *buf)
+{
+  int n = 0;
+  auto list = (double *) buf;
+  int flag = static_cast<int>(list[n++]);
+  if (flag) {
+    int m = static_cast<int>(list[n++]);
+    if (tstat_flag && m == mtchain) {
+      if (!nhc_chain_active()) {
+        for (int ich = 0; ich < mtchain; ich++) eta[ich] = eta_dot[ich] = 0.0;
+        n += 2 * m;
+      } else {
+        for (int ich = 0; ich < mtchain; ich++) eta[ich] = list[n++];
+        for (int ich = 0; ich < mtchain; ich++) eta_dot[ich] = list[n++];
+      }
+    } else {
+      n += 2 * m;
+    }
+  }
+  flag = static_cast<int>(list[n++]);
+  if (flag && ustat_flag) {
+    *Ne = list[n++];
+    *Ne_dot = list[n++];
+  }
+}
+
+/* ----------------------------------------------------------------------
+   if thermostat == NHC, return a single element of the following vectors, in this order:
+      eta[tchain], eta_dot[tchain], PE_eta[tchain], KE_eta_dot[tchain]
+------------------------------------------------------------------------- */
+
+double FixTPRPMD::compute_vector(int n)
+{
+  if (n == 0) return ke_bead;
+  n -= 1;
+  if (n == 0) return se_bead;
+  n -= 1;
+  if (n == 0) return pe_bead;
+  n -= 1;
+  if (n == 0) return tote;
+  n -= 1;
+  if (n == 0) return t_prim;
+  n -= 1;
+  if (n == 0) return t_vir;
+  n -= 1;
+  if (n == 0) return t_cv;
+  n -= 1;
+  if (n == 0) return p_prim;
+  n -= 1;
+  if (n == 0) return p_md;
+  n -= 1;
+  if (n == 0) return p_cv;
+  n -= 1;
+
+  int ilen;
+  double *Ne = this->Ne;
+
+  if (tstat_flag) {
+    ilen = mtchain;
+    if (n < ilen) return eta[n];
+    n -= ilen;
+    ilen = mtchain;
+    if (n < ilen) return eta_dot[n];
+    n -= ilen;
+  }
+
+  double kt = force->boltz * temp;
+  int ich;
+
+  if (tstat_flag) {
+    ilen = mtchain;
+    if (n < ilen) {
+      ich = n;
+      if (ich == 0) return chain0_target_energy() * eta[0];
+      return (nhc_chain_active() ? kt : 0.0) * eta[ich];
+    }
+    n -= ilen;
+    ilen = mtchain;
+    if (n < ilen) {
+      ich = n;
+      if (ich == 0) return 0.5 * eta_mass[0] * eta_dot[0] * eta_dot[0];
+      return 0.5 * eta_mass[ich] * eta_dot[ich] * eta_dot[ich];
+    }
+    n -= ilen;
+  }
+  if (ustat_flag) {
+    ilen = 1;
+    if (n < ilen) return *Ne;
+    n -= ilen;
+    ilen = 1;
+    if (n < ilen) return *Ne_dot;
+    n -= ilen;
+    ilen = 1;
+    if (n < ilen) return dedn_current;
+    n -= ilen;
+    ilen = 1;
+    if (n < ilen) return u_target;
+    n -= ilen;
+    ilen = 1;
+    if (n < ilen) return 0.5 * (*Ne_mass) * (*Ne_dot) * (*Ne_dot);
+    n -= ilen;
+    ilen = 1;
+    if (n < ilen) return kt * eta[0] - u_target * (*Ne);
+  }
+
+  return 0.0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::compute_mu_target()
+{
+  double delta = update->ntimestep - update->beginstep;
+  if (delta != 0.0) delta /= update->endstep - update->beginstep;
+
+  u_target = u_start + delta * (u_stop - u_start);
+  mu = u_target;
+}
+
+/* ---------------------------------------------------------------------- */
+
+double FixTPRPMD::evaluate_dedn()
+{
+  if (dedn_which == ArgInfo::VARIABLE) {
+    if (dedn_index == 0) return input->variable->compute_equal(dedn_var);
+    double *varvec;
+    int nvec = input->variable->compute_vector(dedn_var, &varvec);
+    if (dedn_index > nvec)
+      error->all(FLERR, "Variable {} for fix {} vector is accessed out-of-range{}", dedn_name,
+                 style, utils::errorurl(20));
+    return varvec[dedn_index - 1];
+  }
+
+  if (dedn_which == ArgInfo::COMPUTE) {
+    if (dedn_index == 0) {
+      // Force a fresh compute evaluation when the fix explicitly refreshes
+      // its cached dE/dN value for the current force state.
+      dedn_compute->compute_scalar();
+      dedn_compute->invoked_scalar = update->ntimestep;
+      dedn_compute->invoked_flag |= Compute::INVOKED_SCALAR;
+      return dedn_compute->scalar;
+    }
+    dedn_compute->compute_vector();
+    dedn_compute->invoked_vector = update->ntimestep;
+    dedn_compute->invoked_flag |= Compute::INVOKED_VECTOR;
+    return dedn_compute->vector[dedn_index - 1];
+  }
+
+  if (dedn_index == 0) return dedn_fix->compute_scalar();
+  return dedn_fix->compute_vector(dedn_index - 1);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::refresh_dedn_cache()
+{
+  double dedn_local = evaluate_dedn();
+  double dedn_avg = 0.0;
+  MPI_Allreduce(&dedn_local, &dedn_avg, 1, MPI_DOUBLE, MPI_SUM, universe->uworld);
+  dedn_current = dedn_avg * inverse_np;
+  u_current = dedn_current;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixTPRPMD::parse_dedn_source(const char *arg)
+{
+  ArgInfo argi(arg);
+  if ((argi.get_type() == ArgInfo::UNKNOWN) || (argi.get_type() == ArgInfo::NONE) ||
+      (argi.get_dim() > 1))
+    error->all(FLERR, "Illegal dedn reference {} for fix {}", arg, style);
+
+  delete[] dedn_name;
+  dedn_name = argi.copy_name();
+  dedn_which = argi.get_type();
+  dedn_index = argi.get_index1();
+}

--- a/src/EXTRA-FIX/fix_tprpmd.cpp
+++ b/src/EXTRA-FIX/fix_tprpmd.cpp
@@ -56,7 +56,7 @@ FixTPRPMD::FixTPRPMD(LAMMPS *lmp, int narg, char **arg) :
     tagrecv(nullptr), bufsend(nullptr), bufrecv(nullptr), bufbeads(nullptr), bufsorted(nullptr),
     bufsortedall(nullptr), tagsendall(nullptr),
     tagrecvall(nullptr), bufsendall(nullptr), bufrecvall(nullptr), counts(nullptr),
-    displacements(nullptr), lam(nullptr), M_x2xp(nullptr), M_xp2x(nullptr), modeindex(nullptr), tau_k(nullptr), _omega_k(nullptr), Lan_s(nullptr),
+    displacements(nullptr), rootworld(MPI_COMM_NULL), lam(nullptr), M_x2xp(nullptr), M_xp2x(nullptr), modeindex(nullptr), tau_k(nullptr), _omega_k(nullptr), Lan_s(nullptr),
     Lan_c(nullptr), xc(nullptr), xcall(nullptr),
     x_unwrap(nullptr), id_pe(nullptr), id_press(nullptr), c_pe(nullptr), c_press(nullptr),
     eta(nullptr), eta_dot(nullptr), eta_dotdot(nullptr), eta_mass(nullptr), Ne_dot(nullptr),
@@ -307,6 +307,7 @@ FixTPRPMD::~FixTPRPMD()
   delete[] plansend;
   delete[] planrecv;
   delete[] modeindex;
+  memory->sfree(lam);
   memory->destroy(xcall);
   if (cmode == SINGLE_PROC) {
     memory->destroy(bufsorted);
@@ -346,6 +347,7 @@ FixTPRPMD::~FixTPRPMD()
       delete [] Ne_mass;
     }
   }
+  if (rootworld != MPI_COMM_NULL) MPI_Comm_free(&rootworld);
   delete[] dedn_name;
 }
 
@@ -1054,7 +1056,6 @@ void FixTPRPMD::nhc_mu_integrate()
     }
 
     double eta_dot_k = eta_dot[0], eta_dot_ave = 0;
-    MPI_Barrier(universe->uworld);
     MPI_Allreduce(&eta_dot_k, &eta_dot_ave, 1, MPI_DOUBLE, MPI_SUM, universe->uworld);
 
     if (method == TPRPMD && np != 1) {
@@ -1062,8 +1063,6 @@ void FixTPRPMD::nhc_mu_integrate()
     } else {
       eta_dot_ave *= inverse_np;
     }
-    MPI_Barrier(universe->uworld);
-    MPI_Bcast(&eta_dot_ave, 1, MPI_DOUBLE, 0, universe->uworld);
 
     *Ne_dot *= exp(-ncfac * dthalf * eta_dot_ave);
 

--- a/src/EXTRA-FIX/fix_tprpmd.h
+++ b/src/EXTRA-FIX/fix_tprpmd.h
@@ -1,0 +1,213 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef FIX_CLASS
+// clang-format off
+FixStyle(tprpmd,FixTPRPMD);
+// clang-format on
+#else
+
+#ifndef LMP_FIX_TPRPMD_H
+#define LMP_FIX_TPRPMD_H
+
+#include "arg_info.h"
+#include "fix.h"
+
+namespace LAMMPS_NS {
+
+class Compute;
+class Fix;
+
+class FixTPRPMD : public Fix {
+ public:
+  FixTPRPMD(class LAMMPS *, int, char **);
+  ~FixTPRPMD() override;
+
+  int setmask() override;
+
+  void init() override;
+  void setup(int) override;
+  void post_force(int) override;
+  void initial_integrate(int) override;
+  void final_integrate() override;
+  void end_of_step() override;
+
+  double compute_vector(int) override;
+
+ protected:
+  // System setting variables
+  int method;                              // TPPIMD or TPRPMD
+  int fmmode;                              // physical or normal
+  int np;                                  // number of beads
+  double inverse_np;                       // 1.0/np
+  double temp;                             // temperature
+  double hbar;                             // Planck's constant
+  double lj_epsilon, lj_sigma, lj_mass;    // LJ unit energy, length, and mass scales
+  double other_planck;
+  double other_mvv2e;
+  double kt;               // k_B * temp
+  double beta, beta_np;    // beta = 1./kBT beta_np = 1./kBT/np
+  int thermostat;          // NHC
+  int integrator;          // obabo or baoab
+  int ensemble;            // UVT
+  int mapflag;             // should be 1 if number of beads > 1
+  int removecomflag;
+  double masstotal;
+
+  double fixedpoint[3];    // location of dilation fixed-point
+
+  // NHC
+
+  double *eta, *eta_dot;    // chain thermostat for particles
+  double *eta_dotdot;
+  double *eta_mass;
+
+  int mtchain;                 // length of chain
+  int nc_tchain;
+  double factor_eta;
+  double drag, tdrag_factor;     // drag factor on particle thermostat
+  double t_freq;
+  double t_period;
+  double tdof;
+  double ke_target;
+
+  // ring-polymer model
+
+  double omega_np, fbond, spring_energy, sp;
+
+  // fictitious mass
+
+  double fmass, *mass;
+
+  // inter-partition communication
+
+  MPI_Comm rootworld;
+  int me, nprocs, ireplica, nreplica, nprocs_universe;
+  int ntotal, maxlocal;
+
+  int x_last, x_next;
+
+  int cmode;
+  int sizeplan;
+  int *plansend, *planrecv;
+
+  tagint *tagsend, *tagrecv;
+  double **bufsend, **bufrecv, **bufbeads;
+  double **bufsorted, **bufsortedall;
+
+  tagint *tagsendall, *tagrecvall;
+  double **bufsendall, **bufrecvall;
+
+  int *counts, *displacements;
+
+  void comm_init();
+  void inter_replica_comm(double **ptr);
+
+  /* normal-mode operations */
+
+  double *lam, **M_x2xp, **M_xp2x;
+  int *modeindex;
+
+  void reallocate();
+  void nmpimd_init();
+  void nmpimd_transform(double **, double **, double *);
+
+  /* Ring-polymer integration helpers */
+
+  double dtv, dtf, dtv2, dtv3, dthalf, dt4, dt8;
+  double tau;
+  double *tau_k;
+  double pilescale;
+  double *_omega_k, *Lan_s, *Lan_c;    // sin(omega_k*dt*0.5), cos(omega_k*dt*0.5)
+
+  int tstat_flag;    // tstat_flat = 1 if thermostat if used
+  void nhc_init();
+  void b_step();    // integrate for dt/2 according to B part (v <- v + f * dt/2)
+  void
+  a_step();    // integrate for dt/2 according to A part (non-centroid mode, harmonic force between replicas)
+  void qc_step();    // integrate for dt/2 for the centroid mode (x <- x + v * dt/2)
+  void o_step();     // integrate for dt according to O part (O-U process, for thermostating)
+  void nhc_temp_integrate();
+
+  virtual void nh_v_temp();
+  bool nuclear_thermostat_off() const;
+  bool ne_thermostat_participates() const;
+  bool nhc_chain_active() const;
+  double chain0_target_energy() const;
+  double ne_kinetic_current_share() const;
+
+  /* potentiostat */
+
+  int ustat_flag;
+  double mu;
+  double *Ne_dot;
+  double *Ne_mass;
+  double u_freq;
+  double u_period;
+  void nhc_mu_integrate();
+  void compute_mu_target();
+  double evaluate_dedn();
+  void refresh_dedn_cache();
+  void parse_dedn_source(const char *);
+
+  /* centroid-virial estimator computation */
+  double **xc, *xcall;
+  int maxxc;
+  int maxunwrap;
+  double **x_unwrap;
+  void reallocate_x_unwrap();
+  void reallocate_xc();
+  void collect_xc();
+  void remove_com_motion();
+  double vir, vir_, centroid_vir;
+  double t_prim, t_vir, t_cv, p_prim, p_cv, p_md;
+
+  /* Computes */
+  double pote, tote, totke;
+  double ke_bead, se_bead, pe_bead;
+  double total_spring_energy;
+  char *id_pe;
+  char *id_press;
+  class Compute *c_pe;
+  class Compute *c_press;
+
+  void compute_totke();            // 1: kinetic energy
+  void compute_spring_energy();    // 2: spring elastic energy
+  void compute_pote();             // 3: potential energy
+  void compute_tote();             // 4: total energy: 1+2+3 for all the beads
+  void compute_t_prim();
+  void compute_t_vir();
+  void compute_p_prim();
+  void compute_p_cv();    // centroid-virial pressure estimator
+  void compute_vir();
+  void compute_xf_vir();
+  void compute_cvir();
+  void write_restart(FILE *fp) override;
+  int size_restart_global();
+  int pack_restart_data(double *list);
+  void restart(char *buf) override;
+
+  double *Ne;
+  double u_start, u_stop;
+  double u_current, u_target;
+  char *dedn_name;
+  int dedn_which;
+  int dedn_index;
+  int dedn_var;
+  Compute *dedn_compute;
+  Fix *dedn_fix;
+  double dedn_current;
+};
+}    // namespace LAMMPS_NS
+#endif
+#endif

--- a/unittest/commands/CMakeLists.txt
+++ b/unittest/commands/CMakeLists.txt
@@ -44,10 +44,6 @@ target_link_libraries(test_groups PRIVATE lammps GTest::GMock)
 add_test(NAME Groups COMMAND test_groups)
 
 if(PKG_EXTRA-FIX)
-  add_executable(test_fix_uvt test_fix_uvt.cpp)
-  target_link_libraries(test_fix_uvt PRIVATE lammps GTest::GMock)
-  add_test(NAME FixUVT COMMAND test_fix_uvt)
-
   add_executable(test_fix_tprpmd test_fix_tprpmd.cpp)
   target_link_libraries(test_fix_tprpmd PRIVATE lammps GTest::GMock)
   add_test(NAME FixTPRPMD COMMAND test_fix_tprpmd --gtest_filter=FixTPRPMDSerialTest.*)

--- a/unittest/commands/CMakeLists.txt
+++ b/unittest/commands/CMakeLists.txt
@@ -43,6 +43,17 @@ add_executable(test_groups test_groups.cpp)
 target_link_libraries(test_groups PRIVATE lammps GTest::GMock)
 add_test(NAME Groups COMMAND test_groups)
 
+if(PKG_EXTRA-FIX)
+  add_executable(test_fix_uvt test_fix_uvt.cpp)
+  target_link_libraries(test_fix_uvt PRIVATE lammps GTest::GMock)
+  add_test(NAME FixUVT COMMAND test_fix_uvt)
+
+  add_executable(test_fix_tprpmd test_fix_tprpmd.cpp)
+  target_link_libraries(test_fix_tprpmd PRIVATE lammps GTest::GMock)
+  add_test(NAME FixTPRPMD COMMAND test_fix_tprpmd --gtest_filter=FixTPRPMDSerialTest.*)
+  add_mpi_test(NAME FixTPRPMDPartition NUM_PROCS 2
+               COMMAND $<TARGET_FILE:test_fix_tprpmd> --gtest_filter=FixTPRPMDMPI.*)
+endif()
 add_executable(test_regions test_regions.cpp)
 target_link_libraries(test_regions PRIVATE lammps GTest::GMock)
 add_test(NAME Regions COMMAND test_regions)

--- a/unittest/commands/test_fix_tprpmd.cpp
+++ b/unittest/commands/test_fix_tprpmd.cpp
@@ -1,0 +1,414 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with the U.S. Government retains
+   certain rights in this software.
+------------------------------------------------------------------------- */
+
+#define LAMMPS_LIB_MPI 1
+
+#include "lammps.h"
+#include "library.h"
+
+#include "platform.h"
+
+#include "../testing/core.h"
+#include "gtest/gtest.h"
+
+#include <cmath>
+#include <mpi.h>
+
+bool verbose = false;
+
+namespace LAMMPS_NS {
+
+class FixTPRPMDSerialTest : public LAMMPSTest {
+ protected:
+  void setup_quadratic_system()
+  {
+    command("units lj");
+    command("atom_style atomic");
+    command("atom_modify map yes");
+    command("boundary p p p");
+    command("lattice fcc 0.8442");
+    command("region box block 0 3 0 3 0 3");
+    command("create_box 1 box");
+    command("create_atoms 1 box");
+    command("mass 1 1.0");
+    command("pair_style zero 2.5");
+    command("pair_coeff * *");
+    command("neighbor 0.3 bin");
+    command("neigh_modify every 1 delay 0 check yes");
+    command("velocity all create 1.0 492845 mom yes rot no dist gaussian");
+    command("timestep 0.005");
+  }
+
+  void setup_quadratic_fix()
+  {
+    command("variable k_quad equal 5.0");
+    command("variable N0_quad equal 1.0");
+    command("variable dEdN equal v_k_quad*(f_cp[23]-v_N0_quad)");
+    command("fix cp all tprpmd method tp-rpmd ensemble uvt thermostat NHC temp 1.0 Tdamp 0.5 "
+            "tchain 3 tloop 1 mu 2.0 2.0 0.5 ne 1.8 ne_velocity 0.0 dedn v_dEdN");
+  }
+
+  double fix_value(const char *id, int index)
+  {
+    void *ptr = lammps_extract_fix(lmp, id, LMP_STYLE_GLOBAL, LMP_TYPE_VECTOR, index, 0);
+    double value = *(double *) ptr;
+    lammps_free(ptr);
+    return value;
+  }
+};
+
+TEST_F(FixTPRPMDSerialTest, RestartRestoresElectronState)
+{
+  double ne_before = 0.0;
+  double nedot_before = 0.0;
+  double dedn_before = 0.0;
+  double mu_before = 0.0;
+
+  setup_quadratic_system();
+  setup_quadratic_fix();
+  command("run 20 post no");
+
+  ne_before = fix_value("cp", 22);
+  nedot_before = fix_value("cp", 23);
+  dedn_before = fix_value("cp", 24);
+  mu_before = fix_value("cp", 25);
+
+  command("write_restart tprpmd.restart");
+  command("clear");
+  command("read_restart tprpmd.restart");
+  command("variable k_quad equal 5.0");
+  command("variable N0_quad equal 1.0");
+  command("variable dEdN equal v_k_quad*(f_cp[23]-v_N0_quad)");
+  command("fix cp all tprpmd method tp-rpmd ensemble uvt thermostat NHC temp 1.0 Tdamp 0.5 "
+          "tchain 3 tloop 1 mu 2.0 2.0 0.5 ne 1.8 ne_velocity 0.0 dedn v_dEdN");
+  command("run 0 post no");
+  platform::unlink("tprpmd.restart");
+
+  EXPECT_NEAR(fix_value("cp", 22), ne_before, 1.0e-10);
+  EXPECT_NEAR(fix_value("cp", 23), nedot_before, 1.0e-10);
+  EXPECT_NEAR(fix_value("cp", 24), dedn_before, 1.0e-10);
+  EXPECT_NEAR(fix_value("cp", 25), mu_before, 1.0e-10);
+}
+
+TEST_F(FixTPRPMDSerialTest, QuadraticToyFixedPointHasZeroElectronicForce)
+{
+  setup_quadratic_system();
+  command("variable k_quad equal 5.0");
+  command("variable N0_quad equal 1.0");
+  command("variable dEdN equal v_k_quad*(f_cp[23]-v_N0_quad)");
+  command("fix cp all tprpmd method tp-rpmd ensemble uvt thermostat NHC temp 1.0 Tdamp 0.5 "
+          "tchain 3 tloop 1 mu 2.0 2.0 0.5 ne 1.4 ne_velocity 0.0 dedn v_dEdN");
+  command("run 0 post no");
+
+  EXPECT_NEAR(fix_value("cp", 22), 1.4, 1.0e-10);
+  EXPECT_NEAR(fix_value("cp", 23), 0.0, 1.0e-10);
+  EXPECT_NEAR(fix_value("cp", 24), 2.0, 1.0e-10);
+  EXPECT_NEAR(fix_value("cp", 25), 2.0, 1.0e-12);
+}
+
+TEST_F(FixTPRPMDSerialTest, QuadraticToyPhysicsAveragesConverge)
+{
+  command("units lj");
+  command("atom_style atomic");
+  command("atom_modify map yes");
+  command("boundary p p p");
+  command("lattice sc 0.7");
+  command("region box block 0 2 0 2 0 2");
+  command("create_box 1 box");
+  command("create_atoms 1 box");
+  command("mass 1 1.0");
+  command("pair_style zero 2.5");
+  command("pair_coeff * *");
+  command("neighbor 0.3 bin");
+  command("neigh_modify every 1 delay 0 check yes");
+  command("velocity all create 1.0 492845 mom yes rot no dist gaussian");
+  command("timestep 0.005");
+  command("variable k_quad equal 5.0");
+  command("variable N0_quad equal 1.0");
+  command("variable dEdN equal v_k_quad*(f_cp[23]-v_N0_quad)");
+  command("fix cp all tprpmd method tp-rpmd ensemble uvt thermostat NHC temp 1.0 Tdamp 0.5 "
+          "tchain 3 tloop 1 mu 2.0 2.0 0.5 ne 1.8 ne_velocity 0.0 dedn v_dEdN");
+  command("fix avg all ave/time 1 20000 20000 f_cp[23] f_cp[24] f_cp[25]");
+  command("run 20000 post no");
+
+  EXPECT_NEAR(fix_value("avg", 0), 1.4, 1.0e-1);
+  EXPECT_NEAR(fix_value("avg", 1), 0.0, 1.0e-1);
+  EXPECT_NEAR(fix_value("avg", 2), 2.0, 1.0e-1);
+}
+
+TEST_F(FixTPRPMDSerialTest, TPRPMDP1RetainsElectronicThermostat)
+{
+  setup_quadratic_system();
+  command("variable k_quad equal 5.0");
+  command("variable N0_quad equal 1.0");
+  command("variable dEdN equal v_k_quad*(f_cp[23]-v_N0_quad)");
+  command("fix cp all tprpmd method tp-rpmd ensemble uvt thermostat NHC temp 1.0 Tdamp 0.5 "
+          "tchain 3 tloop 1 mu 2.0 2.0 0.5 ne 1.8 ne_velocity 0.4 dedn v_dEdN");
+  command("run 20 post no");
+
+  EXPECT_TRUE(std::isfinite(fix_value("cp", 10)));
+  EXPECT_TRUE(std::isfinite(fix_value("cp", 13)));
+  EXPECT_GT(std::fabs(fix_value("cp", 13)), 1.0e-12);
+}
+
+TEST(FixTPRPMDMPI, PartitionedRunExercisesBeadExpansion)
+{
+  int nprocs = 0;
+  MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+  if (nprocs != 2) GTEST_SKIP() << "This test requires exactly 2 MPI ranks";
+
+  const char *args[] = {"LAMMPS_test", "-log", "none", "-partition", "2x1", "-echo",
+                        "screen",      "-nocite",       "-in",        "none", nullptr};
+  char **argv = (char **) args;
+  int argc = (sizeof(args) / sizeof(char *)) - 1;
+
+  void *lmp = nullptr;
+  ASSERT_NO_THROW(lmp = lammps_open(argc, argv, MPI_COMM_WORLD, nullptr));
+  ASSERT_NE(lmp, nullptr);
+
+  auto command = [lmp](const char *line) { lammps_command(lmp, line); };
+  auto fix_value = [lmp](const char *id, int index) {
+    void *ptr = lammps_extract_fix(lmp, id, LMP_STYLE_GLOBAL, LMP_TYPE_VECTOR, index, 0);
+    double value = *(double *) ptr;
+    lammps_free(ptr);
+    return value;
+  };
+
+  command("units lj");
+  command("atom_style atomic");
+  command("atom_modify map yes");
+  command("boundary p p p");
+  command("lattice sc 0.7");
+  command("region box block 0 2 0 2 0 2");
+  command("create_box 1 box");
+  command("create_atoms 1 box");
+  command("mass 1 1.0");
+  command("pair_style zero 2.5");
+  command("pair_coeff * *");
+  command("neighbor 0.3 bin");
+  command("neigh_modify every 1 delay 0 check yes");
+  command("timestep 0.002");
+  command("variable beadshift universe 0.0 0.15");
+  command("displace_atoms all move ${beadshift} 0.0 0.0 units box");
+  command("velocity all create 0.8 97531 mom yes rot no dist gaussian");
+  command("variable k_quad equal 3.0");
+  command("variable N0_quad equal 1.2");
+  command("variable dEdN equal v_k_quad*(f_cp[23]-v_N0_quad)");
+  command("fix cp all tprpmd method tp-rpmd ensemble uvt thermostat NHC temp 0.8 Tdamp 0.2 "
+          "tchain 3 tloop 1 mu 1.5 1.5 0.2 ne 1.8 ne_velocity 0.0 dedn v_dEdN");
+  command("run 1 post no");
+
+  EXPECT_TRUE(std::isfinite(fix_value("cp", 22)));
+  EXPECT_TRUE(std::isfinite(fix_value("cp", 23)));
+  EXPECT_TRUE(std::isfinite(fix_value("cp", 24)));
+  EXPECT_NEAR(fix_value("cp", 25), 1.5, 1.0e-12);
+  EXPECT_NE(fix_value("cp", 24), 0.0);
+
+  lammps_close(lmp);
+}
+
+TEST(FixTPRPMDMPI, BeadAveragedQuadraticDerivativeAtFixedPoint)
+{
+  int nprocs = 0;
+  MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+  if (nprocs != 2) GTEST_SKIP() << "This test requires exactly 2 MPI ranks for bead averaging";
+
+  const char *args[] = {"LAMMPS_test", "-log", "none", "-partition", "2x1", "-echo",
+                        "screen",      "-nocite",       "-in",        "none", nullptr};
+  char **argv = (char **) args;
+  int argc = (sizeof(args) / sizeof(char *)) - 1;
+
+  void *lmp = nullptr;
+  ASSERT_NO_THROW(lmp = lammps_open(argc, argv, MPI_COMM_WORLD, nullptr));
+  ASSERT_NE(lmp, nullptr);
+
+  auto command = [lmp](const char *line) { lammps_command(lmp, line); };
+  auto fix_value = [lmp](const char *id, int index) {
+    void *ptr = lammps_extract_fix(lmp, id, LMP_STYLE_GLOBAL, LMP_TYPE_VECTOR, index, 0);
+    double value = *(double *) ptr;
+    lammps_free(ptr);
+    return value;
+  };
+
+  command("units lj");
+  command("atom_style atomic");
+  command("atom_modify map yes");
+  command("boundary p p p");
+  command("lattice sc 0.7");
+  command("region box block 0 2 0 2 0 2");
+  command("create_box 1 box");
+  command("create_atoms 1 box");
+  command("mass 1 1.0");
+  command("pair_style zero 2.5");
+  command("pair_coeff * *");
+  command("neighbor 0.3 bin");
+  command("neigh_modify every 1 delay 0 check yes");
+  command("timestep 0.002");
+  command("variable beadshift universe 0.0 0.15");
+  command("displace_atoms all move ${beadshift} 0.0 0.0 units box");
+  command("velocity all create 0.8 97531 mom yes rot no dist gaussian");
+  command("variable N0_quad universe 1.0 1.4");
+  command("variable k_quad equal 3.0");
+  command("variable dEdN equal v_k_quad*(f_cp[23]-v_N0_quad)");
+  command("fix cp all tprpmd method tp-rpmd ensemble uvt thermostat NHC temp 0.8 Tdamp 0.2 "
+          "tchain 3 tloop 1 mu 1.5 1.5 0.2 ne 1.7 ne_velocity 0.0 dedn v_dEdN");
+  command("run 0 post no");
+
+  EXPECT_NEAR(fix_value("cp", 22), 1.7, 1.0e-10);
+  EXPECT_NEAR(fix_value("cp", 23), 0.0, 1.0e-10);
+  EXPECT_NEAR(fix_value("cp", 24), 1.5, 1.0e-10);
+  EXPECT_NEAR(fix_value("cp", 25), 1.5, 1.0e-12);
+
+  lammps_close(lmp);
+}
+
+TEST(FixTPRPMDMPI, TPRPMDCentroidThermostatIsSuppressed)
+{
+  int nprocs = 0;
+  MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+  if (nprocs != 2) GTEST_SKIP() << "This test requires exactly 2 MPI ranks for 2-bead TP-RPMD";
+
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  const char *args[] = {"LAMMPS_test", "-log", "none", "-partition", "2x1", "-echo",
+                        "screen",      "-nocite",       "-in",        "none", nullptr};
+  char **argv = (char **) args;
+  int argc = (sizeof(args) / sizeof(char *)) - 1;
+
+  void *lmp = nullptr;
+  ASSERT_NO_THROW(lmp = lammps_open(argc, argv, MPI_COMM_WORLD, nullptr));
+  ASSERT_NE(lmp, nullptr);
+
+  auto command = [lmp](const char *line) { lammps_command(lmp, line); };
+  auto fix_value = [lmp](const char *id, int index) {
+    void *ptr = lammps_extract_fix(lmp, id, LMP_STYLE_GLOBAL, LMP_TYPE_VECTOR, index, 0);
+    double value = *(double *) ptr;
+    lammps_free(ptr);
+    return value;
+  };
+
+  command("units lj");
+  command("atom_style atomic");
+  command("atom_modify map yes");
+  command("boundary p p p");
+  command("lattice sc 0.7");
+  command("region box block 0 2 0 2 0 2");
+  command("create_box 1 box");
+  command("create_atoms 1 box");
+  command("mass 1 1.0");
+  command("pair_style zero 2.5");
+  command("pair_coeff * *");
+  command("neighbor 0.3 bin");
+  command("neigh_modify every 1 delay 0 check yes");
+  command("timestep 0.002");
+  command("variable beadshift universe 0.0 0.15");
+  command("displace_atoms all move ${beadshift} 0.0 0.0 units box");
+  command("velocity all create 0.8 97531 mom yes rot no dist gaussian");
+  command("variable k_quad equal 3.0");
+  command("variable N0_quad equal 1.2");
+  command("variable dEdN equal v_k_quad*(f_cp[23]-v_N0_quad)");
+  command("fix cp all tprpmd method tp-rpmd ensemble uvt thermostat NHC temp 0.8 Tdamp 0.2 "
+          "tchain 3 tloop 1 mu 1.5 1.5 0.2 ne 1.8 ne_velocity 0.0 dedn v_dEdN");
+  command("run 10");
+
+  if (rank == 0) {
+    EXPECT_NEAR(fix_value("cp", 10), 0.0, 1.0e-14);
+    EXPECT_NEAR(fix_value("cp", 11), 0.0, 1.0e-14);
+    EXPECT_NEAR(fix_value("cp", 12), 0.0, 1.0e-14);
+    EXPECT_NEAR(fix_value("cp", 13), 0.0, 1.0e-14);
+    EXPECT_NEAR(fix_value("cp", 14), 0.0, 1.0e-14);
+    EXPECT_NEAR(fix_value("cp", 15), 0.0, 1.0e-14);
+  } else {
+    EXPECT_TRUE(std::isfinite(fix_value("cp", 10)));
+    EXPECT_TRUE(std::isfinite(fix_value("cp", 11)));
+    EXPECT_TRUE(std::isfinite(fix_value("cp", 12)));
+    EXPECT_TRUE(std::isfinite(fix_value("cp", 13)));
+    EXPECT_TRUE(std::isfinite(fix_value("cp", 14)));
+    EXPECT_TRUE(std::isfinite(fix_value("cp", 15)));
+  }
+
+  lammps_close(lmp);
+}
+
+TEST(FixTPRPMDMPI, P4LongTimeConvergence)
+{
+  int nprocs = 0;
+  MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+  if (nprocs != 4) GTEST_SKIP() << "This test requires exactly 4 MPI ranks for 4-bead TP-RPMD";
+
+  const char *args[] = {"LAMMPS_test", "-log", "none", "-partition", "4x1", "-echo",
+                        "screen",      "-nocite",       "-in",        "none", nullptr};
+  char **argv = (char **) args;
+  int argc = (sizeof(args) / sizeof(char *)) - 1;
+
+  void *lmp = nullptr;
+  ASSERT_NO_THROW(lmp = lammps_open(argc, argv, MPI_COMM_WORLD, nullptr));
+  ASSERT_NE(lmp, nullptr);
+
+  auto command = [lmp](const char *line) { lammps_command(lmp, line); };
+  auto fix_value = [lmp](const char *id, int index) {
+    void *ptr = lammps_extract_fix(lmp, id, LMP_STYLE_GLOBAL, LMP_TYPE_VECTOR, index, 0);
+    double value = *(double *) ptr;
+    lammps_free(ptr);
+    return value;
+  };
+
+  command("units lj");
+  command("atom_style atomic");
+  command("atom_modify map yes");
+  command("boundary p p p");
+  command("lattice sc 0.7");
+  command("region box block 0 2 0 2 0 2");
+  command("create_box 1 box");
+  command("create_atoms 1 box");
+  command("mass 1 1.0");
+  command("pair_style zero 2.5");
+  command("pair_coeff * *");
+  command("neighbor 0.3 bin");
+  command("neigh_modify every 1 delay 0 check yes");
+  command("timestep 0.005");
+  command("variable beadshift universe 0.0 0.1 0.2 0.3");
+  command("displace_atoms all move ${beadshift} 0.0 0.0 units box");
+  command("velocity all create 1.0 492845 mom yes rot no dist gaussian");
+  command("variable k_quad equal 5.0");
+  command("variable N0_quad equal 1.0");
+  command("variable dEdN equal v_k_quad*(f_cp[23]-v_N0_quad)");
+  command("fix cp all tprpmd method tp-rpmd ensemble uvt thermostat NHC temp 1.0 Tdamp 0.5 "
+          "tchain 3 tloop 1 mu 2.0 2.0 0.5 ne 1.8 ne_velocity 0.0 dedn v_dEdN");
+  command("fix avg all ave/time 1 20000 20000 f_cp[23] f_cp[24] f_cp[25]");
+  command("run 20000 post no");
+
+  EXPECT_NEAR(fix_value("avg", 0), 1.4, 1.0e-1);
+  EXPECT_NEAR(fix_value("avg", 1), 0.0, 1.0e-1);
+  EXPECT_NEAR(fix_value("avg", 2), 2.0, 1.0e-1);
+
+  lammps_close(lmp);
+}
+
+}    // namespace LAMMPS_NS
+
+int main(int argc, char **argv)
+{
+  MPI_Init(&argc, &argv);
+  ::testing::InitGoogleMock(&argc, argv);
+
+  if (const char *var = getenv("TEST_ARGS")) {
+    std::vector<std::string> env = LAMMPS_NS::utils::split_words(var);
+    for (auto arg : env) {
+      if (arg == "-v") verbose = true;
+    }
+  }
+
+  if ((argc > 1) && (strcmp(argv[1], "-v") == 0)) verbose = true;
+
+  int rv = RUN_ALL_TESTS();
+  MPI_Finalize();
+  return rv;
+}


### PR DESCRIPTION
**Summary**

This pull request adds a new `fix tprpmd` style for constant-potential path-integral dynamics in LAMMPS.

This work is a direct extension of the classical constant-potential framework introduced in #5024. While #5024 adds the classical constant-potential workflow, the present pull request extends the same framework to path-integral simulations, with support for:

- thermostatted-potentiostatted path-integral molecular dynamics through `method tp-pimd`
- thermostatted-potentiostatted ring-polymer molecular dynamics through `method tp-rpmd`

The fix is intended for replica-partitioned LAMMPS runs in which each partition represents one ring-polymer bead. All ring-polymer beads share a single extended electron-number coordinate, `Ne`.

This pull request is submitted separately from #5024 on purpose. Although both pull requests are part of the same constant-potential feature line, keeping the classical and path-integral implementations separate makes review easier because they differ in integration schemes, thermostat participation rules, and inter-partition communication.

This pull request includes:

- a new `fix tprpmd` style
- documentation for the new fix
- an update to the replica how-to documentation
- a toy-model TP-RPMD example
- a restart regression example
- command-level and partition-level unit tests

**Related Issue(s)**

Related pull requests:

- #5024
- deepmodeling/deepmd-kit#5498

**Author(s)**

Li Fu  
Peking University, Beijing 100871, People's Republic of China  
Corresponding e-mail: [fuli200202@163.com](mailto:fuli200202@163.com)

**Licensing**

By submitting this pull request, I agree that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

By submitting this pull request, I confirm that I used AI tools to assist with parts of the implementation, documentation, test scaffolding, debugging, and validation workflow for this contribution.

In particular, OpenAI Codex / ChatGPT and OpenCode were used to help draft and revise code, documentation text, tests, and validation steps. Final algorithmic, physical, and repository-integration decisions were reviewed and approved by the human author.

**Backward Compatibility**

This pull request does not change the behavior of existing LAMMPS fix styles or existing input scripts.

It adds a new `fix tprpmd` style and related documentation, examples, and tests. Existing input scripts are expected to remain backward compatible.

**Implementation Notes**

`fix tprpmd` extends the constant-potential framework introduced by `fix uvt` to path-integral molecular dynamics.

The implementation propagates a single extended electron-number coordinate, `Ne`, shared by all ring-polymer beads. It consumes bead-resolved contributions to a user-provided `dE/dN` signal, which are communicated and averaged across the replica partitions before the driving force on `Ne` is applied.

The driving force on the shared electron-number coordinate is based on

$$
\mu - \frac{dE}{dN},
$$

where `mu` is the imposed chemical potential and `dE/dN` is supplied externally.

The implementation includes:

- inter-partition communication and averaging of the bead-resolved contributions to `dE/dN`
- single-timestep caching of the consumed `dE/dN` signal
- propagation of the shared extended electron-number coordinate and its velocity
- Nosé-Hoover-chain thermostatting associated with the extended electron-number degree of freedom
- separate nuclear thermostat participation rules for TP-PIMD and TP-RPMD
- restart support for the electron-number variables and their associated thermostat state

For `method tp-pimd`, all nuclear ring-polymer normal modes are thermostatted.

For `method tp-rpmd`, the nuclear ring-polymer centroid mode is left unthermostatted, while the internal nuclear modes are thermostatted.

As in #5024, the LAMMPS-side implementation acts as a generic consumer of `dE/dN`. The signal may be supplied by:

- an equal-style variable: `v_name`
- a global compute: `c_ID`
- a global fix: `f_ID`

The DeepMD-kit backend/provider implementation is maintained separately in deepmodeling/deepmd-kit#5498.

**Post Submission Checklist**

- [x] The feature or features in this pull request are complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake-based build system
- [x] Suitable tests have been added to the unittest tree
- [x] A package-specific README file has been included or updated
- [x] One or more example input decks are included

**Further Information, Files, and Links**

Validation performed for this pull request includes:

- successful rebuilding of the MPI LAMMPS executable
- successful execution of the submitted TP-RPMD toy-model example
- successful execution of the submitted restart example
- verification that the consumed `dE/dN` approaches the imposed `mu` in steady state for the toy model
- verification of restart continuity for `Ne`, `Ne_dot`, `dE/dN`, and the associated thermostat state
- verification of inter-partition communication and bead averaging
- verification of the different nuclear thermostat participation rules for TP-PIMD and TP-RPMD
- successful command-level regression tests:
  - `FixTPRPMD`
  - `FixTPRPMDPartition`

Additional toy-model and real-system validation was performed outside the repository during development.

Conceptually, the two constant-potential pull requests form parts of the same framework:

- #5024 adds classical constant-potential dynamics through `fix uvt`
- this pull request extends the framework to path-integral dynamics through `fix tprpmd`

The methodology implemented here corresponds to the thermostatted-potentiostatted path-integral and ring-polymer molecular dynamics framework developed for constant-potential simulations with nuclear quantum effects.