### PR TITLE
fix: correctly implement the wrap function for orientation_angle

### DIFF
--- a/lib/colvars/colvarcomp_rotations.cpp
+++ b/lib/colvars/colvarcomp_rotations.cpp
@@ -251,8 +251,9 @@ colvarvalue colvar::orientation_angle::dist2_rgrad(colvarvalue const &x1,
 }
 
 
-void colvar::orientation_angle::wrap(colvarvalue & /* x_unwrapped */) const {}
-
+void colvar::orientation_angle::wrap(colvarvalue &x_unwrapped) const {
+  return cvc::wrap(x_unwrapped);
+}
 
 
 colvar::orientation_proj::orientation_proj()


### PR DESCRIPTION
**Summary**

Fix the wrapping of arbitrary values for `spinAngle` type to their [-180:180] period. The values of this type of variables were always correct, but fictitious masses (i.e. extended-Lagrangian restraints) were not wrapped correctly until this fix, needlessly broadening the range of sampled values.

Submitting a PR for this bugfix on its own to ensure it will be in the coming stable release.

**Related Issue(s)**

Issue on the Colvars repo: https://github.com/Colvars/colvars/issues/942

**Author(s)**

@HanatoK

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

<!--Please update the following sentence as needed in case you were using AI tools to
generate code.  Please mention which specific AI tool or tools you were using and which
parts of the code were AI generated versus the parts written by a human.  The use of AI
tools for checking spelling and syntax does not need to be reported.-->

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

Bugfix

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

Only changes to Colvars library

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

n/a (Colvars library-only update)

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


