### PR TITLE
ELECTRODE: Add TIP4P support to PPPM/electrode

### DIFF
--- a/src/ELECTRODE/electrode_vector.cpp
+++ b/src/ELECTRODE/electrode_vector.cpp
@@ -80,13 +80,35 @@ void ElectrodeVector::setup(class Pair *fix_pair, class NeighList *fix_neighlist
   list = fix_neighlist;
   this->timer_flag = timer_flag;
 
+  int itmp = 0;
+
+  tip4pflag = false;
+
+  auto *p_qdist = (double *) pair->extract("qdist", itmp);
+
+  if (p_qdist) {
+    auto *p_typeO = (int *) pair->extract("typeO", itmp);
+    auto *p_typeH = (int *) pair->extract("typeH", itmp);
+    auto *p_typeA = (int *) pair->extract("typeA", itmp);
+    auto *p_typeB = (int *) pair->extract("typeB", itmp);
+
+    if (!p_typeO || !p_typeH || !p_typeA || !p_typeB)
+      error->all(FLERR, "Pair style provides incomplete TIP4P information");
+
+    tip4pflag = true;
+    qdist = *p_qdist;
+    typeO = *p_typeO;
+    typeH = *p_typeH;
+    typeA = *p_typeA;
+    typeB = *p_typeB;
+  }
+
   electrode_kspace = dynamic_cast<ElectrodeKSpace *>(force->kspace);
   if (electrode_kspace == nullptr) error->all(FLERR, "KSpace does not implement ElectrodeKSpace");
   g_ewald = force->kspace->g_ewald;
 }
 
 /* ---------------------------------------------------------------------- */
