### PR TITLE
Add try_jump option to read_restart

### DIFF
--- a/doc/src/read_restart.rst
+++ b/doc/src/read_restart.rst
@@ -8,9 +8,16 @@ Syntax
 
 .. code-block:: LAMMPS
 
-   read_restart file
+   read_restart file keyword value ...
 
 * file = name of binary restart file to read in
+* zero or more keyword/value pairs may be appended
+* keyword = *try_jump*
+
+  .. parsed-literal::
+
+      *try_jump* value = jump_location
+        jump_location = arg(s) passed to jump command if restart is successful
 
 Examples
 """"""""
@@ -19,6 +26,8 @@ Examples
 
    read_restart save.10000
    read_restart restart.*
+   read_restart restart.* try_jump newfile
+   read_restart restart.* try_jump "SELF runloop"
 
 Description
 """""""""""
@@ -35,6 +44,13 @@ processors in the current simulation and the settings of the
 :doc:`processors <processors>` command.  The partitioning can later be
 changed by the :doc:`balance <balance>` or :doc:`fix balance
 <fix_balance>` commands.
+
+Normally, it is an error if no restart file is found. Specifying the *try_jump*
+option allows attempting to restart when the presence of a file is unknown. If
+a restart file is found, this command will restart from it and jump to
+*jump_location*. If no restart file is found, this command returns as a no-op.
+Note that this command will still generate an error if restart files are
+corrupt, a subset of restart files are missing, or any other errors occur.
 
 .. deprecated:: 23Jun2022
 

--- a/examples/mc/in.gcmc.restart
+++ b/examples/mc/in.gcmc.restart
@@ -53,7 +53,10 @@ clear
 
 # rerun simulation from restart
 
-read_restart    ${restartfile}
+read_restart    ${restartfile} try_jump "SELF lj_restarted"
+print "LJ: unable to read restart file "
+quit 1
+label lj_restarted
 
 # gcmc
 
@@ -177,7 +180,11 @@ clear
 
 # rerun simulation from restart
 
-read_restart    ${restartfile}
+read_restart    ${restartfile} try_jump "SELF h20_restarted"
+print "H2O: unable to read restart file "
+quit 1
+label h20_restarted
+
 molecule        h2omol H2O.txt
 kspace_style    ewald 0.0001
 fix             mynvt h2o nvt temp ${temp} ${temp} 100

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -34,6 +34,7 @@
 #include "pair.h"
 #include "special.h"
 #include "update.h"
+#include "input.h"
 
 #include <cstring>
 #include <filesystem>
@@ -50,8 +51,8 @@ ReadRestart::ReadRestart(LAMMPS *lmp) : Command(lmp) {}
 
 void ReadRestart::command(int narg, char **arg)
 {
-  if (narg != 1 && narg != 2)
-    error->all(FLERR, Error::COMMAND, "Read_restart must have one or two arguments");
+  if (narg < 1)
+    error->all(FLERR, Error::COMMAND, "Read_restart must have at least one argument");
 
   if (domain->box_exist)
     error->all(FLERR, Error::COMMAND, "Cannot use read_restart after simulation box is defined"
@@ -63,13 +64,19 @@ void ReadRestart::command(int narg, char **arg)
   MPI_Comm_rank(world,&me);
   MPI_Comm_size(world,&nprocs);
 
-  // check for remap option
-
+  // check options
+  try_jump = false;
   int remapflag = 1;
-  if (narg == 2) {
-    if (strcmp(arg[1],"noremap") == 0) remapflag = 0;
-    else if (strcmp(arg[1],"remap") == 0) remapflag = 1; // for backward compatibility
-    else error->all(FLERR, 1, "Unknown read_restart keyword {}", arg[1]);
+  for (int i = 1; i < narg; i++) {
+    if (strcmp(arg[i],"noremap") == 0) remapflag = 0;
+    else if (strcmp(arg[i],"remap") == 0) remapflag = 1; // for backward compatibility
+    else if (strcmp(arg[i],"try_jump") == 0) {
+      if (i+1 >= narg) {
+        utils::missing_cmd_args(FLERR, "read_restart try_jump", error);
+      }
+      try_jump = true;
+      jump_location = arg[++i];
+    } else error->all(FLERR, 1, "Unknown read_restart keyword {}", arg[1]);
   }
 
   // if filename contains "*", search dir for latest restart file
@@ -78,11 +85,15 @@ void ReadRestart::command(int narg, char **arg)
   if (strchr(arg[0],'*')) {
     int n=0;
     if (me == 0) {
-      auto fn = file_search(arg[0]);
-      n = fn.size()+1;
-      file = utils::strdup(fn);
+      auto fn_opt = file_search(arg[0]);
+      if (fn_opt) {
+        auto& fn = fn_opt.value();
+        n = fn.size()+1;
+        file = utils::strdup(fn);
+      }
     }
     MPI_Bcast(&n,1,MPI_INT,0,world);
+    if (n == 0) return;
     if (me != 0) file = new char[n];
     MPI_Bcast(file,n,MPI_CHAR,0,world);
   } else file = utils::strdup(arg[0]);
@@ -94,18 +105,29 @@ void ReadRestart::command(int narg, char **arg)
   if (utils::strmatch(arg[0],R"(\.mpiio)"))
     error->all(FLERR, Error::ARGZERO, "MPI-IO restart files are no longer supported by LAMMPS");
 
+  std::string hfile = file;
+  if (multiproc) {
+    hfile.replace(hfile.find('%'),1,"base");
+  }
+
   // open single restart file or base file for multiproc case
 
-  if (me == 0) {
+  if (me == 0 && (!try_jump || std::filesystem::exists(hfile))) {
     utils::logmesg(lmp,"Reading restart file ...\n");
-    std::string hfile = file;
-    if (multiproc) {
-      hfile.replace(hfile.find('%'),1,"base");
-    }
     fp = fopen(hfile.c_str(),"rb");
-    if (fp == nullptr)
+    if (fp == nullptr) {
       error->one(FLERR, Error::ARGZERO, "Cannot open restart file {}: {}", hfile,
                  utils::getsyserror());
+    }
+  }
+
+  // Check if file was found and opened
+
+  int file_opened = fp != nullptr;
+  MPI_Bcast(&file_opened,1,MPI_INT,0,world);
+  if (!file_opened) {
+    delete[] file;
+    return;
   }
 
   // read magic string, endian flag, format revision
@@ -493,6 +515,10 @@ void ReadRestart::command(int narg, char **arg)
 
   if (comm->me == 0)
     utils::logmesg(lmp,"  read_restart CPU = {:.3f} seconds\n",platform::walltime()-time1);
+
+  if (try_jump) {
+    input->one("jump " + jump_location);
+  }
 }
 
 /* ----------------------------------------------------------------------
@@ -504,7 +530,7 @@ void ReadRestart::command(int narg, char **arg)
    only called by proc 0
 ------------------------------------------------------------------------- */
 
-std::string ReadRestart::file_search(const std::string &inpfile)
+std::optional<std::string> ReadRestart::file_search(const std::string &inpfile)
 {
   // separate inpfile into dir + filename
 
@@ -540,7 +566,13 @@ std::string ReadRestart::file_search(const std::string &inpfile)
         if (num > maxnum) maxnum = num;
       }
     }
-    if (maxnum < 0) error->one(FLERR, 1, "Found no restart file matching pattern");
+    if (maxnum < 0) {
+      if (!try_jump) {
+        error->one(FLERR, 1, "Found no restart file matching pattern");
+      } else {
+        return {};
+      }
+    }
     filename.replace(filename.find('*'),1,std::to_string(maxnum));
   }
   return platform::path_join(dirname,filename);

--- a/src/read_restart.h
+++ b/src/read_restart.h
@@ -23,6 +23,8 @@ CommandStyle(read_restart,ReadRestart);
 #include "command.h"
 #include "safe_pointers.h"
 
+#include <optional>
+
 namespace LAMMPS_NS {
 
 class ReadRestart : public Command {
@@ -40,7 +42,10 @@ class ReadRestart : public Command {
   int nprocs_file;       // total # of procs that wrote restart file
   int revision;          // revision number of the restart file format
 
-  std::string file_search(const std::string &);
+  bool try_jump;
+  std::string jump_location;
+
+  std::optional<std::string> file_search(const std::string &);
   void header();
   void type_arrays();
   void force_fields();


### PR DESCRIPTION
**Summary**

This option allows users to attempt to read_restart when the presence of a restart file is unknown. Allows checkpoint/restart to run via a single input file that can be called repeatedly. The *try_jump* option allows you to jump past any simulation setup that you would do in the absence of a restart file.

**Author(s)**

Matthew Whitlock, Sandia National Laboratories.

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

<!--Please update the following sentence as needed in case you were using AI tools to
generate code.  Please mention which specific AI tool or tools you were using and which
parts of the code were AI generated versus the parts written by a human.  The use of AI
tools for checking spelling and syntax does not need to be reported.-->

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

No breaks.

**Implementation Notes**

There aren't any existing unit tests for jump functionality, so I chose an example file that uses read_restart and modified it to use this new feature. I manually confirmed correct behavior when no restart file was written by commenting out the write_restart command in the example's input file.

Is this sufficient for this small change, or do changes need to be made to support jumping to labels in the unit tests?

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [x] A package specific README file has been included or updated
- [x] One or more example input decks are included


<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


