### PR TITLE
Collected small changes and fixes

### DIFF
--- a/cmake/Modules/Testing.cmake
+++ b/cmake/Modules/Testing.cmake
@@ -15,7 +15,11 @@ if(ENABLE_TESTING)
   # them buries the actual defects under thousands of one-time initializations in
   # OpenSSL, libcurl, CPython, and GoogleTest, plus everything that is still in use
   # when a command like "quit" or an error exit terminates the process on purpose.
-  set(VALGRIND_DEFAULT_OPTIONS "--leak-check=full --show-leak-kinds=definite,indirect,possible --track-origins=yes --suppressions=${CMAKE_BINARY_DIR}/lammps.supp")
+  # --max-stackframe is raised because Fortran libraries (e.g. QUIP) place large
+  # automatic arrays on the stack; with the default limit valgrind misreads the
+  # resulting stack pointer jump as a stack switch and then floods the log with
+  # millions of bogus invalid access and uninitialized value errors.
+  set(VALGRIND_DEFAULT_OPTIONS "--leak-check=full --show-leak-kinds=definite,indirect,possible --track-origins=yes --max-stackframe=16777216 --suppressions=${CMAKE_BINARY_DIR}/lammps.supp")
 
   set(MEMORYCHECK_COMMAND "${VALGRIND_BINARY}" CACHE FILEPATH "Memory Check Command")
   set(MEMORYCHECK_COMMAND_OPTIONS "${VALGRIND_DEFAULT_OPTIONS}" CACHE STRING "Memory Check Command Options")

--- a/examples/PACKAGES/sna_nnn_slcsa/in.slcsa
+++ b/examples/PACKAGES/sna_nnn_slcsa/in.slcsa
@@ -42,7 +42,7 @@ velocity        all create ${trequis} 42345 dist gaussian
 compute         bnnn all sna/atom 9.0 0.99363 8 0.5 1.0 rmin0 0.0 nnn 24 wmode 1 delta 0.25
 
 # 2nd step : perform dimension reduction + logistic regression
-compute         slcsa all slcsa/atom 8 4 dir.slcsa/mean_descriptor.dat dir.slcsa/lda_scalings.dat dir.slcsa/lr_decision.dat dir.slcsa/lr_bias.dat dir.slcsa/mahalanobis_file.dat c_bnnn[*]
+compute         slcsa all slcsa/atom 8 4 dir.slcsa/mean_descriptor.dat dir.slcsa/lda_scalings.dat dir.slcsa/lr_decision.dat dir.slcsa/lr_bias.dat dir.slcsa/mahalanobis_file.dat c_bnnn[1]
 
 #dump            d1 all custom ${freqdump} slcsa_demo.dump id x y z c_slcsa[*]
 

--- a/examples/PACKAGES/yaff/mil53al/in.mil53a
+++ b/examples/PACKAGES/yaff/mil53al/in.mil53a
@@ -18,7 +18,6 @@ bond_style      harmonic
 angle_style     hybrid cosine/periodic cross harmonic cosine/squared
 dihedral_style  fourier
 improper_style  distharm
-box tilt large
 
 read_data       lammps.data       # Data file location
 kspace_style    pppm 0.0000001      # Ewald accuracy

--- a/examples/PACKAGES/yaff/mof5/in.mof5
+++ b/examples/PACKAGES/yaff/mof5/in.mof5
@@ -18,7 +18,6 @@ bond_style      mm3
 angle_style     hybrid cross mm3
 dihedral_style  fourier
 improper_style  distharm
-box tilt large
 
 read_data       lammps.data       # Data file location
 kspace_style    pppm 0.0000001      # Ewald accuracy

--- a/examples/wall/in.wall.harmonic.2d
+++ b/examples/wall/in.wall.harmonic.2d
@@ -55,9 +55,9 @@ fix            1 all nvt temp ${t} ${t} 0.1
 # Output
 thermo         1000
 thermo_style   custom step temp etotal press f_w2[1]
-dump           dmp all custom 5000 dump.wall.harmonic.2d id type x y vx vy
-dump_modify    dmp sort id
-dump		   2 all image 5000 image.wall.harmonic.2d.*.jpg type type zoom 1.6 region inVol red frame 0.5
+# dump           dmp all custom 5000 dump.wall.harmonic.2d id type x y vx vy
+# dump_modify    dmp sort id
+# dump           2 all image 5000 image.wall.harmonic.2d.*.ppm type type zoom 1.6 region inVol red frame 0.5
 
 timestep       0.01
 run            20000

