### PR TITLE
Implement utils::sprintf() and use it for format style variables and immediate variable expansion

### DIFF
--- a/doc/src/Developer_utils.rst
+++ b/doc/src/Developer_utils.rst
@@ -259,6 +259,9 @@ Convenience functions
 .. doxygenfunction:: print(FILE *fp, const std::string &mesg)
    :project: progguide
 
+.. doxygenfunction:: sprintf(const std::string &format, Args&&... args)
+   :project: progguide
+
 .. doxygenfunction:: errorurl
    :project: progguide
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -586,8 +586,9 @@ void Input::substitute(char *&str, char *&str2, int &max, int &max2, int flag)
   // beyond = points to text following variable
 
   int i,n,paren_count,nchars;
-  char immediate[256];
-  char *var,*value,*beyond;
+  std::string immediate;
+  char *var,*beyond;
+  const char *value;
   char *ptrmatch;
 
   char *ptr = str;
@@ -658,8 +659,8 @@ void Input::substitute(char *&str, char *&str2, int &max, int &max2, int flag)
         if (!utils::strmatch(fmtstr,R"(%[0-9 ]*\.[0-9]+[efgEFG])"))
           error->all(FLERR,"Incorrect conversion in format string {}", fmtstr);
 
-        snprintf(immediate,256,fmtstr,variable->compute_equal(var));
-        value = immediate;
+        immediate = utils::sprintf(fmtstr, variable->compute_equal(var));
+        value = immediate.c_str();
 
       // single character variable name, e.g. $a
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -33,6 +33,8 @@
 #include <cctype>
 #include <cerrno>
 #include <cmath>
+#include <cstdarg>
+#include <cstdio>
 #include <cstring>
 #include <ctime>
 #include <stdexcept>
@@ -289,6 +291,39 @@ void utils::print(const std::string &mesg)
 void utils::fmtargs_print(FILE *fp, fmt::string_view format, fmt::format_args args)
 {
   print(fp, fmt::vformat(format, args));
+}
+
+/* internal function handling the variable argument list for utils::sprintf() */
+
+std::string utils::varargs_sprintf(const char *format, ...)
+{
+  constexpr int firstsize = 512;
+  char firstbuf[firstsize];
+  va_list ap, ap2;
+
+  va_start(ap, format);
+  va_copy(ap2, ap);
+  int len = vsnprintf(firstbuf, firstsize, format, ap);
+  va_end(ap);
+
+  // conversion or output error
+  if (len < 0) {
+    va_end(ap2);
+    return "";
+  }
+
+  // output fits into the fixed size buffer
+  if (len < firstsize) {
+    va_end(ap2);
+    return {firstbuf, (std::size_t) len};
+  }
+
+  // otherwise repeat the conversion with a suitably sized buffer
+  std::string result(len + 1, '\0');
+  vsnprintf(result.data(), len + 1, format, ap2);
+  va_end(ap2);
+  result.resize(len);
+  return result;
 }
 
 std::string utils::errorurl(int errorcode)

--- a/src/utils.h
+++ b/src/utils.h
@@ -206,7 +206,7 @@ template <typename TYPE> inline const TYPE &sprintf_arg(const TYPE &arg)
 {
   static_assert(std::is_arithmetic_v<TYPE> || std::is_pointer_v<TYPE> || std::is_array_v<TYPE>,
                 "Argument type not supported by utils::sprintf()");
-  return arg;
+  return arg; // NOLINT
 }
 
 /*! \overload converts a std::string argument to a C-style string */

--- a/src/utils.h
+++ b/src/utils.h
@@ -22,6 +22,7 @@
 #include <mpi.h>
 
 #include <string>
