### PR TITLE
Make extrapolation count accesible to lammps

### DIFF
--- a/src/ML-RUNNER/pair_runner.cpp
+++ b/src/ML-RUNNER/pair_runner.cpp
@@ -815,18 +815,18 @@ void PairRuNNer::compute(int eflag, int vflag)
     // Number of extrapolation accumulated on this process during this this timestep
     bigint local_extrap_count_timestep = 0;
     // Total number of extrapolation accumulated on this process during the simulation
-    bigint* local_extrap_count_total = nullptr; // Not needed anymore
+    bigint local_extrap_count_total = 0; // Not needed anymore
     bool lreset = false; // Not needed anymore
     // Retrieve the number of extrapolations during this timestep and during the whole simulation
     // on each process and reset the latter if `lreset` is true.
-    runner_interface_extrapolation_count(&local_extrap_count_timestep, local_extrap_count_total,
+    runner_interface_extrapolation_count(&local_extrap_count_timestep, &local_extrap_count_total,
                                          &lreset);
 
     // Number of extrapolations recorded globally during this timestep
     bigint global_extrap_count_timestep = 0;
-    MPI_Reduce(&local_extrap_count_timestep, &global_extrap_count_timestep, 1, MPI_LMP_BIGINT,
-               MPI_SUM, 0, world);
-    pvector[nextra - 1] = global_extrap_count_timestep;
+    MPI_Allreduce(&local_extrap_count_timestep, &global_extrap_count_timestep, 1, MPI_LMP_BIGINT,
+               MPI_SUM, world);
+    pvector[nextra - 1] = static_cast<double>(global_extrap_count_timestep);
 
     // Number of extrapolations recorded globally (printed in each extrapolation summary)
     extrap_count_summary += global_extrap_count_timestep; // Not affected by (`reset_ew_freq`)
@@ -930,7 +930,6 @@ void PairRuNNer::settings(int narg, char **arg)
     } else if (strcmp(arg[iarg], "check_extrap") == 0) {
       if (iarg + 2 > narg) error->all(FLERR, "Illegal pair_style command");
       lcheck_extrap = utils::logical(FLERR, arg[iarg + 1], false, lmp);
-      nextra += 1;
       iarg += 2;
     } else if (strcmp(arg[iarg], "max_extrap") == 0) {
       if (iarg + 2 > narg) error->all(FLERR, "Illegal pair_style command");
@@ -1030,12 +1029,10 @@ void PairRuNNer::init_style()
   if (nnp_generation == 2) no_virial_fdotr_compute = 0;    // Overwrite default flag
 
   // Error checking for output by compute pair command
-  if (
-    (!lcheck_extrap && nextra == num_committee_members) ||
-    (lcheck_extrap && nextra == num_committee_members + 1)
-  ) {
+  if (nextra == num_committee_members) {
     // array for storing committee energies for output by compute pair command
     if (pvector) delete[] pvector;
+    if (lcheck_extrap) nextra += 1;
     pvector = new double[nextra];
   } else {
     error->all(FLERR,

--- a/src/ML-RUNNER/pair_runner.cpp
+++ b/src/ML-RUNNER/pair_runner.cpp
@@ -160,9 +160,9 @@ PairRuNNer::PairRuNNer(LAMMPS *lmp) :
   comm_reverse = 1;    // Reverse communication (1 double per atom)
   commstyle = COMM_NONE;
 
-  // Sum of extrapolation is zero upon initialization of this pair style
   // Tracks number of extrapolations over multiple timesteps
-  local_extrap_sum = 0;
+  extrap_count_summary = 0; // Not affected by `reset_ew_freq`
+  extrap_count_abort = 0;
 
   // variable for output using pair compute
   nextra = 0;
@@ -762,7 +762,7 @@ void PairRuNNer::compute(int eflag, int vflag)
   // - Resets the number of total number of recorded extrapolations during a simulation if
   // the timestep is a multiple of `reset_ew_freq` and larger than 0.
   // - Prints a summary of the recorded extrapolations at every interval until the timestep is
-  // a multiple of `sum_ew_freq` and larger than 0.
+  // a multiple of `sum_ew_freq` and larger than 0. (Not affected by `reset_ew_freq`)
   if (lcheck_extrap) {
 
     bigint timestep = update->ntimestep;
@@ -812,60 +812,58 @@ void PairRuNNer::compute(int eflag, int vflag)
       c_ptr_extrap_msg = nullptr;
     }
 
-    // Total number of extrapolation accumulated on this process during the simulation
-    bigint local_extrap_count_total = 0;
     // Number of extrapolation accumulated on this process during this this timestep
     bigint local_extrap_count_timestep = 0;
-    // Sets the flag `lreset` to reset the total extrapolation count if the timestep
-    // is a multiple of reset_ew_freq and larger than zero
-    bool lreset = false;
-    if (reset_ew_freq > 0 && timestep % reset_ew_freq == 0 && timestep > 0) { lreset = true; }
-
+    // Total number of extrapolation accumulated on this process during the simulation
+    bigint* local_extrap_count_total = nullptr; // Not needed anymore
+    bool lreset = false; // Not needed anymore
     // Retrieve the number of extrapolations during this timestep and during the whole simulation
     // on each process and reset the latter if `lreset` is true.
-    runner_interface_extrapolation_count(&local_extrap_count_timestep, &local_extrap_count_total,
+    runner_interface_extrapolation_count(&local_extrap_count_timestep, local_extrap_count_total,
                                          &lreset);
 
-    // Number of extrapolations recorded on this process (reset at every summary)
-    local_extrap_sum += local_extrap_count_timestep;
-
-    // Number of extrapolations recorded during this timestep across all processes
+    // Number of extrapolations recorded globally during this timestep
     bigint global_extrap_count_timestep = 0;
-    MPI_Reduce(&local_extrap_count_timestep, &global_extrap_count_timestep, 1, MPI_LMP_BIGINT, 
+    MPI_Reduce(&local_extrap_count_timestep, &global_extrap_count_timestep, 1, MPI_LMP_BIGINT,
                MPI_SUM, 0, world);
     pvector[nextra - 1] = global_extrap_count_timestep;
 
-    // Total number of extrapolation accumulated across all processes
-    bigint global_extrap_count_total = 0;
-    MPI_Reduce(&local_extrap_count_total, &global_extrap_count_total, 1, MPI_LMP_BIGINT, MPI_SUM, 0,
-               world);
+    // Number of extrapolations recorded globally (printed in each extrapolation summary)
+    extrap_count_summary += global_extrap_count_timestep; // Not affected by (`reset_ew_freq`)
+    // Number of extrapolations recorded globally (aborts simulation if larger
+    // than `max_extrap`)
+    extrap_count_abort += global_extrap_count_timestep;
 
-    // Abort simulation if the total number of extrapolations across all processes exceeds `max_extrap`
-    if (max_extrap > -1 && global_extrap_count_total > max_extrap && rank == 0) {
+    // Abort simulation if the number of extrapolations across all processes exceeds `max_extrap`
+    if (max_extrap > -1 && extrap_count_abort > max_extrap && rank == 0) {
       error->one(
           FLERR,
           "Maximal number of allowed extrapolations have been exceeded during the simulation!\n"
           "Current extrapolation count: {:10.3e}",
-          static_cast<double>(global_extrap_count_total));
+          static_cast<double>(extrap_count_abort));
+    }
+
+    // Reset the global extrapolation count if the timestep is
+    // a multiple of reset_ew_freq and larger than zero
+    if (reset_ew_freq > 0 && timestep % reset_ew_freq == 0 && timestep > 0) {
+      extrap_count_abort = 0;
     }
 
     // Prints a summary of the recorded extrapolations at every interval until the timestep is
     // a multiple of `sum_ew_freq` and larger than 0.
     if (sum_ew_freq > 0 && timestep % sum_ew_freq == 0 && timestep > 0) {
-      bigint global_extrap_sum = 0;
-      MPI_Reduce(&local_extrap_sum, &global_extrap_sum, 1, MPI_LMP_BIGINT, MPI_SUM, 0, world);
-
       if (rank == 0) {
         utils::logmesg(lmp,
                        "RuNNer2: HDNNP Extrapolation Summary\n"
                        "Timestep: {:10d} Sum: {:10.3e} Frequency: {:10.3e} per timestep\n",
-                       timestep, static_cast<double>(global_extrap_sum),
-                       static_cast<double>(global_extrap_sum) / static_cast<double>(sum_ew_freq));
+                       timestep, static_cast<double>(extrap_count_summary),
+                       static_cast<double>(extrap_count_summary) / static_cast<double>(sum_ew_freq));
       }
-      local_extrap_sum = 0;
+      extrap_count_summary = 0;
     }
     // Deallocates the character array containing the extrapolation message on the Fortran side
-    // and frees up the internal memory of the `ExtrapolationHandler` (see RuNNer 2 documentation)
+    // (if `lshow_ew`) and frees up the internal memory of the `ExtrapolationHandler`
+    // (see RuNNer 2 documentation)
     runner_interface_dealloc_extrapolation_warnings();
   }
 
@@ -1033,7 +1031,7 @@ void PairRuNNer::init_style()
 
   // Error checking for output by compute pair command
   if (
-    (!lcheck_extrap && nextra == num_committee_members) || 
+    (!lcheck_extrap && nextra == num_committee_members) ||
     (lcheck_extrap && nextra == num_committee_members + 1)
   ) {
     // array for storing committee energies for output by compute pair command

--- a/src/ML-RUNNER/pair_runner.cpp
+++ b/src/ML-RUNNER/pair_runner.cpp
@@ -725,7 +725,7 @@ void PairRuNNer::compute(int eflag, int vflag)
   }
 
   // Write committee energies into pair compute vector
-  memset(pvector, 0, num_committee_members * (sizeof *pvector));
+  memset(pvector, 0, nextra * (sizeof *pvector));
   for (i = 0; i < num_committee_members; i++) pvector[i] = committee_energy[i] / cfenergy;
 
   // Charges if charge atom style is used
@@ -815,7 +815,7 @@ void PairRuNNer::compute(int eflag, int vflag)
     // Total number of extrapolation accumulated on this process during the simulation
     bigint local_extrap_count_total = 0;
     // Number of extrapolation accumulated on this process during this this timestep
-    bigint extrap_count_timestep = 0;
+    bigint local_extrap_count_timestep = 0;
     // Sets the flag `lreset` to reset the total extrapolation count if the timestep
     // is a multiple of reset_ew_freq and larger than zero
     bool lreset = false;
@@ -823,11 +823,17 @@ void PairRuNNer::compute(int eflag, int vflag)
 
     // Retrieve the number of extrapolations during this timestep and during the whole simulation
     // on each process and reset the latter if `lreset` is true.
-    runner_interface_extrapolation_count(&extrap_count_timestep, &local_extrap_count_total,
+    runner_interface_extrapolation_count(&local_extrap_count_timestep, &local_extrap_count_total,
                                          &lreset);
 
     // Number of extrapolations recorded on this process (reset at every summary)
-    local_extrap_sum += extrap_count_timestep;
+    local_extrap_sum += local_extrap_count_timestep;
+
+    // Number of extrapolations recorded during this timestep across all processes
+    bigint global_extrap_count_timestep = 0;
+    MPI_Reduce(&local_extrap_count_timestep, &global_extrap_count_timestep, 1, MPI_LMP_BIGINT, 
+               MPI_SUM, 0, world);
+    pvector[nextra - 1] = global_extrap_count_timestep;
 
     // Total number of extrapolation accumulated across all processes
     bigint global_extrap_count_total = 0;
@@ -926,6 +932,7 @@ void PairRuNNer::settings(int narg, char **arg)
     } else if (strcmp(arg[iarg], "check_extrap") == 0) {
       if (iarg + 2 > narg) error->all(FLERR, "Illegal pair_style command");
       lcheck_extrap = utils::logical(FLERR, arg[iarg + 1], false, lmp);
+      nextra += 1;
       iarg += 2;
     } else if (strcmp(arg[iarg], "max_extrap") == 0) {
       if (iarg + 2 > narg) error->all(FLERR, "Illegal pair_style command");
@@ -1025,7 +1032,10 @@ void PairRuNNer::init_style()
   if (nnp_generation == 2) no_virial_fdotr_compute = 0;    // Overwrite default flag
 
   // Error checking for output by compute pair command
-  if (nextra == num_committee_members) {
+  if (
+    (!lcheck_extrap && nextra == num_committee_members) || 
+    (lcheck_extrap && nextra == num_committee_members + 1)
+  ) {
     // array for storing committee energies for output by compute pair command
     if (pvector) delete[] pvector;
     pvector = new double[nextra];

--- a/src/ML-RUNNER/pair_runner.cpp
+++ b/src/ML-RUNNER/pair_runner.cpp
@@ -951,6 +951,8 @@ void PairRuNNer::settings(int narg, char **arg)
       error->all(FLERR, "Illegal pair_style command");
   }
 
+  if (lcheck_extrap) nextra += 1;
+
   // check if linked to the correct RuNNer library API version
   if (runner_lammps_api_version() != 2)
     error->all(FLERR,
@@ -1029,10 +1031,12 @@ void PairRuNNer::init_style()
   if (nnp_generation == 2) no_virial_fdotr_compute = 0;    // Overwrite default flag
 
   // Error checking for output by compute pair command
-  if (nextra == num_committee_members) {
+  if (
+    (!lcheck_extrap && nextra == num_committee_members)
+    || (lcheck_extrap && nextra == num_committee_members + 1)
+    ){
     // array for storing committee energies for output by compute pair command
     if (pvector) delete[] pvector;
-    if (lcheck_extrap) nextra += 1;
     pvector = new double[nextra];
   } else {
     error->all(FLERR,

--- a/src/ML-RUNNER/pair_runner.h
+++ b/src/ML-RUNNER/pair_runner.h
@@ -55,25 +55,30 @@ class PairRuNNer : public Pair {
   double memory_usage() override;
 
  private:
-  double cflength;    // Length conversion factor.
-  double cfenergy;    // Energy conversion factor.
-  bool
-      luse_prev_q;    // Use charges from previous timestep as initial guess for iterative qeq solvers.
-  bool lwrite_f_comm;      // Write committee forces into f_comm array
-  bool lwrite_q_comm;      // Write committee charges into q_comm array
-  bool lcheck_extrap;      // Flag enabling checks for feature extrapolation
-  bigint max_extrap;       // Maximal number of allowed timesteps with feature extrapolations
-  bool lshow_ew;           // Flag enabling output of extrapolation warnings to log file
-  bigint sum_ew_freq;      // Frequency where extrapolation warning summary is printed to log file
-  bigint reset_ew_freq;    // Frequency where extrapolation count is reseted to 0
-  bigint local_extrap_sum;    // Sum of recorded extrapolations per process over multiple time steps
-  double cutoff;              // Max feature map cutoff.
-  double total_charge;        // The total charge of the structure. Must be 0 for periodic systems.
-  char *directory;            // directory containing RuNNer potential files
-  int *map;                   // Mapping from atom types to elements
-  int nmax;                   // Allocated size of per-atom arrays.
-  static int instances;       // count pair style instances, since we currently
-                              // only support one instance at a time
+  double cflength;          // Length conversion factor.
+  double cfenergy;          // Energy conversion factor.
+  bool luse_prev_q;         
+  // Use charges from previous timestep as initial guess for iterative qeq solvers.
+  bool lwrite_f_comm;       // Write committee forces into f_comm array
+  bool lwrite_q_comm;       // Write committee charges into q_comm array
+  bool lcheck_extrap;       // Flag enabling checks for feature extrapolation
+  bigint max_extrap;        // Maximal number of allowed timesteps with feature extrapolations
+  bool lshow_ew;            // Flag enabling output of extrapolation warnings to log file
+  bigint sum_ew_freq;       // Frequency where extrapolation warning summary is printed to log file
+  bigint reset_ew_freq;     // Frequency where extrapolation count is reseted to 0
+  bigint extrap_count_summary; 
+  // Sum of extrapolations recorded globally over multiple time steps
+  // which is used for printing the extrapolation summary (only on root)
+  bigint extrap_count_abort; 
+  // Sum of extrapolations recorded globally over multiple time steps
+  // which is used for aborting the simulation (only on root)
+  double cutoff;             // Max feature map cutoff.
+  double total_charge;       // The total charge of the structure. Must be 0 for periodic systems.
+  char *directory;           // directory containing RuNNer potential files
+  int *map;                  // Mapping from atom types to elements
+  int nmax;                  // Allocated size of per-atom arrays.
+  static int instances;      // count pair style instances, since we currently
+                             // only support one instance at a time
 
   // Additional per-atom arrays
   double *atomic_charge, *hirshfeld_volume, *electronegativity, *lagrange_charges, *de_dq,


### PR DESCRIPTION
This PR makes the global extrapolation count during the current timestep accesible to the `compute pair` command via `pvector`.