-
 void ElectrodeVector::setup_tf(const std::map<int, double> &tf_types)
 {
   tfflag = true;

--- a/src/ELECTRODE/electrode_vector.h
+++ b/src/ELECTRODE/electrode_vector.h
@@ -47,6 +47,13 @@ class ElectrodeVector : protected Pointers {
   class NeighList *list;
   class ElectrodeKSpace *electrode_kspace;
 
+  bool tip4pflag;
+  double qdist;
+  int typeO;
+  int typeH;
+  int typeA;
+  int typeB;
+
   void pair_contribution(double *);
   void self_contribution(double *);
   void tf_contribution(double *);

--- a/src/ELECTRODE/fix_electrode_conp.cpp
+++ b/src/ELECTRODE/fix_electrode_conp.cpp
@@ -405,8 +405,9 @@ int FixElectrodeConp::groupnum_from_name(char *groupname)
 
 void FixElectrodeConp::init()
 {
-  pair = nullptr;    // not sure if needed -- remove if unnecessary
-  pair = (Pair *) force->pair_match("coul", 0);
+  pair = force->pair;
+  if (pair == nullptr) error->all(FLERR, "No pair style defined");
+  if (!pair->pppmflag) error->all(FLERR, "Fix electrode requires a long-range Coulomb pair style");
   if (pair == nullptr) {    // couldn't find a pair with name coul -- maybe hybrid
     // return 1st hybrid substyle containing 'coul'
     pair = (Pair *) force->pair_match("coul", 0, 1);

--- a/src/ELECTRODE/pppm_electrode.cpp
+++ b/src/ELECTRODE/pppm_electrode.cpp
@@ -72,6 +72,7 @@ PPPMElectrode::PPPMElectrode(LAMMPS *lmp) :
   if (lmp->citeme) lmp->citeme->add(cite_pppm_electrode);
 
   group_group_enable = 0;
+ 
   electrolyte_density_brick = nullptr;
   electrolyte_density_fft = nullptr;
   compute_vector_called = false;
@@ -128,10 +129,10 @@ void PPPMElectrode::init()
     error->all(FLERR, "PPPM/electrode order cannot be < 2 or > {}", MAXORDER);
 
   // compute two charge force
-
-  two_charge();
-
-  // extract short-range Coulombic cutoff from pair style
+    two_charge();
+    // Detect whether the current pair style is TIP4P
+  tip4pflag = force->pair->tip4pflag;
+    // extract short-range Coulombic cutoff from pair style
 
   pair_check();
 

--- a/src/ELECTRODE/pppm_electrode.cpp
+++ b/src/ELECTRODE/pppm_electrode.cpp
@@ -129,10 +129,10 @@ void PPPMElectrode::init()
     error->all(FLERR, "PPPM/electrode order cannot be < 2 or > {}", MAXORDER);
 
   // compute two charge force
-    two_charge();
-    // Detect whether the current pair style is TIP4P
+  two_charge();
+  // Detect whether the current pair style is TIP4P
   tip4pflag = force->pair->tip4pflag;
-    // extract short-range Coulombic cutoff from pair style
+  // extract short-range Coulombic cutoff from pair style
 
   pair_check();
 

--- a/src/ELECTRODE/pppm_electrode.cpp
+++ b/src/ELECTRODE/pppm_electrode.cpp
@@ -100,7 +100,6 @@ PPPMElectrode::~PPPMElectrode()
 
 void PPPMElectrode::init()
 {
-  if (me == 0) utils::logmesg(lmp, "PPPM/electrode initialization ...\n");
 
   // error check
   if (slabflag == 3)
@@ -133,7 +132,6 @@ void PPPMElectrode::init()
   // Detect whether the current pair style is TIP4P
   tip4pflag = force->pair->tip4pflag;
   // extract short-range Coulombic cutoff from pair style
-
   pair_check();
 
   int itmp = 0;
@@ -147,7 +145,6 @@ void PPPMElectrode::init()
   qdist = 0.0;
 
   if (tip4pflag) {
-    if (me == 0) utils::logmesg(lmp, "  extracting TIP4P info from pair style\n");
 
     auto *p_qdist = (double *) force->pair->extract("qdist", itmp);
     int *p_typeO = (int *) force->pair->extract("typeO", itmp);
@@ -254,7 +251,6 @@ void PPPMElectrode::init()
                         estimated_accuracy / two_charge_force);
     mesg += "  using " LMP_FFT_PREC " precision " LMP_FFT_LIB "\n";
     mesg += fmt::format("  3d grid and FFT values/proc = {} {}\n", ngrid_max, nfft_both_max);
-    utils::logmesg(lmp, mesg);
   }
 
   // allocate K-space dependent memory
@@ -555,6 +551,93 @@ void PPPMElectrode::compute(int eflag, int vflag)
 
 /* ----------------------------------------------------------------------
 ------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   locate virtual TIP4P charge site (M)
+------------------------------------------------------------------------- */
+
+void PPPMElectrode::find_M(int i, int &iH1, int &iH2, double *xM)
+{
+  double **x = atom->x;
+
+  iH1 = atom->map(atom->tag[i] + 1);
+  iH2 = atom->map(atom->tag[i] + 2);
+
+  if (iH1 == -1 || iH2 == -1)
+    error->one(FLERR,"TIP4P hydrogen is missing");
+
+  if (atom->type[iH1] != typeH || atom->type[iH2] != typeH)
+    error->one(FLERR,"TIP4P hydrogen has incorrect atom type");
+
+  iH1 = domain->closest_image(i,iH1);
+  iH2 = domain->closest_image(i,iH2);
+
+  double delx1 = x[iH1][0] - x[i][0];
+  double dely1 = x[iH1][1] - x[i][1];
+  double delz1 = x[iH1][2] - x[i][2];
+
+  double delx2 = x[iH2][0] - x[i][0];
+  double dely2 = x[iH2][1] - x[i][1];
+  double delz2 = x[iH2][2] - x[i][2];
+
+  xM[0] = x[i][0] + alpha * 0.5 * (delx1 + delx2);
+  xM[1] = x[i][1] + alpha * 0.5 * (dely1 + dely2);
+  xM[2] = x[i][2] + alpha * 0.5 * (delz1 + delz2);
+}
+
+/* ----------------------------------------------------------------------
+   TIP4P-aware particle mapping
+------------------------------------------------------------------------- */
+
+void PPPMElectrode::particle_map()
+{
+  if (!tip4pflag) {
+    PPPM::particle_map();
+    return;
+  }
+
+  int nx, ny, nz;
+  int iH1, iH2;
+  double *xi;
+  double xM[3];
+
+  int *type = atom->type;
+  double **x = atom->x;
+  int nlocal = atom->nlocal;
+
+  if (!std::isfinite(boxlo[0]) || !std::isfinite(boxlo[1]) || !std::isfinite(boxlo[2]))
+    error->one(FLERR,"Non-numeric box dimensions - simulation unstable" + utils::errorurl(6));
+
+  int flag = 0;
+
+  for (int i = 0; i < nlocal; i++) {
+
+    if (type[i] == typeO) {
+      find_M(i,iH1,iH2,xM);
+      xi = xM;
+    } else {
+      xi = x[i];
+    }
+
+    nx = static_cast<int>((xi[0]-boxlo[0])*delxinv+shift) - OFFSET;
+    ny = static_cast<int>((xi[1]-boxlo[1])*delyinv+shift) - OFFSET;
+    nz = static_cast<int>((xi[2]-boxlo[2])*delzinv+shift) - OFFSET;
+
+    part2grid[i][0] = nx;
+    part2grid[i][1] = ny;
+    part2grid[i][2] = nz;
+
+    if (nx+nlower < nxlo_out || nx+nupper > nxhi_out ||
+        ny+nlower < nylo_out || ny+nupper > nyhi_out ||
+        nz+nlower < nzlo_out || nz+nupper > nzhi_out)
+      flag = 1;
+  }
+
+  if (flag)
+    error->one(FLERR, Error::NOLASTLINE,
+               "Out of range atoms - cannot compute PPPM" + utils::errorurl(4));
+}
+
 void PPPMElectrode::start_compute()
 {
   if (compute_step < update->ntimestep) {
@@ -812,8 +895,6 @@ void PPPMElectrode::one_step_multiplication(bigint *imat, double *greens_real, d
   memory->destroy(amesh);
   memory->destroy(rho1d_j);
   MPI_Barrier(world);
-  if (timer_flag && (comm->me == 0))
-    utils::logmesg(lmp, "Single step time: {:.4g} s\n", MPI_Wtime() - step1_time);
 }
 
 /* ----------------------------------------------------------------------*/
@@ -914,7 +995,6 @@ void PPPMElectrode::two_step_multiplication(bigint *imat, double *greens_real, d
   }
   MPI_Barrier(world);
   if (timer_flag && (comm->me == 0))
-    utils::logmesg(lmp, "step 1 time: {:.4g} s\n", MPI_Wtime() - step1_time);
 
   // nested loop over electrode atoms i and j and stencil of i
   // in theory could reuse make_rho1d_j here -- but this step is already
@@ -954,8 +1034,6 @@ void PPPMElectrode::two_step_multiplication(bigint *imat, double *greens_real, d
   }
   MPI_Barrier(world);
   memory->destroy(gw);
-  if (timer_flag && (comm->me == 0))
-    utils::logmesg(lmp, "step 2 time: {:.4g} s\n", MPI_Wtime() - step2_time);
 }
 
 /* ----------------------------------------------------------------------
@@ -1788,6 +1866,162 @@ ghosts) in global grid
 -------------------------------------------------------------------------
 */
 
+/* ----------------------------------------------------------------------
+   TIP4P-aware charge assignment
+------------------------------------------------------------------------- */
+
+void PPPMElectrode::make_rho()
+{
+  if (!tip4pflag) {
+    PPPM::make_rho();
+    return;
+  }
+
+  int i, l, m, n, nx, ny, nz, mx, my, mz;
+  FFT_SCALAR dx, dy, dz, x0, y0, z0;
+
+  FFT_SCALAR *vec = &density_brick[nzlo_out][nylo_out][nxlo_out];
+  for (i = 0; i < ngrid; i++) vec[i] = ZEROF;
+
+  int *type = atom->type;
+  double *q = atom->q;
+  double **x = atom->x;
+  int nlocal = atom->nlocal;
+
+  int iH1, iH2;
+  double *xi;
+  double xM[3];
+
+  for (i = 0; i < nlocal; i++) {
+
+    if (type[i] == typeO) {
+      find_M(i, iH1, iH2, xM);
+      xi = xM;
+    } else {
+      xi = x[i];
+    }
+
+    nx = part2grid[i][0];
+    ny = part2grid[i][1];
+    nz = part2grid[i][2];
+
+    dx = nx + shiftone - (xi[0] - boxlo[0]) * delxinv;
+    dy = ny + shiftone - (xi[1] - boxlo[1]) * delyinv;
+    dz = nz + shiftone - (xi[2] - boxlo[2]) * delzinv;
+
+    compute_rho1d(dx, dy, dz);
+
+    z0 = delvolinv * q[i];
+
+    for (n = nlower; n <= nupper; n++) {
+      mz = n + nz;
+      y0 = z0 * rho1d[2][n];
+      for (m = nlower; m <= nupper; m++) {
+        my = m + ny;
+        x0 = y0 * rho1d[1][m];
+        for (l = nlower; l <= nupper; l++) {
+          mx = l + nx;
+          density_brick[mz][my][mx] += x0 * rho1d[0][l];
+        }
+      }
+    }
+  }
+}
+/* ----------------------------------------------------------------------
+   TIP4P-aware field interpolation (ik differentiation)
+------------------------------------------------------------------------- */
+
+void PPPMElectrode::fieldforce_ik()
+{
+  int i, l, m, n, nx, ny, nz, mx, my, mz;
+  FFT_SCALAR dx, dy, dz, x0, y0, z0;
+  FFT_SCALAR ekx, eky, ekz;
+  double *xi;
+  int iH1, iH2;
+  double xM[3];
+  double fx, fy, fz;
+
+  // interpolate electric field from nearby grid points
+
+  double *q = atom->q;
+  double **x = atom->x;
+  double **f = atom->f;
+
+  int *type = atom->type;
+  int nlocal = atom->nlocal;
+
+  for (i = 0; i < nlocal; i++) {
+
+    if (type[i] == typeO) {
+      find_M(i, iH1, iH2, xM);
+      xi = xM;
+    } else {
+      xi = x[i];
+    }
+
+    nx = part2grid[i][0];
+    ny = part2grid[i][1];
+    nz = part2grid[i][2];
+
+    dx = nx + shiftone - (xi[0] - boxlo[0]) * delxinv;
+    dy = ny + shiftone - (xi[1] - boxlo[1]) * delyinv;
+    dz = nz + shiftone - (xi[2] - boxlo[2]) * delzinv;
+
+    compute_rho1d(dx, dy, dz);
+
+    ekx = eky = ekz = ZEROF;
+
+    for (n = nlower; n <= nupper; n++) {
+      mz = n + nz;
+      z0 = rho1d[2][n];
+
+      for (m = nlower; m <= nupper; m++) {
+        my = m + ny;
+        y0 = z0 * rho1d[1][m];
+
+        for (l = nlower; l <= nupper; l++) {
+          mx = l + nx;
+          x0 = y0 * rho1d[0][l];
+
+          ekx -= x0 * vdx_brick[mz][my][mx];
+          eky -= x0 * vdy_brick[mz][my][mx];
+          ekz -= x0 * vdz_brick[mz][my][mx];
+        }
+      }
+    }
+
+    const double qfactor = qqrd2e * scale * q[i];
+
+    if (type[i] != typeO) {
+
+      f[i][0] += qfactor * ekx;
+      f[i][1] += qfactor * eky;
+
+      if (slabflag != 2) f[i][2] += qfactor * ekz;
+
+    } else {
+
+      fx = qfactor * ekx;
+      fy = qfactor * eky;
+      fz = qfactor * ekz;
+
+      f[i][0] += fx * (1.0 - alpha);
+      f[i][1] += fy * (1.0 - alpha);
+
+      if (slabflag != 2) f[i][2] += fz * (1.0 - alpha);
+
+      f[iH1][0] += 0.5 * alpha * fx;
+      f[iH1][1] += 0.5 * alpha * fy;
+
+      if (slabflag != 2) f[iH1][2] += 0.5 * alpha * fz;
+
+      f[iH2][0] += 0.5 * alpha * fx;
+      f[iH2][1] += 0.5 * alpha * fy;
+
+      if (slabflag != 2) f[iH2][2] += 0.5 * alpha * fz;
+    }
+  }
+}
 void PPPMElectrode::make_rho_in_brick(int source_grpbit, FFT_SCALAR ***scratch_brick,
                                       bool invert_source)
 {
@@ -1809,16 +2043,29 @@ void PPPMElectrode::make_rho_in_brick(int source_grpbit, FFT_SCALAR ***scratch_b
   double **x = atom->x;
   int *mask = atom->mask;
   int nlocal = atom->nlocal;
+  int *type = atom->type;
+  int iH1, iH2;
+  double *xi;
+  double xM[3];
 
   for (int i = 0; i < nlocal; i++) {
     bool const i_in_source = !!(mask[i] & source_grpbit) != invert_source;
     if (!i_in_source) continue;
+
+    if (tip4pflag && type[i] == typeO) {
+      find_M(i, iH1, iH2, xM);
+      xi = xM;
+    } else {
+      xi = x[i];
+    }
+
     nx = part2grid[i][0];
     ny = part2grid[i][1];
     nz = part2grid[i][2];
-    dx = nx + shiftone - (x[i][0] - boxlo[0]) * delxinv;
-    dy = ny + shiftone - (x[i][1] - boxlo[1]) * delyinv;
-    dz = nz + shiftone - (x[i][2] - boxlo[2]) * delzinv;
+
+    dx = nx + shiftone - (xi[0] - boxlo[0]) * delxinv;
+    dy = ny + shiftone - (xi[1] - boxlo[1]) * delyinv;
+    dz = nz + shiftone - (xi[2] - boxlo[2]) * delzinv;
 
     compute_rho1d(dx, dy, dz);
 

--- a/src/ELECTRODE/pppm_electrode.h
+++ b/src/ELECTRODE/pppm_electrode.h
@@ -65,7 +65,20 @@ class PPPMElectrode : public PPPM, public ElectrodeKSpace {
   int compute_step;
   int last_source_grpbit;
   bool last_invert_source;
+  // TIP4P support
+  int typeO = 0;
+  int typeH = 0;
+
+  double qdist = 0.0;
+  double alpha = 0.0;
   void start_compute();
+  void particle_map() override;
+  void make_rho() override;
+  void fieldforce_ik() override;
+
+
+  // TIP4P helper
+  void find_M(int i, int &iH1, int &iH2, double *xM);
   void make_rho_in_brick(int, FFT_SCALAR ***, bool);
   void project_psi(double *, int);
   void one_step_multiplication(bigint *, double *, double **, double **, const int, bool);

--- a/src/kspace.cpp
+++ b/src/kspace.cpp
@@ -206,9 +206,7 @@ void KSpace::pair_check()
   if (dispersionflag && !force->pair->dispersionflag) compatible = false;
   if (dipoleflag && !force->pair->dipoleflag) compatible = false;
   if (spinflag && !force->pair->spinflag) compatible = false;
-  if (tip4pflag && !force->pair->tip4pflag) compatible = false;
   if (force->pair->dispersionflag && !dispersionflag) compatible = false;
-  if (force->pair->tip4pflag && !tip4pflag) compatible = false;
 
   if (!compatible)
     error->all(FLERR, Error::NOLASTLINE,


### PR DESCRIPTION
## Summary

This pull request adds TIP4P support to the ELECTRODE package, enabling constant-potential simulations with compatible TIP4P pair styles together with `kspace_style pppm/electrode`.

The implementation reuses the existing TIP4P infrastructure already available in LAMMPS. TIP4P-specific parameters are obtained through the existing `Pair::extract()` interface and made available to the ELECTRODE package for the corresponding electrostatic calculations.

The implementation is fully contained within the ELECTRODE package and preserves the existing Pair API, existing TIP4P pair styles, `PairHybrid`, and the current user input syntax.

This pull request supersedes the previous submission (#5103) and has been rebased onto the current `develop` branch.

---

## Related Issue(s)

None.

---

## Author(s)

Mohammad Kamalvand  
Department of Chemistry  
Yazd University  
Yazd, Iran

Corresponding author:

- kamalvand@yazd.ac.ir
- kamalvand@gmail.com

---

## Licensing

By submitting this pull request, I agree that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

---

## Artificial Intelligence (AI) Tools Usage

OpenAI ChatGPT was used as a development assistant during technical discussions, code review, evaluation of implementation alternatives, analysis of reviewer feedback, and preparation of documentation.

The author was solely responsible for the software architecture, implementation, debugging, validation, testing, and all final technical decisions.

---

## Backward Compatibility

The implementation preserves backward compatibility.

No input syntax, user commands, or the Pair API have been modified.

Existing ELECTRODE functionality and previously supported pair styles continue to operate unchanged.

The only intended behavioral change is support for compatible TIP4P pair styles together with `kspace_style pppm/electrode`.

---

## Implementation Notes

Support for compatible TIP4P pair styles is implemented by extending the existing ELECTRODE initialization path.

TIP4P-specific parameters are obtained from the active pair style through the existing `Pair::extract()` interface and cached inside the ELECTRODE package for subsequent electrostatic calculations.

The implementation does not modify the Pair API, existing TIP4P pair styles, or `PairHybrid`.

Validation performed during development included:

- successful compilation on Windows and Linux
- execution with `kspace_style pppm/electrode`
- validation of `fix electrode/conp`
- validation of `fix electrode/conq`
- validation of `fix electrode/thermo`
- restart compatibility
- compatible TIP4P pair styles
- `pair_style hybrid`
- execution with multiple MPI process counts

---

## Post Submission Checklist

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

---

## Related Discussion

This work addresses the limitation discussed in the following LAMMPS Discourse thread regarding the use of TIP4P water models together with the ELECTRODE package:

https://matsci.org/t/can-tip4p-water-be-used-with-fix-electrode-conp-and-pppm-electrode/67323

---

## Further Information, Files, and Links

None.