+#include <type_traits>
 #include <vector>    // IWYU pragma: export
 
 namespace LAMMPS_NS {
@@ -191,6 +192,74 @@ void print(FILE *fp, const std::string &mesg);
  *  \param mesg   string with message to be printed */
 
 void print(const std::string &mesg);
+
+/*! Internal function handling the variable argument list for sprintf(). */
+
+std::string varargs_sprintf(const char *format, ...);
+
+/*! Internal helper function passing individual arguments for sprintf() to the
+ *  C-style variable argument list of varargs_sprintf().  Arithmetic types,
+ *  pointers, and arrays (e.g. string literals) are passed through unchanged;
+ *  all other types are rejected at compile time. */
+
+template <typename TYPE> inline const TYPE &sprintf_arg(const TYPE &arg)
+{
+  static_assert(std::is_arithmetic_v<TYPE> || std::is_pointer_v<TYPE> || std::is_array_v<TYPE>,
+                "Argument type not supported by utils::sprintf()");
+  return arg;
+}
+
+/*! \overload converts a std::string argument to a C-style string */
+
+inline const char *sprintf_arg(const std::string &arg)
+{
+  return arg.c_str();
+}
+
+/*! Format data into a string with printf() style formatting and return it
+
+\verbatim embed:rst
+
+.. versionadded:: TBD
+
+This function formats its arguments according to a printf() style format
+string and returns the result as a ``std::string``, similar to the
+(non-standard) ``asprintf()`` C library function.  It is a convenient
+replacement for formatting into a fixed size buffer with ``snprintf()``
+without the risk of truncation.  The actual conversion is done by the
+``vsnprintf()`` C library function, first into a fixed size internal buffer
+and - should that buffer be too small - a second time into a temporary
+buffer of exactly the required size.  Thus the accepted format specifiers
+and modifiers and the resulting output are those of the C library.  In case
+of an output error an empty string is returned.
+
+Unlike its C library counterparts, this function also accepts
+``std::string`` instances as arguments for ``%s`` conversions in addition
+to C-style strings, and arguments with class types that cannot be passed
+through a C-style variable argument list are rejected at compile time.
+It cannot detect, however, when an argument does not match its format
+specifier, so the same care as with ``snprintf()`` must be taken.
+
+.. note::
+
+   The main application of this function is the output of numerical data
+   with user provided format strings that are only known at runtime, as
+   is the case for dump styles or thermo output.  For all other string
+   formatting tasks the functions using {fmt} style format strings, i.e.
+   ``fmt::format()``, :cpp:func:`utils::print() <LAMMPS_NS::utils::print>`,
+   or :cpp:func:`utils::logmesg() <LAMMPS_NS::utils::logmesg>`, are
+   preferred since they detect format errors at runtime.
+
+\endverbatim
+ *
+ *  \param format printf() style format string
+ *  \param args   arguments to format string
+ *  \return       string with formatted output */
+
+template <typename... Args> std::string sprintf(const std::string &format, Args &&...args)
+{
+  return varargs_sprintf(format.c_str(), sprintf_arg(args)...);
+}
 
 /*! Return text redirecting the user to a specific paragraph in the manual
  *

--- a/src/utils.h
+++ b/src/utils.h
@@ -201,13 +201,14 @@ std::string varargs_sprintf(const char *format, ...);
  *  C-style variable argument list of varargs_sprintf().  Arithmetic types,
  *  pointers, and arrays (e.g. string literals) are passed through unchanged;
  *  all other types are rejected at compile time. */
-
+// NOLINTBEGIN
 template <typename TYPE> inline const TYPE &sprintf_arg(const TYPE &arg)
 {
   static_assert(std::is_arithmetic_v<TYPE> || std::is_pointer_v<TYPE> || std::is_array_v<TYPE>,
                 "Argument type not supported by utils::sprintf()");
-  return arg; // NOLINT
+  return arg;
 }
+// NOLINTEND
 
 /*! \overload converts a std::string argument to a C-style string */
 

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -561,8 +561,7 @@ void Variable::set(int narg, char **arg)
     newvar.data = new char *[newvar.num];
     newvar.data[0] = utils::strdup(arg[2]);
     newvar.data[1] = utils::strdup(arg[3]);
-    newvar.data[2] = new char[VALUELENGTH];
-    strcpy(newvar.data[2], "(undefined)");
+    newvar.data[2] = utils::strdup("(undefined)");
     newvar.style = FORMAT;
     return;
 
@@ -1190,7 +1189,8 @@ char *Variable::retrieve(const char *name)
       error->all(FLERR, "Variable {}: format variable {} has incompatible style",
                  var.name, var.data[0]);
     double answer = compute_equal(jvar);
-    snprintf(var.data[2],VALUELENGTH,var.data[1],answer);
+    delete[] var.data[2];
+    var.data[2] = utils::strdup(utils::sprintf(var.data[1], answer));
     str = var.data[2];
 
   } else if (var.style == GETENV) {

--- a/unittest/commands/test_variables.cpp
+++ b/unittest/commands/test_variables.cpp
@@ -854,6 +854,13 @@ TEST_F(VariableTest, Format)
     END_HIDE_OUTPUT();
     EXPECT_THAT(variable->retrieve("wide1"), StrEq(refbuf));
 
+    // formatted immediate variable expansions are no longer truncated to 255 characters
+    snprintf(refbuf, sizeof(refbuf), "%.310f", 1.0 / 3.0);
+    BEGIN_HIDE_OUTPUT();
+    command("variable wide2 index $(1.0/3.0:%.310f)");
+    END_HIDE_OUTPUT();
+    EXPECT_THAT(variable->retrieve("wide2"), StrEq(refbuf));
+
     TEST_FAILURE(".*ERROR: Variable f1idx: format variable idx has incompatible style.*",
                  command("variable f1idx format idx %8.4f"););
     TEST_FAILURE(".*ERROR: Variable f1two: format variable two has incompatible style.*",

--- a/unittest/commands/test_variables.cpp
+++ b/unittest/commands/test_variables.cpp
@@ -26,6 +26,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include <cstdio>
 #include <cstring>
 #include <vector>
 
@@ -844,6 +845,14 @@ TEST_F(VariableTest, Format)
     command("variable three delete");
     END_HIDE_OUTPUT();
     EXPECT_THAT(variable->retrieve("f1one"), StrEq("-0.6220 "));
+
+    // format variable results are no longer truncated to 63 characters
+    char refbuf[512];
+    snprintf(refbuf, sizeof(refbuf), "%70.40f", -0.622);
+    BEGIN_HIDE_OUTPUT();
+    command("variable wide1 format one \"%70.40f\"");
+    END_HIDE_OUTPUT();
+    EXPECT_THAT(variable->retrieve("wide1"), StrEq(refbuf));
 
     TEST_FAILURE(".*ERROR: Variable f1idx: format variable idx has incompatible style.*",
                  command("variable f1idx format idx %8.4f"););

--- a/unittest/utils/CMakeLists.txt
+++ b/unittest/utils/CMakeLists.txt
@@ -66,6 +66,10 @@ add_executable(test_fmtlib test_fmtlib.cpp)
 target_link_libraries(test_fmtlib PRIVATE lammps GTest::GMockMain)
 add_test(NAME FmtLib COMMAND test_fmtlib)
 
+add_executable(test_sprintf test_sprintf.cpp)
+target_link_libraries(test_sprintf PRIVATE lammps GTest::GMockMain)
+add_test(NAME Sprintf COMMAND test_sprintf)
+
 add_executable(test_json test_json.cpp)
 target_link_libraries(test_json PRIVATE lammps GTest::GMockMain)
 add_test(NAME JSON COMMAND test_json)

--- a/unittest/utils/test_sprintf.cpp
+++ b/unittest/utils/test_sprintf.cpp
@@ -1,0 +1,314 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS Development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "lmptype.h"
+#include "utils.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <string>
+
+using namespace LAMMPS_NS;
+using ::testing::Eq;
+using ::testing::StartsWith;
+
+// this tests the printf() conversions supported by utils::sprintf() that
+// are most relevant to LAMMPS, i.e. for dump or thermo style output
+
+TEST(Sprintf, plain_text)
+{
+    auto text = utils::sprintf("some plain text");
+    ASSERT_THAT(text, Eq("some plain text"));
+}
+
+TEST(Sprintf, empty_format)
+{
+    auto text = utils::sprintf("");
+    ASSERT_THAT(text, Eq(""));
+}
+
+TEST(Sprintf, percent_literal)
+{
+    auto text = utils::sprintf("100%% done");
+    ASSERT_THAT(text, Eq("100% done"));
+}
+
+TEST(Sprintf, percent_literal_with_args)
+{
+    auto text = utils::sprintf("%d%% of %d", 50, 200);
+    ASSERT_THAT(text, Eq("50% of 200"));
+}
+
+TEST(Sprintf, insert_int)
+{
+    constexpr int val = 333;
+    auto text         = utils::sprintf("word %d", val);
+    ASSERT_THAT(text, Eq("word 333"));
+    text = utils::sprintf("word %i", val);
+    ASSERT_THAT(text, Eq("word 333"));
+}
+
+TEST(Sprintf, insert_neg_int)
+{
+    constexpr int val = -333;
+    auto text         = utils::sprintf("word %d", val);
+    ASSERT_THAT(text, Eq("word -333"));
+}
+
+TEST(Sprintf, insert_int_extremes)
+{
+    auto text = utils::sprintf("%d %d", std::numeric_limits<int>::max(),
+                               std::numeric_limits<int>::min());
+    ASSERT_THAT(text, Eq("2147483647 -2147483648"));
+}
+
+TEST(Sprintf, int_flags_and_width)
+{
+    ASSERT_THAT(utils::sprintf("%8d", 333), Eq("     333"));
+    ASSERT_THAT(utils::sprintf("%-8d|", 333), Eq("333     |"));
+    ASSERT_THAT(utils::sprintf("%08d", 333), Eq("00000333"));
+    ASSERT_THAT(utils::sprintf("%+d", 333), Eq("+333"));
+    ASSERT_THAT(utils::sprintf("% d", 333), Eq(" 333"));
+    ASSERT_THAT(utils::sprintf("%2d", 333), Eq("333"));
+}
+
+TEST(Sprintf, insert_unsigned)
+{
+    constexpr unsigned int val = 4294967295U;
+    auto text                  = utils::sprintf("word %u", val);
+    ASSERT_THAT(text, Eq("word 4294967295"));
+}
+
+TEST(Sprintf, insert_octal_hex)
+{
+    ASSERT_THAT(utils::sprintf("%o", 8), Eq("10"));
+    ASSERT_THAT(utils::sprintf("%#o", 8), Eq("010"));
+    ASSERT_THAT(utils::sprintf("%x", 255), Eq("ff"));
+    ASSERT_THAT(utils::sprintf("%X", 255), Eq("FF"));
+    ASSERT_THAT(utils::sprintf("%#x", 255), Eq("0xff"));
+    ASSERT_THAT(utils::sprintf("%08x", 48879), Eq("0000beef"));
+}
+
+TEST(Sprintf, insert_char)
+{
+    ASSERT_THAT(utils::sprintf("%c", 'A'), Eq("A"));
+    ASSERT_THAT(utils::sprintf("%c%c%c", 'x', 'y', 'z'), Eq("xyz"));
+    ASSERT_THAT(utils::sprintf("%c", 65), Eq("A"));
+}
+
+TEST(Sprintf, insert_cstring)
+{
+    constexpr char val[] = "word";
+    auto text            = utils::sprintf("word %s", val);
+    ASSERT_THAT(text, Eq("word word"));
+    const char *ptr = val;
+    text            = utils::sprintf("word %s", ptr);
+    ASSERT_THAT(text, Eq("word word"));
+}
+
+TEST(Sprintf, insert_stdstring)
+{
+    const std::string val = "word";
+    auto text             = utils::sprintf("word %s", val);
+    ASSERT_THAT(text, Eq("word word"));
+}
+
+TEST(Sprintf, string_flags_and_width)
+{
+    const std::string val = "word";
+    ASSERT_THAT(utils::sprintf("%10s", val), Eq("      word"));
+    ASSERT_THAT(utils::sprintf("%-10s|", val), Eq("word      |"));
+    ASSERT_THAT(utils::sprintf("%.2s", val), Eq("wo"));
+}
+
+TEST(Sprintf, insert_long_long)
+{
+    constexpr long long val = 9945234592LL;
+    auto text               = utils::sprintf("word %lld", val);
+    ASSERT_THAT(text, Eq("word 9945234592"));
+}
+
+TEST(Sprintf, insert_size_t)
+{
+    auto text = utils::sprintf("word %zu", sizeof(double));
+    ASSERT_THAT(text, Eq("word 8"));
+}
+
+TEST(Sprintf, insert_bigint)
+{
+#if defined(LAMMPS_BIGBIG) || defined(LAMMPS_SMALLBIG)
+    constexpr bigint val = 9945234592L;
+    auto text            = utils::sprintf("word " BIGINT_FORMAT, val);
+    ASSERT_THAT(text, Eq("word 9945234592"));
+#else
+    GTEST_SKIP();
+#endif
+}
+
+TEST(Sprintf, insert_neg_bigint)
+{
+#if defined(LAMMPS_BIGBIG) || defined(LAMMPS_SMALLBIG)
+    constexpr bigint val = -9945234592L;
+    auto text            = utils::sprintf("word " BIGINT_FORMAT, val);
+    ASSERT_THAT(text, Eq("word -9945234592"));
+#else
+    GTEST_SKIP();
+#endif
+}
+
+TEST(Sprintf, insert_tagint)
+{
+#if defined(LAMMPS_BIGBIG)
+    constexpr tagint val = 9945234592L;
+    auto text            = utils::sprintf("word " TAGINT_FORMAT, val);
+    ASSERT_THAT(text, Eq("word 9945234592"));
+#else
+    GTEST_SKIP();
+#endif
+}
+
+TEST(Sprintf, insert_neg_tagint)
+{
+#if defined(LAMMPS_BIGBIG)
+    constexpr tagint val = -9945234592L;
+    auto text            = utils::sprintf("word " TAGINT_FORMAT, val);
+    ASSERT_THAT(text, Eq("word -9945234592"));
+#else
+    GTEST_SKIP();
+#endif
+}
+
+TEST(Sprintf, insert_double)
+{
+    constexpr double val = 1.5;
+    auto text            = utils::sprintf("word %f", val);
+    ASSERT_THAT(text, Eq("word 1.500000"));
+}
+
+TEST(Sprintf, insert_neg_double)
+{
+    constexpr double val = -1.5;
+    auto text            = utils::sprintf("word %f", val);
+    ASSERT_THAT(text, Eq("word -1.500000"));
+}
+
+TEST(Sprintf, insert_float)
+{
+    constexpr float val = 1.5f;
+    auto text           = utils::sprintf("word %.1f", val);
+    ASSERT_THAT(text, Eq("word 1.5"));
+}
+
+TEST(Sprintf, double_flags_and_width)
+{
+    ASSERT_THAT(utils::sprintf("%.2f", 1.5), Eq("1.50"));
+    ASSERT_THAT(utils::sprintf("%8.3f", 1.5), Eq("   1.500"));
+    ASSERT_THAT(utils::sprintf("%-8.3f|", 1.5), Eq("1.500   |"));
+    ASSERT_THAT(utils::sprintf("%08.3f", 1.5), Eq("0001.500"));
+    ASSERT_THAT(utils::sprintf("%+.2f", 1.5), Eq("+1.50"));
+    ASSERT_THAT(utils::sprintf("% .2f", 1.5), Eq(" 1.50"));
+}
+
+TEST(Sprintf, insert_exponential)
+{
+    ASSERT_THAT(utils::sprintf("%e", 1.5), Eq("1.500000e+00"));
+    ASSERT_THAT(utils::sprintf("%.2E", -1.5), Eq("-1.50E+00"));
+    ASSERT_THAT(utils::sprintf("%15.8e", 0.1), Eq(" 1.00000000e-01"));
+}
+
+TEST(Sprintf, insert_general)
+{
+    ASSERT_THAT(utils::sprintf("%g", 0.00001), Eq("1e-05"));
+    ASSERT_THAT(utils::sprintf("%G", 0.00001), Eq("1E-05"));
+    ASSERT_THAT(utils::sprintf("%g", 100000.0), Eq("100000"));
+    ASSERT_THAT(utils::sprintf("%g", 1000000.0), Eq("1e+06"));
+    // default thermo floating point format
+    ASSERT_THAT(utils::sprintf("%12.8g", 0.1), Eq("         0.1"));
+    ASSERT_THAT(utils::sprintf("%12.8g", 1.0 / 3.0), Eq("  0.33333333"));
+    ASSERT_THAT(utils::sprintf("%-12.8g|", 1.0 / 3.0), Eq("0.33333333  |"));
+}
+
+TEST(Sprintf, insert_hexfloat)
+{
+    // the exact hexadecimal float representation is implementation specific,
+    // so we convert the output back and compare the numbers instead
+    constexpr double val = 1.5;
+    auto text            = utils::sprintf("%a", val);
+    ASSERT_EQ(std::strtod(text.c_str(), nullptr), val);
+}
+
+TEST(Sprintf, insert_inf_nan)
+{
+    constexpr double inf = std::numeric_limits<double>::infinity();
+    ASSERT_THAT(utils::sprintf("%f", inf), Eq("inf"));
+    ASSERT_THAT(utils::sprintf("%f", -inf), Eq("-inf"));
+    ASSERT_THAT(utils::sprintf("%g", std::numeric_limits<double>::quiet_NaN()),
+                StartsWith("nan"));
+}
+
+TEST(Sprintf, insert_pointer)
+{
+    // pointer representation is implementation specific: compare with snprintf()
+    int val = 0;
+    char buf[32];
+    snprintf(buf, sizeof(buf), "%p", (void *) &val);
+    ASSERT_THAT(utils::sprintf("%p", (void *) &val), Eq(buf));
+}
+
+TEST(Sprintf, dynamic_width_precision)
+{
+    ASSERT_THAT(utils::sprintf("%*d", 8, 42), Eq("      42"));
+    ASSERT_THAT(utils::sprintf("%-*d|", 8, 42), Eq("42      |"));
+    ASSERT_THAT(utils::sprintf("%.*f", 3, 1.5), Eq("1.500"));
+    ASSERT_THAT(utils::sprintf("%*.*f", 10, 3, 1.5), Eq("     1.500"));
+}
+
+TEST(Sprintf, multiple_args)
+{
+    const std::string prop = "PotEng";
+    auto text = utils::sprintf("Step %d: %s = %-12.8g temp: %8.3f", 100, prop, -1.5, 300.0);
+    ASSERT_THAT(text, Eq("Step 100: PotEng = -1.5         temp:  300.000"));
+}
+
+TEST(Sprintf, consecutive_conversions)
+{
+    auto text = utils::sprintf("%d%d%s", 1, 2, "3");
+    ASSERT_THAT(text, Eq("123"));
+}
+
+TEST(Sprintf, buffer_boundaries)
+{
+    // exercise field widths around the size of the internal fixed size buffer
+    for (int width : {510, 511, 512, 513, 1024}) {
+        auto text = utils::sprintf("%*d", width, 1);
+        ASSERT_EQ((int) text.size(), width);
+        ASSERT_EQ(text.back(), '1');
+        ASSERT_EQ(text.front(), ' ');
+    }
+}
+
+TEST(Sprintf, oversize_output)
+{
+    auto text = utils::sprintf("%600d", 42);
+    ASSERT_EQ((int) text.size(), 600);
+    ASSERT_THAT(text.substr(598), Eq("42"));
+    ASSERT_EQ(text.front(), ' ');
+
+    const std::string big(2000, 'x');
+    text = utils::sprintf("<%s>", big);
+    ASSERT_EQ((int) text.size(), 2002);
+    ASSERT_THAT(text, Eq('<' + big + '>'));
+}


### PR DESCRIPTION
**Summary**

This pull request implements an `utils::sprintf()` function that provides printf() style formatting in a std::string context. It follows in spirit the implementation of `fmt::sprintf()` similar to how `utils::print()` follows `fmt::print()` both of which are not available in the std::format support. This new function has no limit in the size of the output string (other than the limits of `std::string` itself) and better argument checking than snprintf()/sprintf().

A future pull request will use this facility to replace the remaining C-library style buffer based formatting from thermo output and dump styles.

**Related Issue(s)**

N/A

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

The bulk of the implementation was realized using Claude Code (Fable 5) after detailed planning under supervision and with validation of a human.

**Backward Compatibility**

All existing regression tests pass.

**Implementation Notes**

This is implemented as a variadic template `utils::sprintf(const std::string &format, args...)` returning `std::string`, structured like `utils::print()` — the template forwards to an internal C-variadic `utils::varargs_sprintf()`. A `sprintf_arg()` helper sits between them: it passes arithmetic types, pointers, and string literals through unchanged, converts `std::string` arguments to `std::string.c_str()` so they work with %s (a convenience plain snprintf doesn't have), and rejects any other class type with a compile-time static_assert. It cannot catch %d-with-a-double mismatches, which the doc comment says explicitly.

This is realized with vsnprintf() and a 512-byte stack buffer — sized to match thermo's current static char fmtbuf[512], so a future application to thermo output completes in one pass with no allocation. If the result is larger, the conversion repeats once into a heap buffer of exactly the size `vsnprintf` reported (via `va_copy`), so unlike the current call sites the output is never truncated. A conversion error returns an empty string. Deliberately using the C-library semantics and thus preserving the current behavior and runtime %-formats keep working as documented behavior.

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