--- a/lib/gpu/geryon/ocl_timer.h
+++ b/lib/gpu/geryon/ocl_timer.h
@@ -54,13 +54,9 @@ class UCL_Timer {
   /** \note init() must be called to reuse timer after a clear() **/
   inline void clear() {
     if (_initialized) {
-      if (has_measured_time) {
-        #ifndef GERYON_NO_OCL_MARKERS
-        clReleaseEvent(start_event);
-        clReleaseEvent(stop_event);
-        #endif
-        has_measured_time = false;
-      }
+      free_event(start_event);
+      free_event(stop_event);
+      has_measured_time = false;
       CL_DESTRUCT_CALL(clReleaseCommandQueue(_cq));
       _initialized=false;
       _total_time=0.0;
@@ -81,18 +77,14 @@ class UCL_Timer {
 
   /// Start timing on default command queue
   inline void start() {
-    if (has_measured_time) {
-      #ifndef GERYON_NO_OCL_MARKERS
-      clReleaseEvent(start_event);
-      clReleaseEvent(stop_event);
-      #endif
-      has_measured_time = false;
-    }
+    free_event(start_event);
+    has_measured_time = false;
     UCL_OCL_MARKER(_cq,&start_event);
   }
 
   /// Stop timing on default command queue
   inline void stop() {
+    free_event(stop_event);
     UCL_OCL_MARKER(_cq,&stop_event);
     has_measured_time = true;
   }
@@ -102,8 +94,8 @@ class UCL_Timer {
     #ifndef GERYON_NO_OCL_MARKERS
     CL_SAFE_CALL(clWaitForEvents(1,&start_event));
     if (has_measured_time) {
-      clReleaseEvent(start_event);
-      clReleaseEvent(stop_event);
+      free_event(start_event);
+      free_event(stop_event);
       has_measured_time = false;
     }
     #else
@@ -124,6 +116,8 @@ class UCL_Timer {
 
   /// Set the time elapsed to zero (not the total_time)
   inline void zero() {
+    free_event(start_event);
+    free_event(stop_event);
     has_measured_time = false;
     UCL_OCL_MARKER(_cq,&start_event);
     UCL_OCL_MARKER(_cq,&stop_event);
@@ -152,8 +146,8 @@ class UCL_Timer {
     CL_SAFE_CALL(clGetEventProfilingInfo(start_event,
                                          CL_PROFILING_COMMAND_END,
                                          sizeof(cl_ulong), &tstart, nullptr));
-    clReleaseEvent(start_event);
-    clReleaseEvent(stop_event);
+    free_event(start_event);
+    free_event(stop_event);
     has_measured_time = false;
     return (tend-tstart)*1e-6;
     #else
@@ -178,6 +172,18 @@ class UCL_Timer {
   double _total_time;
   bool _initialized;
   bool has_measured_time;
+
+  // events from clEnqueueMarker(WithWaitList) must be released before the
+  // handle is overwritten or the runtime objects are leaked; a released or
+  // never-created event is a null handle
+  inline void free_event(cl_event &event) {
+    #ifndef GERYON_NO_OCL_MARKERS
+    if (event) {
+      clReleaseEvent(event);
+      event = nullptr;
+    }
+    #endif
+  }
 };
 
 } // namespace

--- a/lib/gpu/lal_device.cpp
+++ b/lib/gpu/lal_device.cpp
@@ -66,6 +66,7 @@ namespace LAMMPS_AL {
 
 template <class numtyp, class acctyp>
 DeviceT::Device() : _init_count(0), _device_init(false),
+                    _comm_gpu_allocated(false),
                     _gpu_mode(GPU_FORCE), _first_device(0),
                     _last_device(0), _platform_id(-1), _compiled(false),
                     _use_old_nbor_build(0), _use_device_sort(0) {
@@ -301,6 +302,8 @@ int DeviceT::init_device(MPI_Comm /*world*/, MPI_Comm replica, const int ngpu,
   // Set up a per device communicator
   MPI_Comm_split(node_comm,my_gpu,0,&_comm_gpu);
   MPI_Comm_rank(_comm_gpu,&_gpu_rank);
+  _comm_gpu_allocated=true;
+  MPI_Comm_free(&node_comm);
 
   #if !defined(CUDA_MPS_SUPPORT)
   if (_procs_per_gpu>1 && !gpu->sharing_supported(my_gpu))
@@ -1059,6 +1062,14 @@ void DeviceT::clear_device() {
   if (_device_init && !lal_defer_device_clear) {
     delete gpu;
     _device_init=false;
+  }
+  // the global Device instance is destroyed after MPI_Finalize(), so the
+  // per-device communicator can only be freed when torn down before that
+  if (_comm_gpu_allocated) {
+    int mpi_finalized;
+    MPI_Finalized(&mpi_finalized);
+    if (!mpi_finalized) MPI_Comm_free(&_comm_gpu);
+    _comm_gpu_allocated=false;
   }
 }
 

--- a/lib/gpu/lal_device.h
+++ b/lib/gpu/lal_device.h
@@ -334,7 +334,7 @@ class Device {
  private:
   std::queue<Answer<numtyp,acctyp> *> ans_queue;
   int _init_count;
-  bool _device_init, _host_timer_started, _time_device;
+  bool _device_init, _comm_gpu_allocated, _host_timer_started, _time_device;
   MPI_Comm _comm_world, _comm_replica, _comm_gpu;
   int _procs_per_gpu, _gpu_rank, _world_me, _world_size, _replica_me,
       _replica_size;

--- a/src/AMOEBA/fix_amoeba_bitorsion.cpp
+++ b/src/AMOEBA/fix_amoeba_bitorsion.cpp
@@ -783,27 +783,26 @@ void FixAmoebaBiTorsion::read_grid_data(char *bitorsion_file)
     MPI_Bcast(&nx,1,MPI_INT,0,world);
     MPI_Bcast(&ny,1,MPI_INT,0,world);
 
-    // sanity check the grid dimensions from the file; this also keeps
-    // the products below within the range of an int
+    // sanity check of the grid dimensions from the file
 
-    if ((nx < 2) || (ny < 2) || (nx > 1000) || (ny > 1000))
+    if ((nx < 2) || (ny < 2))
       error->all(FLERR, Error::NOLASTLINE,
                  "Invalid {} by {} grid for type {} in fix amoeba/bitorsion file", nx, ny, itype);
 
     nxgrid[itype] = nx;
     nygrid[itype] = ny;
+    const bigint npoints = static_cast<bigint>(nx)*static_cast<bigint>(ny);
 
     memory->create(ttx[itype],nx,"bitorsion:ttx");
     memory->create(tty[itype],ny,"bitorsion:tty");
-    memory->create(tbf[itype],nx*ny,"bitorsion:tbf");
+    memory->create(tbf[itype],npoints,"bitorsion:tbf");
 
     // read the whole nx by ny grid of (x, y, value) lines in one call
 
-    const int nvalues = 3*nx*ny;
     if (me == 0) {
-      std::vector<double> grid(nvalues);
+      std::vector<double> grid(3*npoints);
       try {
-        reader->next_dvector(grid.data(), nvalues);
+        reader->next_dvector(grid.data(), 3*npoints);
       } catch (std::exception &e) {
         error->one(FLERR, Error::NOLASTLINE, "Error reading fix amoeba/bitorsion file: {}",
                    e.what());

--- a/src/AMOEBA/fix_amoeba_bitorsion.cpp
+++ b/src/AMOEBA/fix_amoeba_bitorsion.cpp
@@ -782,6 +782,14 @@ void FixAmoebaBiTorsion::read_grid_data(char *bitorsion_file)
 
     MPI_Bcast(&nx,1,MPI_INT,0,world);
     MPI_Bcast(&ny,1,MPI_INT,0,world);
+
+    // sanity check the grid dimensions from the file; this also keeps
+    // the products below within the range of an int
+
+    if ((nx < 2) || (ny < 2) || (nx > 1000) || (ny > 1000))
+      error->all(FLERR, Error::NOLASTLINE,
+                 "Invalid {} by {} grid for type {} in fix amoeba/bitorsion file", nx, ny, itype);
+
     nxgrid[itype] = nx;
     nygrid[itype] = ny;
 
@@ -791,10 +799,11 @@ void FixAmoebaBiTorsion::read_grid_data(char *bitorsion_file)
 
     // read the whole nx by ny grid of (x, y, value) lines in one call
 
+    const int nvalues = 3*nx*ny;
     if (me == 0) {
-      std::vector<double> grid(3*nx*ny);
+      std::vector<double> grid(nvalues);
       try {
-        reader->next_dvector(grid.data(), 3*nx*ny);
+        reader->next_dvector(grid.data(), nvalues);
       } catch (std::exception &e) {
         error->one(FLERR, Error::NOLASTLINE, "Error reading fix amoeba/bitorsion file: {}",
                    e.what());

--- a/src/EXTRA-COMPUTE/compute_slcsa_atom.cpp
+++ b/src/EXTRA-COMPUTE/compute_slcsa_atom.cpp
@@ -112,10 +112,11 @@ ComputeSLCSAAtom::ComputeSLCSAAtom(LAMMPS *lmp, int narg, char **arg) :
 
   if ((val.which == ArgInfo::FIX) || (val.which == ArgInfo::VARIABLE) ||
       (val.which == ArgInfo::UNKNOWN) || (val.which == ArgInfo::NONE) || (argi.get_dim() > 1))
-    error->all(FLERR, 10, "Invalid compute slcsa/atom argument: {}", arg[0]);
+    error->all(FLERR, 10, "Invalid compute slcsa/atom argument: {}", arg[10]);
 
   val.val.c = modify->get_compute_by_id(val.id);
-  if (!val.val.c) error->all(FLERR, 10, "Compute ID {} for fix slcsa/atom does not exist", val.id);
+  if (!val.val.c)
+    error->all(FLERR, 10, "Compute ID {} for compute slcsa/atom does not exist", val.id);
   if (val.val.c->peratom_flag == 0)
     error->all(FLERR, 10, "Compute slcsa/atom compute {} does not calculate per-atom values",
                val.id);
@@ -141,9 +142,8 @@ ComputeSLCSAAtom::ComputeSLCSAAtom(LAMMPS *lmp, int narg, char **arg) :
   if (comm->me == 0) {
 
     if (strcmp(database_mean_descriptor_file, "NULL") == 0) {
-      error->one(FLERR, Error::NOLASTLINE,
-                 "Cannot open database mean descriptor file {}: ", database_mean_descriptor_file,
-                 utils::getsyserror());
+      error->one(FLERR, Error::NOLASTLINE, "Cannot open database mean descriptor file {}",
+                 database_mean_descriptor_file);
     } else {
       PotentialFileReader reader(lmp, database_mean_descriptor_file,
                                  "database mean descriptor file");
@@ -157,7 +157,7 @@ ComputeSLCSAAtom::ComputeSLCSAAtom(LAMMPS *lmp, int narg, char **arg) :
 
     if (strcmp(lda_scalings_file, "NULL") == 0) {
       error->one(FLERR, Error::NOLASTLINE, "Cannot open database linear discriminant analysis "
-                 "scalings file {}: ", lda_scalings_file, utils::getsyserror());
+                 "scalings file {}", lda_scalings_file);
     } else {
       PotentialFileReader reader(lmp, lda_scalings_file, "lda scalings file");
       int nread = 0;
@@ -171,8 +171,8 @@ ComputeSLCSAAtom::ComputeSLCSAAtom(LAMMPS *lmp, int narg, char **arg) :
     }
 
     if (strcmp(lr_decision_file, "NULL") == 0) {
-      error->one(FLERR, Error::NOLASTLINE, "Cannot open logistic regression decision file {}: ",
-                 lr_decision_file, utils::getsyserror());
+      error->one(FLERR, Error::NOLASTLINE, "Cannot open logistic regression decision file {}",
+                 lr_decision_file);
     } else {
       PotentialFileReader reader(lmp, lr_decision_file, "lr decision file");
       int nread = 0;
@@ -186,8 +186,8 @@ ComputeSLCSAAtom::ComputeSLCSAAtom(LAMMPS *lmp, int narg, char **arg) :
     }
 
     if (strcmp(lr_bias_file, "NULL") == 0) {
-      error->one(FLERR, Error::NOLASTLINE, "Cannot open logistic regression bias file {}: ",
-                 lr_bias_file, utils::getsyserror());
+      error->one(FLERR, Error::NOLASTLINE, "Cannot open logistic regression bias file {}",
+                 lr_bias_file);
     } else {
       PotentialFileReader reader(lmp, lr_bias_file, "lr bias file");
       auto values = reader.next_values(nclasses);
@@ -198,8 +198,7 @@ ComputeSLCSAAtom::ComputeSLCSAAtom(LAMMPS *lmp, int narg, char **arg) :
     }
 
     if (strcmp(maha_file, "NULL") == 0) {
-      error->one(FLERR, Error::NOLASTLINE, "Cannot open mahalanobis stats file {}: ", maha_file,
-                 utils::getsyserror());
+      error->one(FLERR, Error::NOLASTLINE, "Cannot open mahalanobis stats file {}", maha_file);
     } else {
       PotentialFileReader reader(lmp, maha_file, "mahalanobis stats file");
       int nvalues = nclasses * ((nclasses - 1) * (nclasses - 1) + nclasses);

--- a/src/GPU/fix_nve_asphere_gpu.cpp
+++ b/src/GPU/fix_nve_asphere_gpu.cpp
@@ -152,13 +152,19 @@ static constexpr double INERTIA = 0.2;          // moment of inertia prefactor f
 /* ---------------------------------------------------------------------- */
 
 FixNVEAsphereGPU::FixNVEAsphereGPU(LAMMPS *lmp, int narg, char **arg) :
-  FixNVE(lmp, narg, arg)
+FixNVE(lmp, narg, arg), _dtfm(nullptr), _inertia0(nullptr), _inertia1(nullptr), _inertia2(nullptr)
 {
-  _dtfm = nullptr;
   _nlocal_max = 0;
-  _inertia0 = nullptr;
-  _inertia1 = nullptr;
-  _inertia2 = nullptr;
+}
+
+/* ---------------------------------------------------------------------- */
+
+FixNVEAsphereGPU::~FixNVEAsphereGPU()
+{
+  memory->destroy(_dtfm);
+  memory->destroy(_inertia0);
+  memory->destroy(_inertia1);
+  memory->destroy(_inertia2);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -167,10 +173,10 @@ void FixNVEAsphereGPU::init()
 {
   avec = dynamic_cast<AtomVecEllipsoid *>(atom->style_match("ellipsoid"));
   if (!avec)
-    error->all(FLERR,"Compute nve/asphere requires atom style ellipsoid");
+    error->all(FLERR, Error::NOLASTLINE, "Compute nve/asphere requires atom style ellipsoid");
 
   if (atom->superellipsoid_flag)
-    error->all(FLERR, "Fix nve/asphere_gpu does not support superellipsoids");
+    error->all(FLERR, Error::NOLASTLINE, "Fix nve/asphere_gpu does not support superellipsoids");
 
   // check that all particles are finite-size ellipsoids
   // no point particles allowed, spherical is OK
@@ -182,7 +188,7 @@ void FixNVEAsphereGPU::init()
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit)
       if (ellipsoid[i] < 0)
-        error->one(FLERR,"Fix nve/asphere requires extended particles");
+        error->one(FLERR, Error::NOLASTLINE, "Fix nve/asphere requires extended particles");
 
   FixNVE::init();
 }

--- a/src/GPU/fix_nve_asphere_gpu.h
+++ b/src/GPU/fix_nve_asphere_gpu.h
@@ -31,6 +31,7 @@ namespace LAMMPS_NS {
 class FixNVEAsphereGPU : public FixNVE {
  public:
   FixNVEAsphereGPU(class LAMMPS *, int, char **);
+  ~FixNVEAsphereGPU() override;
   void init() override;
   void setup(int vflag) override;
   void initial_integrate(int) override;

--- a/src/GRANSURF/fix_surface_global.cpp
+++ b/src/GRANSURF/fix_surface_global.cpp
@@ -445,6 +445,9 @@ FixSurfaceGlobal::~FixSurfaceGlobal()
   memory->destroy(fflag_c1);
   memory->destroy(fflag_c2);
   memory->destroy(fflag_c3);
+  memory->destroy(nside_c1);
+  memory->destroy(nside_c2);
+  memory->destroy(nside_c3);
 
   memory->sfree(connect2d);
   memory->sfree(connect3d);

--- a/src/GRAPHICS/fix_graphics_isosurface.cpp
+++ b/src/GRAPHICS/fix_graphics_isosurface.cpp
@@ -804,6 +804,8 @@ void FixGraphicsIsosurface::end_of_step()
       distribute(isogrid, distgrid, typegrid, x[i], type[i], pdata[i], sublo, delta, nx, ny, nz,
                  nrange, rcutsq, rad);
   }
+  // no longer needed
+  memory->destroy(distgrid);
 
   // subtract the isovalue from grid data so that the isosurface would be drawn for a value of < 0.0
   for (int ix = 0; ix < nx; ++ix) {
@@ -908,8 +910,9 @@ void FixGraphicsIsosurface::end_of_step()
       }
     }
   }
-  // we don't need the iso value grid anymore.
+  // we don't need these grids anymore.
   memory->destroy(isogrid);
+  memory->destroy(typegrid);
 
   // allocate and assign list of graphics objects
   numobjs = triangles.size();

--- a/src/KOKKOS/pair_pace_extrapolation_kokkos.cpp
+++ b/src/KOKKOS/pair_pace_extrapolation_kokkos.cpp
@@ -75,8 +75,13 @@ PairPACEExtrapolationKokkos<DeviceType>::~PairPACEExtrapolationKokkos()
 {
   if (copymode) return;
 
-  memoryKK->destroy_kokkos(k_eatom,eatom);
-  memoryKK->destroy_kokkos(k_vatom,vatom);
+  // with host_flag the base class compute() is used and eatom/vatom are
+  // plain arrays from Pair::ev_setup() that are freed in ~Pair(); calling
+  // destroy_kokkos() on them would clear the pointers without freeing
+  if (!host_flag) {
+    memoryKK->destroy_kokkos(k_eatom,eatom);
+    memoryKK->destroy_kokkos(k_vatom,vatom);
+  }
 
   deallocate_views_of_views();
 }

--- a/src/KOKKOS/pair_pace_kokkos.cpp
+++ b/src/KOKKOS/pair_pace_kokkos.cpp
@@ -76,8 +76,13 @@ PairPACEKokkos<DeviceType>::~PairPACEKokkos()
 {
   if (copymode) return;
 
-  memoryKK->destroy_kokkos(k_eatom,eatom);
-  memoryKK->destroy_kokkos(k_vatom,vatom);
+  // with host_flag the base class compute() is used and eatom/vatom are
+  // plain arrays from Pair::ev_setup() that are freed in ~Pair(); calling
+  // destroy_kokkos() on them would clear the pointers without freeing
+  if (!host_flag) {
+    memoryKK->destroy_kokkos(k_eatom,eatom);
+    memoryKK->destroy_kokkos(k_vatom,vatom);
+  }
 
   deallocate_views_of_views();
 }

--- a/src/lammps.cpp
+++ b/src/lammps.cpp
@@ -1290,6 +1290,14 @@ void _noopt LAMMPS::help()
   fprintf(fp,"\n\n");
 
   pos = 80;
+  fprintf(fp,"* Body styles:\n");
+#define BODY_CLASS
+#define BodyStyle(key,Class) print_style(fp,#key,pos);
+#include "style_body.h"  // IWYU pragma: keep
+#undef BODY_CLASS
+  fprintf(fp,"\n\n");
+
+  pos = 80;
   fprintf(fp,"* Integrate styles:\n");
 #define INTEGRATE_CLASS
 #define IntegrateStyle(key,Class) print_style(fp,#key,pos);

--- a/src/nbin_manual.cpp
+++ b/src/nbin_manual.cpp
@@ -32,13 +32,20 @@ static constexpr double CUT2BIN_RATIO = 100.0;
 
 /* ---------------------------------------------------------------------- */
 
-NBinManual::NBinManual(LAMMPS *lmp) : NBin(lmp)
+NBinManual::NBinManual(LAMMPS *lmp) :
+  NBin(lmp), binhead_custom(nullptr), bins_custom(nullptr), custom2bin(nullptr)
 {
   cutoff_custom = 0.0;
   maxbin_custom = maxcustom = 0;
-  binhead_custom = nullptr;
-  bins_custom = nullptr;
-  custom2bin = nullptr;
+}
+
+/* ---------------------------------------------------------------------- */
+
+NBinManual::~NBinManual()
+{
+  memory->destroy(binhead_custom);
+  memory->destroy(bins_custom);
+  memory->destroy(custom2bin);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/nbin_manual.h
+++ b/src/nbin_manual.h
@@ -21,6 +21,7 @@ namespace LAMMPS_NS {
 class NBinManual : public NBin {
  public:
   NBinManual(class LAMMPS *);
+  ~NBinManual() override;
 
   void bin_atoms_setup(int) override;
   void setup_bins(int) override;

--- a/tools/valgrind/MPICH.supp
+++ b/tools/valgrind/MPICH.supp
@@ -133,6 +133,21 @@
    ...
 }
 {
+   MPICH_MPI_init11
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:allocate_and_init
+   ...
+   fun:psm3_info_query
+   ...
+   fun:find_provider
+   ...
+   fun:MPII_Init_thread.isra.0
+   ...
+}
+{
    MPICH_library1
    Memcheck:Leak
    match-leak-kinds: reachable
@@ -313,6 +328,19 @@
    fun:MPIDI_OFI_init_local
    ...
    fun:PMPI_Init
+   ...
+}
+{
+   MPICH_psm3_4
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:calloc
+   fun:psmx3_recv_generic
+   fun:psmx3_recvmsg
+   ...
+   fun:MPIDI_OFI_init_local
+   ...
+   fun:PMPI_Init_thread
    ...
 }
 {

--- a/tools/valgrind/Python3.supp
+++ b/tools/valgrind/Python3.supp
@@ -403,3 +403,17 @@
    fun:_PyEval_EvalFrameDefault
    ...
 }
+{
+   Dlopen_init0
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:dl_open_worker_begin
+   ...
+   fun:dl_open_worker
+   ...
+   fun:dlopen_doit
+   ...
+   obj:*
+}

--- a/tools/valgrind/Python3.supp
+++ b/tools/valgrind/Python3.supp
@@ -417,3 +417,18 @@
    ...
    obj:*
 }
+
+# ---------------------------------------------------------------------------
+# CPython keeps the locks of buffered file objects (io.BufferedReader/-Writer)
+# in a small free list that is not returned to the OS at interpreter shutdown,
+# so PyThread_allocate_lock blocks show up as "possibly lost".  Internal to
+# CPython, outside of LAMMPS.
+# ---------------------------------------------------------------------------
+{
+   CPython_bufferedio_lock
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:PyThread_allocate_lock
+   ...
+}

--- a/tools/valgrind/QUIP.supp
+++ b/tools/valgrind/QUIP.supp
@@ -1,0 +1,42 @@
+# ---------------------------------------------------------------------------
+# The QUIP library (ML-QUIP package) has a bug in its Stillinger-Weber
+# parameter parsing: IPModel_SW.F90 allocates the AA, BB, p, q, eps2, lambda,
+# gamma, and eps3 parameter arrays without initializing them, so entries for
+# type combinations that are not listed in the potential file (e.g. in
+# SiGeH.sw.quip) remain uninitialized and valgrind flags their use during the
+# force computation and when QUIP prints its output.  This must be fixed
+# upstream in QUIP; until then these entries silence the reports that are
+# triggered from inside the QUIP library.  Reports where the uninitialized
+# data propagates into LAMMPS (thermo output, force arrays) cannot be
+# suppressed safely and will remain until the upstream fix.
+# ---------------------------------------------------------------------------
+{
+   QUIP_wrapper_cond
+   Memcheck:Cond
+   ...
+   fun:quip_lammps_*
+   ...
+}
+{
+   QUIP_wrapper_value8
+   Memcheck:Value8
+   ...
+   fun:quip_lammps_*
+   ...
+}
+# QUIP formatting real numbers for its own log output; the deep libc printf
+# call chain pushes the quip_lammps_* entry point out of the recorded stack.
+{
+   QUIP_system_module_cond
+   Memcheck:Cond
+   ...
+   fun:__system_module_MOD_*
+   ...
+}
+{
+   QUIP_system_module_value8
+   Memcheck:Value8
+   ...
+   fun:__system_module_MOD_*
+   ...
+}

--- a/tools/valgrind/README
+++ b/tools/valgrind/README
@@ -15,6 +15,7 @@ valgrind --leak-check=full --track-origins=yes \
    --suppressions=/path/to/lammps/tools/valgrind/OpenMP.supp \
    --suppressions=/path/to/lammps/tools/valgrind/OpenMPI.supp \
    --suppressions=/path/to/lammps/tools/valgrind/Python3.supp \
+   --suppressions=/path/to/lammps/tools/valgrind/ROCm.supp \
    --suppressions=/path/to/lammps/tools/valgrind/libc.supp \
    --suppressions=/path/to/lammps/tools/valgrind/readline.supp \
     lmp -in in.melt
@@ -32,10 +33,11 @@ Or you can create a file $HOME/.valgrindrc with one option per line:
 --suppressions=/path/to/lammps/tools/valgrind/OpenMP.supp
 --suppressions=/path/to/lammps/tools/valgrind/OpenMPI.supp
 --suppressions=/path/to/lammps/tools/valgrind/Python3.supp
+--suppressions=/path/to/lammps/tools/valgrind/ROCm.supp
 --suppressions=/path/to/lammps/tools/valgrind/libc.supp
 --suppressions=/path/to/lammps/tools/valgrind/readline.supp
 
 These options will be automatically added to the valgrind
 command line, so it becomes: valgrind lmp -in in.melt
 
-Last update: 2026-07-26
+Last update: 2026-08-21

--- a/tools/valgrind/README
+++ b/tools/valgrind/README
@@ -7,6 +7,8 @@ on running LAMMPS, use a command line like following:
 
 valgrind --leak-check=full --track-origins=yes \
    --show-leak-kinds=definite,indirect,possible \
+   --max-stackframe=16777216 \
+   --suppressions=/path/to/lammps/tools/valgrind/FFTW.supp \
    --suppressions=/path/to/lammps/tools/valgrind/FlexiBLAS.supp \
    --suppressions=/path/to/lammps/tools/valgrind/GTest.supp \
    --suppressions=/path/to/lammps/tools/valgrind/Kokkos.supp \
@@ -15,6 +17,7 @@ valgrind --leak-check=full --track-origins=yes \
    --suppressions=/path/to/lammps/tools/valgrind/OpenMP.supp \
    --suppressions=/path/to/lammps/tools/valgrind/OpenMPI.supp \
    --suppressions=/path/to/lammps/tools/valgrind/Python3.supp \
+   --suppressions=/path/to/lammps/tools/valgrind/QUIP.supp \
    --suppressions=/path/to/lammps/tools/valgrind/ROCm.supp \
    --suppressions=/path/to/lammps/tools/valgrind/libc.supp \
    --suppressions=/path/to/lammps/tools/valgrind/readline.supp \
@@ -25,6 +28,8 @@ Or you can create a file $HOME/.valgrindrc with one option per line:
 --leak-check=full
 --show-leak-kinds=definite,indirect,possible
 --track-origins=yes
+--max-stackframe=16777216
+--suppressions=/path/to/lammps/tools/valgrind/FFTW.supp
 --suppressions=/path/to/lammps/tools/valgrind/FlexiBLAS.supp
 --suppressions=/path/to/lammps/tools/valgrind/GTest.supp
 --suppressions=/path/to/lammps/tools/valgrind/Kokkos.supp
@@ -33,6 +38,7 @@ Or you can create a file $HOME/.valgrindrc with one option per line:
 --suppressions=/path/to/lammps/tools/valgrind/OpenMP.supp
 --suppressions=/path/to/lammps/tools/valgrind/OpenMPI.supp
 --suppressions=/path/to/lammps/tools/valgrind/Python3.supp
+--suppressions=/path/to/lammps/tools/valgrind/QUIP.supp
 --suppressions=/path/to/lammps/tools/valgrind/ROCm.supp
 --suppressions=/path/to/lammps/tools/valgrind/libc.supp
 --suppressions=/path/to/lammps/tools/valgrind/readline.supp
@@ -40,4 +46,9 @@ Or you can create a file $HOME/.valgrindrc with one option per line:
 These options will be automatically added to the valgrind
 command line, so it becomes: valgrind lmp -in in.melt
 
-Last update: 2026-08-21
+The --max-stackframe option is needed because some Fortran libraries
+(e.g. QUIP) place large automatic arrays on the stack; with the default
+limit valgrind misreads the resulting stack pointer jump as a stack
+switch and reports millions of bogus invalid access errors.
+
+Last update: 2026-08-22

--- a/tools/valgrind/ROCm.supp
+++ b/tools/valgrind/ROCm.supp
@@ -1,0 +1,22 @@
+{
+   ROCm_device_init0
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:realloc
+   fun:add_device_ids_to_mapped_array
+   ...
+   fun:init
+   ...
+   obj:*
+}
+{
+   ROCm_device_init1
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:realloc
+   fun:add_device_ids_to_mapped_array
+   ...
+   fun:alloc
+   ...
+   obj:*
+}

--- a/tools/valgrind/ROCm.supp
+++ b/tools/valgrind/ROCm.supp
@@ -20,3 +20,49 @@
    ...
    obj:*
 }
+
+# ---------------------------------------------------------------------------
+# ROCm HSA/KFD runtime (libhsa-runtime64, hsakmt) and AMD OpenCL runtime
+# internals.  Any process that merely probes the GPU (all unit tests, since
+# the GPU package queries the OpenCL platform on startup) collects a fixed
+# set of "possibly lost" blocks from aperture/memory-object bookkeeping and
+# runtime worker-thread TLS.  All allocations happen inside the ROCm user
+# space stack and are outside of LAMMPS.  Anchored on the stable hsakmt
+# entry points so they keep matching across ROCm versions.
+# ---------------------------------------------------------------------------
+{
+   ROCm_hsakmt_vm_object
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:vm_create_and_init_object
+   ...
+}
+{
+   ROCm_hsakmt_map_to_gpu
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:realloc
+   fun:add_device_ids_to_mapped_array
+   ...
+}
+{
+   ROCm_rocr_thread_tls
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   ...
+   fun:pthread_create@*
+   fun:os_thread
+   ...
+}
+{
+   ROCm_amdocl_thread_tls
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   ...
+   fun:pthread_create@*
+   fun:_ZN3amd*guessTlsSizeEv*
+   ...
+}


### PR DESCRIPTION
**Summary**

This pull request collects multiple small changes and fixes

**Related Issue(s)**

Fixes https://github.com/lammps/lammps/security/code-scanning/619

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

By submitting this pull request, I confirm that I did NOT use any AI tools to *generate*
all or parts of the code and modifications in this pull request. Claude Code (Opus 5) was used to *identify where* changes are needed.

**Backward Compatibility**

N/A

**Implementation Notes**

The following individual changes are included:
- remove "box tilt large" from examples (which has no effect)
- correct example input file for `compute slcsa/atom`
- avoid total grid point integer overflow in Amoeba BiTorsion grids
- correct error messages in `compute slcsa/atom'
- report included body styles in the -help output
- add a few more valgrind suppressions to keep `ctest -T memcheck` quiet about non-LAMMPS issues
- plug memory leaks detected by `ctest -T memcheck`
- fix memory leak in non-GPU KOKKOS versions of ML-PACE pair styles
- fix MPI communicator leaks in GPU library

**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
