### PR TITLE
Add and apply utility functions to check custom format strings

### DIFF
--- a/doc/src/Commands_parse.rst
+++ b/doc/src/Commands_parse.rst
@@ -85,6 +85,12 @@ LAMMPS:
    format string is not specified, a high-precision ``%.20g`` is used as
    the default format.
 
+   .. versionchanged:: TBD
+
+   A conversion in the format string must match a floating-point value.
+   Format strings with a second conversion, such as ``:%.3f%d``, were
+   previously accepted and produced bogus output.
+
    This can be useful for formatting print output to a desired precision:
 
    .. code-block:: LAMMPS

--- a/doc/src/Developer_utils.rst
+++ b/doc/src/Developer_utils.rst
@@ -262,6 +262,21 @@ Convenience functions
 .. doxygenfunction:: sprintf(const std::string &format, Args&&... args)
    :project: progguide
 
+.. doxygenfunction:: check_format(const std::string &format, const std::vector<FmtArg> &expect)
+   :project: progguide
+
+.. doxygenfunction:: check_format(const std::string &format, FmtArg expect)
+   :project: progguide
+
+.. doxygenfunction:: adjust_format(const std::string &format, const std::vector<FmtArg> &expect)
+   :project: progguide
+
+.. doxygenfunction:: adjust_format(const std::string &format, FmtArg expect)
+   :project: progguide
+
+.. doxygenenum:: FmtArg
+   :project: progguide
+
 .. doxygenfunction:: errorurl
    :project: progguide
 

--- a/doc/src/Errors_messages.rst
+++ b/doc/src/Errors_messages.rst
@@ -2500,11 +2500,6 @@ Please also see the page with :doc:`Warning messages <Errors_warnings>`.
    Must have periodic x,y dimensions and non-periodic z dimension to use
    2d slab option with pppm/disp.
 
-*Incorrect conversion in format string*
-   A format style variable was not using either a %f, a %g, or a %e conversion.
-   Or an immediate variable with format suffix was not using either
-   a %f, a %g or a %e conversion in the format suffix.
-
 *Incorrect element names in ADP potential file*
    The element names in the ADP file do not match those requested.
 

--- a/doc/src/dump_modify.rst
+++ b/doc/src/dump_modify.rst
@@ -455,17 +455,29 @@ else the *line* setting (if specified) for that value is used, else
 the default setting is used.  A setting of *none* clears all previous
 settings, reverting all values to their default format.
 
+.. versionchanged:: TBD
+
+Format strings are checked when they are set and LAMMPS will stop with an
+error if a format string does not match the kind of value it is applied
+to, for example when a "%d" conversion is used for a floating-point value.
+Previously such a mismatch was not detected and silently produced
+incorrect output.  A format string may still contain arbitrary literal
+text, and may leave trailing values unformatted.
+
 .. note::
 
    Atom and molecule IDs are stored internally as 4-byte or 8-byte
-   signed integers, depending on how LAMMPS was compiled.  When
-   specifying the *format int* option you can use a "%d"-style format
-   identifier in the format string and LAMMPS will convert this to the
-   corresponding 8-byte form if it is needed when outputting those
-   values.  However, when specifying the *line* option or *format M
-   string* option for those values, you should specify a format string
-   appropriate for an 8-byte signed integer (e.g., one with "%ld") if
-   LAMMPS was compiled with the -DLAMMPS_BIGBIG option for 8-byte IDs.
+   signed integers, depending on how LAMMPS was compiled.  You can use a
+   "%d"-style format identifier for them in all variants of the *format*
+   keyword and LAMMPS will convert it to the corresponding 8-byte form
+   where needed.
+
+   .. versionchanged:: TBD
+
+   This conversion is now also applied to the *line* option and the
+   *format M string* option.  Previously those required a format string
+   for an 8-byte signed integer (e.g., one with "%ld") if LAMMPS was
+   compiled with the -DLAMMPS_BIGBIG option for 8-byte IDs.
 
 .. note::
 

--- a/doc/src/fix_ave_chunk.rst
+++ b/doc/src/fix_ave_chunk.rst
@@ -462,6 +462,13 @@ printed to a file via the *file* keyword.  Note that all values are
 floating point quantities.  The default format is " %g".  You can specify
 a higher precision if desired (e.g., " %20.16g").
 
+.. versionchanged:: TBD
+
+The format string is checked when it is set and LAMMPS will stop with an
+error if its conversion does not match a floating-point value.  Previously
+a mismatched format string was not detected and silently produced
+incorrect output.  Literal text without a conversion remains valid.
+
 The *title1* and *title2* and *title3* keywords allow specification of
 the strings that will be printed as the first three lines of the output
 file, assuming the *file* keyword was used.  LAMMPS uses default

--- a/doc/src/fix_ave_time.rst
+++ b/doc/src/fix_ave_time.rst
@@ -307,6 +307,13 @@ printed to a file via the *file* keyword.  Note that all values are
 floating point quantities.  The default format is " %g".  You can specify
 a higher precision if desired (e.g., " %20.16g").
 
+.. versionchanged:: TBD
+
+The format string is checked when it is set and LAMMPS will stop with an
+error if its conversion does not match a floating-point value.  Previously
+a mismatched format string was not detected and silently produced
+incorrect output.  Literal text without a conversion remains valid.
+
 The *title1* and *title2* and *title3* keywords allow specification of
 the strings that will be printed as the first 2 or 3 lines of the
 output file, assuming the *file* keyword was used.  LAMMPS uses

--- a/doc/src/thermo_modify.rst
+++ b/doc/src/thermo_modify.rst
@@ -216,17 +216,29 @@ else the *line* setting (if specified) for that value is used, else
 the default setting is used.  A setting of *none* clears all previous
 settings, reverting all values to their default format.
 
+.. versionchanged:: TBD
+
+Format strings are checked when the thermo output is set up and LAMMPS
+will stop with an error if a format string does not match the kind of
+value it is applied to, for example when a "%d" conversion is used for a
+floating-point value.  Previously such a mismatch was not detected and
+silently produced incorrect output.  A format string may still contain
+arbitrary literal text, and may leave trailing values unformatted.
+
 .. note::
 
    The thermo output values *step* and *atoms* are stored internally as
    8-byte signed integers, rather than the usual 4-byte signed integers.
-   When specifying the *format int* option you can use a "%d"-style
-   format identifier in the format string and LAMMPS will convert this
-   to the corresponding 8-byte form when it is applied to those
-   keywords.  However, when specifying the *line* option or *format ID
-   string* option for *step* and *natoms*, you should specify a format
-   string appropriate for an 8-byte signed integer (i.e., one with "%ld"
-   or "%lld", depending on the platform).
+   You can use a "%d"-style format identifier for them in all variants of
+   the *format* keyword and LAMMPS will convert it to the corresponding
+   8-byte form when it is applied to those keywords.
+
+   .. versionchanged:: TBD
+
+   This conversion is now also applied to the *line* option and the
+   *format ID string* option.  Previously those required a format string
+   appropriate for an 8-byte signed integer (i.e., one with "%ld" or
+   "%lld", depending on the platform).
 
 The *temp* keyword is used to determine how thermodynamic temperature is
 calculated, which is used by all thermo quantities that require a

--- a/doc/src/variable.rst
+++ b/doc/src/variable.rst
@@ -376,9 +376,16 @@ to the variable.
 For the *format* style, an equal-style or compatible variable is
 specified along with a C-style format string, e.g. "%f" or "%.10g",
 which must be appropriate for formatting a double-precision
-floating-point value and may not have extra characters.  The default
-format is "%.15g".  This variable style allows an equal-style variable
-to be formatted precisely when it is evaluated.
+floating-point value.  The default format is "%.15g".  This variable
+style allows an equal-style variable to be formatted precisely when it
+is evaluated.
+
+.. versionchanged:: TBD
+
+A conversion in the format string must match a floating-point value.  The
+string may now also contain additional text and use all flags and
+modifiers supported by the C library, e.g. "%+12.6e" or "<%.4f>", which
+were previously rejected.
 
 Note that if you simply wish to print a variable value with desired
 precision to the screen or logfile via the :doc:`print <print>` or

--- a/src/EXTRA-DUMP/dump_extxyz.cpp
+++ b/src/EXTRA-DUMP/dump_extxyz.cpp
@@ -83,12 +83,28 @@ void DumpExtXYZ::update_properties()
 
   // The output printf-style format
   delete[] format;
+  std::string lineformat;
   if (format_line_user)
-    format = utils::strdup(fmt::format("{}\n", format_line_user));
+    lineformat = fmt::format("{}\n", format_line_user);
   else {
-    format = utils::strdup(fmt::format("%s %g %g %g{}{}{}\n", (with_vel ? " %g %g %g" : ""),
-                                       (with_forces ? " %g %g %g" : ""), (with_mass ? " %g" : "")));
+    lineformat = fmt::format("%s %g %g %g{}{}{}\n", (with_vel ? " %g %g %g" : ""),
+                             (with_forces ? " %g %g %g" : ""), (with_mass ? " %g" : ""));
   }
+
+  // the line format may come from the user, so it has to be checked against
+  // the values it is used with: the element name and a variable number of
+  // coordinates, velocities, forces, and the mass
+
+  std::vector<utils::FmtArg> expect = {utils::FmtArg::STRING, utils::FmtArg::FLOAT,
+                                       utils::FmtArg::FLOAT, utils::FmtArg::FLOAT};
+  if (with_vel) expect.insert(expect.end(), 3, utils::FmtArg::FLOAT);
+  if (with_forces) expect.insert(expect.end(), 3, utils::FmtArg::FLOAT);
+  if (with_mass) expect.push_back(utils::FmtArg::FLOAT);
+
+  auto errmsg = utils::check_format(lineformat, expect);
+  if (!errmsg.empty())
+    error->all(FLERR, Error::NOLASTLINE, "Invalid dump {} format line: {}", id, errmsg);
+  format = utils::strdup(lineformat);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -1051,6 +1051,38 @@ void Dump::balance()
 }
 
 /* ----------------------------------------------------------------------
+   map the type of a dump column to the type of value its format consumes
+------------------------------------------------------------------------- */
+
+utils::FmtArg Dump::fmtarg_type(int vtype)
+{
+  switch (vtype) {
+    case Dump::INT: return utils::FmtArg::INTEGER;
+    case Dump::BIGINT: return utils::FmtArg::BIGINT;
+    case Dump::STRING:      // fallthrough
+    case Dump::STRING2: return utils::FmtArg::STRING;
+    default: return utils::FmtArg::FLOAT;
+  }
+}
+
+/* ----------------------------------------------------------------------
+   check the format string of a single dump column against the type of its
+   value and adjust the length modifier to the size of the integer types.
+   the format strings may come from the user, so passing an argument that
+   does not match its conversion must be ruled out before it is used.
+------------------------------------------------------------------------- */
+
+void Dump::check_column_format(std::string &colformat, int vtype, int icol)
+{
+  const auto expect = fmtarg_type(vtype);
+  auto errmsg = utils::check_format(colformat, expect);
+  if (!errmsg.empty())
+    error->all(FLERR, Error::NOLASTLINE, "Invalid dump {} format for column {}: {}", id,
+               icol + 1, errmsg);
+  colformat = utils::adjust_format(colformat, expect);
+}
+
+/* ----------------------------------------------------------------------
    process params common to all dumps here
    if unknown param, call modify_param specific to the dump
 ------------------------------------------------------------------------- */

--- a/src/dump.h
+++ b/src/dump.h
@@ -168,6 +168,11 @@ class Dump : protected Pointers {
   virtual void write_data(int, double *) = 0;
   virtual void write_footer() {}
 
+  // type of value a column of this dump is formatted from
+  static utils::FmtArg fmtarg_type(int vtype);
+  // check the format string of a single column and adjust its length modifier
+  void check_column_format(std::string &colformat, int vtype, int icol);
+
   void pbc_allocate();
   double compute_time();
 

--- a/src/dump_atom.cpp
+++ b/src/dump_atom.cpp
@@ -59,12 +59,29 @@ void DumpAtom::init_style()
   // default depends on image flags
 
   delete[] format;
+  std::string lineformat;
   if (format_line_user) {
-    format = utils::strdup(std::string(format_line_user) + "\n");
+    lineformat = std::string(format_line_user) + "\n";
   } else {
-    if (image_flag == 0) format = utils::strdup(TAGINT_FORMAT " %d %g %g %g\n");
-    else format = utils::strdup(TAGINT_FORMAT " %d %g %g %g %d %d %d\n");
+    if (image_flag == 0) lineformat = TAGINT_FORMAT " %d %g %g %g\n";
+    else lineformat = TAGINT_FORMAT " %d %g %g %g %d %d %d\n";
   }
+
+  // the line format may come from the user, so it has to be checked against
+  // the values it is used with.  the length modifiers of the integer
+  // conversions are adjusted, so that a user may write %d regardless of the
+  // integer sizes LAMMPS was compiled with.
+
+  const auto tagtype = (sizeof(tagint) == sizeof(smallint)) ? utils::FmtArg::INTEGER
+                                                            : utils::FmtArg::BIGINT;
+  std::vector<utils::FmtArg> expect = {tagtype, utils::FmtArg::INTEGER, utils::FmtArg::FLOAT,
+                                       utils::FmtArg::FLOAT, utils::FmtArg::FLOAT};
+  if (image_flag) expect.insert(expect.end(), 3, utils::FmtArg::INTEGER);
+
+  auto errmsg = utils::check_format(lineformat, expect);
+  if (!errmsg.empty())
+    error->all(FLERR, Error::NOLASTLINE, "Invalid dump {} format line: {}", id, errmsg);
+  format = utils::strdup(utils::adjust_format(lineformat, expect));
 
   // setup boundary string
 

--- a/src/dump_custom.cpp
+++ b/src/dump_custom.cpp
@@ -275,18 +275,23 @@ void DumpCustom::init_style()
     if (i >= nfield) break;
     delete[] vformat[i];
 
+    std::string colformat;
     if (format_column_user[i])
-      vformat[i] = utils::strdup(std::string(format_column_user[i]) + " ");
+      colformat = format_column_user[i];
     else if (vtype[i] == Dump::INT && format_int_user)
-      vformat[i] = utils::strdup(std::string(format_int_user) + " ");
+      colformat = format_int_user;
     else if (vtype[i] == Dump::DOUBLE && format_float_user)
-      vformat[i] = utils::strdup(std::string(format_float_user) + " ");
+      colformat = format_float_user;
     else if (vtype[i] == Dump::BIGINT && format_bigint_user)
-      vformat[i] = utils::strdup(std::string(format_bigint_user) + " ");
-    else vformat[i] = utils::strdup(word + " ");
+      colformat = format_bigint_user;
+    else colformat = word;
 
-    // remove trailing blank on last column's format
-    if (i == nfield-1) vformat[i][strlen(vformat[i])-1] = '\0';
+    // the format may come from the user, so check it against the column type
+    check_column_format(colformat, vtype[i], i);
+
+    // add trailing blank, but not on the last column's format
+    if (i < nfield-1) colformat += " ";
+    vformat[i] = utils::strdup(colformat);
 
     ++i;
   }
@@ -1942,19 +1947,20 @@ int DumpCustom::modify_param(int narg, char **arg)
     if (narg < 3) utils::missing_cmd_args(FLERR, "dump_modify format", error);
 
     if (strcmp(arg[1],"int") == 0) {
+      auto errmsg = utils::check_format(arg[2], utils::FmtArg::INTEGER);
+      if (!errmsg.empty())
+        error->all(FLERR, argoff + 2, "Invalid dump_modify int format: {}", errmsg);
       delete[] format_int_user;
       format_int_user = utils::strdup(arg[2]);
-      // replace "d" in format_int_user with bigint format specifier
-      // which is BIGINT_FORMAT without the leading '%'
-      std::string ifmt = format_int_user;
-      auto found = ifmt.find('d');
-      if (found == std::string::npos)
-        error->all(FLERR, argoff + 2, "Dump_modify int format does not contain d character");
-      ifmt.replace(found, 1, std::string(BIGINT_FORMAT).substr(1));
+      // derive the format for large integers from the one given by the user
       delete[] format_bigint_user;
-      format_bigint_user = utils::strdup(ifmt);
+      format_bigint_user =
+        utils::strdup(utils::adjust_format(arg[2], utils::FmtArg::BIGINT));
 
     } else if (strcmp(arg[1],"float") == 0) {
+      auto errmsg = utils::check_format(arg[2], utils::FmtArg::FLOAT);
+      if (!errmsg.empty())
+        error->all(FLERR, argoff + 2, "Invalid dump_modify float format: {}", errmsg);
       delete[] format_float_user;
       format_float_user = utils::strdup(arg[2]);
 
@@ -1962,6 +1968,9 @@ int DumpCustom::modify_param(int narg, char **arg)
       int i = utils::inumeric(FLERR,arg[1],false,lmp) - 1;
       if (i < 0 || i >= nfield)
         error->all(FLERR, argoff + 1, "Unknown dump_modify format ID keyword: {}", arg[1]);
+      auto errmsg = utils::check_format(arg[2], fmtarg_type(vtype[i]));
+      if (!errmsg.empty())
+        error->all(FLERR, argoff + 2, "Invalid dump_modify format for column {}: {}", i + 1, errmsg);
       delete[] format_column_user[i];
       format_column_user[i] = utils::strdup(arg[2]);
     }

--- a/src/dump_grid.cpp
+++ b/src/dump_grid.cpp
@@ -216,18 +216,23 @@ void DumpGrid::init_style()
   for (const auto &word : words) {
     delete[] vformat[i];
 
+    std::string colformat;
     if (format_column_user[i])
-      vformat[i] = utils::strdup(std::string(format_column_user[i]) + " ");
+      colformat = format_column_user[i];
     else if (vtype[i] == Dump::INT && format_int_user)
-      vformat[i] = utils::strdup(std::string(format_int_user) + " ");
+      colformat = format_int_user;
     else if (vtype[i] == Dump::DOUBLE && format_float_user)
-      vformat[i] = utils::strdup(std::string(format_float_user) + " ");
+      colformat = format_float_user;
     else if (vtype[i] == Dump::BIGINT && format_bigint_user)
-      vformat[i] = utils::strdup(std::string(format_bigint_user) + " ");
-    else vformat[i] = utils::strdup(word + " ");
+      colformat = format_bigint_user;
+    else colformat = word;
 
-    // remove trailing blank on last column's format
-    if (i == nfield-1) vformat[i][strlen(vformat[i])-1] = '\0';
+    // the format may come from the user, so check it against the column type
+    check_column_format(colformat, vtype[i], i);
+
+    // add trailing blank, but not on the last column's format
+    if (i < nfield-1) colformat += " ";
+    vformat[i] = utils::strdup(colformat);
 
     ++i;
   }
@@ -767,19 +772,20 @@ int DumpGrid::modify_param(int narg, char **arg)
     if (narg < 3) error->all(FLERR,"Illegal dump_modify command");
 
     if (strcmp(arg[1],"int") == 0) {
+      auto errmsg = utils::check_format(arg[2], utils::FmtArg::INTEGER);
+      if (!errmsg.empty())
+        error->all(FLERR, "Invalid dump_modify int format: {}", errmsg);
       delete[] format_int_user;
       format_int_user = utils::strdup(arg[2]);
-      // replace "d" in format_int_user with bigint format specifier
-      // which is BIGINT_FORMAT without the leading '%'
-      std::string ifmt = format_int_user;
-      auto found = ifmt.find('d');
-      if (found == std::string::npos)
-        error->all(FLERR,"Dump_modify int format does not contain d character");
-      ifmt.replace(found, 1, std::string(BIGINT_FORMAT).substr(1));
+      // derive the format for large integers from the one given by the user
       delete[] format_bigint_user;
-      format_bigint_user = utils::strdup(ifmt);
+      format_bigint_user =
+        utils::strdup(utils::adjust_format(arg[2], utils::FmtArg::BIGINT));
 
     } else if (strcmp(arg[1],"float") == 0) {
+      auto errmsg = utils::check_format(arg[2], utils::FmtArg::FLOAT);
+      if (!errmsg.empty())
+        error->all(FLERR, "Invalid dump_modify float format: {}", errmsg);
       delete[] format_float_user;
       format_float_user = utils::strdup(arg[2]);
 
@@ -787,6 +793,9 @@ int DumpGrid::modify_param(int narg, char **arg)
       int i = utils::inumeric(FLERR,arg[1],false,lmp) - 1;
       if (i < 0 || i >= nfield)
         error->all(FLERR,"Illegal dump_modify command");
+      auto errmsg = utils::check_format(arg[2], fmtarg_type(vtype[i]));
+      if (!errmsg.empty())
+        error->all(FLERR, "Invalid dump_modify format for column {}: {}", i + 1, errmsg);
       delete[] format_column_user[i];
       format_column_user[i] = utils::strdup(arg[2]);
     }

--- a/src/dump_local.cpp
+++ b/src/dump_local.cpp
@@ -194,15 +194,20 @@ void DumpLocal::init_style()
     if (i >= size_one) break;
     delete[] vformat[i];
 
+    std::string colformat;
     if (format_column_user[i])
-      vformat[i] = utils::strdup(std::string(format_column_user[i]) + " ");
+      colformat = format_column_user[i];
     else if (vtype[i] == Dump::INT && format_int_user)
-      vformat[i] = utils::strdup(std::string(format_int_user) + " ");
+      colformat = format_int_user;
     else if (vtype[i] == Dump::DOUBLE && format_float_user)
-      vformat[i] = utils::strdup(std::string(format_float_user) + " ");
+      colformat = format_float_user;
     else if (vtype[i] == Dump::BIGINT && format_bigint_user)
-      vformat[i] = utils::strdup(std::string(format_bigint_user) + " ");
-    else vformat[i] = utils::strdup(word + " ");
+      colformat = format_bigint_user;
+    else colformat = word;
+
+    // the format may come from the user, so check it against the column type
+    check_column_format(colformat, vtype[i], i);
+    vformat[i] = utils::strdup(colformat + " ");
     ++i;
   }
 
@@ -262,19 +267,20 @@ int DumpLocal::modify_param(int narg, char **arg)
       }
       return 2;
     } else if (strcmp(arg[1],"int") == 0) {
+      auto errmsg = utils::check_format(arg[2], utils::FmtArg::INTEGER);
+      if (!errmsg.empty())
+        error->all(FLERR, argoff + 2, "Invalid dump_modify int format: {}", errmsg);
       delete[] format_int_user;
       format_int_user = utils::strdup(arg[2]);
-      // replace "d" in format_int_user with bigint format specifier
-      // which is BIGINT_FORMAT without the leading '%'
-      std::string ifmt = format_int_user;
-      auto found = ifmt.find('d');
-      if (found == std::string::npos)
-        error->all(FLERR, argoff + 2, "Dump_modify int format does not contain d character");
-      ifmt.replace(found, 1, std::string(BIGINT_FORMAT).substr(1));
+      // derive the format for large integers from the one given by the user
       delete[] format_bigint_user;
-      format_bigint_user = utils::strdup(ifmt);
+      format_bigint_user =
+        utils::strdup(utils::adjust_format(arg[2], utils::FmtArg::BIGINT));
 
     } else if (strcmp(arg[1],"float") == 0) {
+      auto errmsg = utils::check_format(arg[2], utils::FmtArg::FLOAT);
+      if (!errmsg.empty())
+        error->all(FLERR, argoff + 2, "Invalid dump_modify float format: {}", errmsg);
       delete[] format_float_user;
       format_float_user = utils::strdup(arg[2]);
 
@@ -282,6 +288,9 @@ int DumpLocal::modify_param(int narg, char **arg)
       int i = utils::inumeric(FLERR,arg[1],false,lmp) - 1;
       if (i < 0 || i >= nfield)
         error->all(FLERR, 1, "Illegal dump_modify format column number {}", i);
+      auto errmsg = utils::check_format(arg[2], fmtarg_type(vtype[i]));
+      if (!errmsg.empty())
+        error->all(FLERR, argoff + 2, "Invalid dump_modify format for column {}: {}", i + 1, errmsg);
       delete[] format_column_user[i];
       format_column_user[i] = utils::strdup(arg[2]);
     }

--- a/src/dump_xyz.cpp
+++ b/src/dump_xyz.cpp
@@ -73,10 +73,21 @@ void DumpXYZ::init_style()
 
   delete [] format;
 
+  std::string lineformat;
   if (format_line_user)
-    format = utils::strdup(fmt::format("{}\n", format_line_user));
+    lineformat = fmt::format("{}\n", format_line_user);
   else
-    format = utils::strdup(fmt::format("{}\n", format_default));
+    lineformat = fmt::format("{}\n", format_default);
+
+  // the line format may come from the user and is used with the element name
+  // and the three coordinates, so it has to be checked before it is used
+
+  const std::vector<utils::FmtArg> expect = {utils::FmtArg::STRING, utils::FmtArg::FLOAT,
+                                             utils::FmtArg::FLOAT, utils::FmtArg::FLOAT};
+  auto errmsg = utils::check_format(lineformat, expect);
+  if (!errmsg.empty())
+    error->all(FLERR, Error::NOLASTLINE, "Invalid dump {} format line: {}", id, errmsg);
+  format = utils::strdup(lineformat);
 
   // initialize typenames array to be backward compatible by default
   if (typenames == nullptr) {

--- a/src/fix_ave_chunk.cpp
+++ b/src/fix_ave_chunk.cpp
@@ -216,6 +216,9 @@ FixAveChunk::FixAveChunk(LAMMPS *lmp, int narg, char **arg) :
       iarg += 1;
     } else if (strcmp(arg[iarg],"format") == 0) {
       if (iarg+2 > nargnew)  utils::missing_cmd_args(FLERR, "fix ave/chunk format", error);
+      auto errmsg = utils::check_format(arg[iarg+1], utils::FmtArg::FLOAT);
+      if (!errmsg.empty())
+        error->all(FLERR, iarg+1, "Invalid fix ave/chunk format argument: {}", errmsg);
       delete[] format;
       format = utils::strdup(arg[iarg+1]);
       iarg += 2;

--- a/src/fix_ave_time.cpp
+++ b/src/fix_ave_time.cpp
@@ -1073,6 +1073,9 @@ void FixAveTime::options(int iarg, int narg, char **arg)
       iarg += 1;
     } else if (strcmp(arg[iarg],"format") == 0) {
       if (iarg+2 > narg) utils::missing_cmd_args(FLERR, "fix ave/time format", error);
+      auto errmsg = utils::check_format(arg[iarg+1], utils::FmtArg::FLOAT);
+      if (!errmsg.empty())
+        error->all(FLERR, iarg+1, "Invalid fix ave/time format argument: {}", errmsg);
       delete[] format;
       format = utils::strdup(arg[iarg+1]);
       iarg += 2;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -649,10 +649,11 @@ void Input::substitute(char *&str, char *&str2, int &max, int &max2, int flag)
           *fmtflag='\0';
         }
 
-        // quick check for proper format string
+        // check that the format string matches the floating point value
 
-        if (!utils::strmatch(fmtstr,R"(%[0-9 ]*\.[0-9]+[efgEFG])"))
-          error->all(FLERR,"Incorrect conversion in format string {}", fmtstr);
+        auto errmsg = utils::check_format(fmtstr, utils::FmtArg::FLOAT);
+        if (!errmsg.empty())
+          error->all(FLERR,"Invalid format string in immediate variable: {}", errmsg);
 
         immediate = utils::sprintf(fmtstr, variable->compute_equal(var));
         value = immediate.c_str();

--- a/src/thermo.cpp
+++ b/src/thermo.cpp
@@ -270,14 +270,22 @@ void Thermo::init()
           format_this = FORMAT_INT_MULTI_DEFAULT;
         else
           format_this = FORMAT_INT_YAML_DEFAULT;
-        if (vtype[i] == BIGINT) {
-          // replace "d" in int format with bigint format specifier
-          auto found = format_this.find('%');
-          found = format_this.find('d', found);
-          format_this = format_this.replace(found, 1, std::string(BIGINT_FORMAT).substr(1));
-        }
       }
     }
+
+    // the format string may come from the user, so it must be checked against
+    // the type of the value before it is used.  the length modifier of integer
+    // conversions is adjusted so that users need not care about the integer
+    // size LAMMPS was compiled with.
+
+    const auto expect = (vtype[i] == FLOAT)    ? utils::FmtArg::FLOAT
+                        : (vtype[i] == BIGINT) ? utils::FmtArg::BIGINT
+                                               : utils::FmtArg::INTEGER;
+    auto errmsg = utils::check_format(format_this, expect);
+    if (!errmsg.empty())
+      error->all(FLERR, Error::NOLASTLINE, "Invalid thermo format for column {} ({}): {}", i + 1,
+                 keyword_user[i].empty() ? keyword[i] : keyword_user[i], errmsg);
+    format_this = utils::adjust_format(format_this, expect);
 
     if (lineflag == ONELINE)
       format[i] += format_this + " ";
@@ -734,16 +742,16 @@ void Thermo::modify_params(int narg, char **arg)
       if (strcmp(arg[iarg + 1], "line") == 0) {
         format_line_user = arg[iarg + 2];
       } else if (strcmp(arg[iarg + 1], "int") == 0) {
+        auto errmsg = utils::check_format(arg[iarg + 2], utils::FmtArg::INTEGER);
+        if (!errmsg.empty())
+          error->all(FLERR, iarg + 2, "Invalid thermo_modify int format: {}", errmsg);
         format_int_user = arg[iarg + 2];
-        // replace "d" in format_int_user with bigint format specifier
-        auto found = format_int_user.find('%');
-        found = format_int_user.find('d', found);
-        if (found == std::string::npos)
-          error->all(FLERR, iarg + 2,
-                     "Thermo_modify int format does not contain a d conversion character");
-        format_bigint_user =
-            format_int_user.replace(found, 1, std::string(BIGINT_FORMAT).substr(1));
+        // derive the format for large integers from the one given by the user
+        format_bigint_user = utils::adjust_format(format_int_user, utils::FmtArg::BIGINT);
       } else if (strcmp(arg[iarg + 1], "float") == 0) {
+        auto errmsg = utils::check_format(arg[iarg + 2], utils::FmtArg::FLOAT);
+        if (!errmsg.empty())
+          error->all(FLERR, iarg + 2, "Invalid thermo_modify float format: {}", errmsg);
         format_float_user = arg[iarg + 2];
       } else if (utils::strmatch(arg[iarg + 1], R"(^\d*\*\d*$)")) {
         // handles cases such as 2*6; currently doesn't allow negatives

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -327,6 +327,212 @@ std::string utils::varargs_sprintf(const char *format, ...)
   return result;
 }
 
+/* ----------------------------------------------------------------------
+   scanning and checking of printf() style format strings.  LAMMPS accepts
+   those from users in several places (dump_modify, thermo_modify, ...) and
+   passing an argument that does not match its conversion is undefined
+   behavior, so the format strings must be validated before they are used.
+------------------------------------------------------------------------- */
+
+// one conversion in a printf() style format string
+
+namespace {
+struct FmtSpec {
+  std::size_t start;      // offset of the leading '%'
+  std::size_t len;        // length of the entire conversion
+  std::size_t lenmod;     // offset of the length modifier
+  char conv;              // conversion character
+  utils::FmtArg type;     // type of value consumed
+};
+
+// classify a conversion character.  returns FmtArg::NONE if unsupported.
+
+utils::FmtArg conv_type(char conv)
+{
+  // strchr() also matches the terminating null byte
+  if (conv == '\0') return utils::FmtArg::NONE;
+  if (strchr("diouxXc", conv)) return utils::FmtArg::INTEGER;
+  if (strchr("eEfFgGaA", conv)) return utils::FmtArg::FLOAT;
+  if (conv == 's') return utils::FmtArg::STRING;
+  if (conv == 'p') return utils::FmtArg::POINTER;
+  return utils::FmtArg::NONE;
+}
+
+// scan a format string and return its conversions.  on a malformed or
+// unsupported conversion, errmsg is set and scanning stops.
+
+std::vector<FmtSpec> scan_format(const std::string &format, std::string &errmsg)
+{
+  std::vector<FmtSpec> specs;
+  const std::size_t num = format.size();
+  errmsg.clear();
+
+  for (std::size_t i = 0; i < num; ++i) {
+    if (format[i] != '%') continue;
+    const std::size_t start = i++;
+
+    // "%%" is a literal percent sign and consumes no argument
+    if ((i < num) && (format[i] == '%')) continue;
+
+    // flags
+    while ((i < num) && (format[i] != '\0') && strchr("-+ #0'", format[i])) ++i;
+
+    // field width.  a '*' would consume an extra argument, so it is rejected
+    if ((i < num) && (format[i] == '*')) {
+      errmsg = fmt::format("variable field width '*' is not supported in '{}'", format);
+      return specs;
+    }
+    while ((i < num) && isdigit((unsigned char) format[i])) ++i;
+
+    // precision
+    if ((i < num) && (format[i] == '.')) {
+      ++i;
+      if ((i < num) && (format[i] == '*')) {
+        errmsg = fmt::format("variable precision '*' is not supported in '{}'", format);
+        return specs;
+      }
+      while ((i < num) && isdigit((unsigned char) format[i])) ++i;
+    }
+
+    // length modifier
+    const std::size_t lenmod = i;
+    if ((i < num) && ((format[i] == 'h') || (format[i] == 'l'))) {
+      const char mod = format[i++];
+      if ((i < num) && (format[i] == mod)) ++i;
+    } else if ((i < num) && (format[i] != '\0') && strchr("jztL", format[i])) {
+      ++i;
+    }
+
+    if (i >= num) {
+      errmsg = fmt::format("incomplete conversion '{}' in '{}'", format.substr(start), format);
+      return specs;
+    }
+
+    FmtSpec spec;
+    spec.start = start;
+    spec.len = i - start + 1;
+    spec.lenmod = lenmod;
+    spec.conv = format[i];
+    spec.type = conv_type(spec.conv);
+
+    if (spec.type == utils::FmtArg::NONE) {
+      errmsg = fmt::format("unsupported conversion '{}' in '{}'",
+                           format.substr(start, spec.len), format);
+      return specs;
+    }
+
+    // a length modifier only makes sense for numbers
+    if ((lenmod < i) && ((spec.type == utils::FmtArg::STRING) ||
+                         (spec.type == utils::FmtArg::POINTER))) {
+      errmsg = fmt::format("unsupported length modifier in conversion '{}' of '{}'",
+                           format.substr(start, spec.len), format);
+      return specs;
+    }
+    specs.push_back(spec);
+  }
+  return specs;
+}
+
+// Integer conversions can be retyped by adjust_format(), so both integer types
+// are equivalent when a conversion is checked against an expected value type.
+
+utils::FmtArg fmtarg_group(utils::FmtArg type)
+{
+  return (type == utils::FmtArg::BIGINT) ? utils::FmtArg::INTEGER : type;
+}
+
+// name of an argument type for use in error messages
+
+std::string fmtarg_name(utils::FmtArg type)
+{
+  switch (type) {
+    case utils::FmtArg::INTEGER: return "integer";
+    case utils::FmtArg::BIGINT: return "large integer";
+    case utils::FmtArg::FLOAT: return "floating-point";
+    case utils::FmtArg::STRING: return "string";
+    case utils::FmtArg::POINTER: return "pointer";
+    default: return "unknown";
+  }
+}
+
+// Length modifier required for a bigint argument.  This must not be hardcoded:
+// int64_t is "long int" on LP64 platforms (Linux, macOS) but "long long int" on
+// LLP64 platforms (Windows), so the required modifier is "l" on the former and
+// "ll" on the latter.  BIGINT_FORMAT is built from the PRId64 macro of
+// <cinttypes>, which is the standardized way to spell this per platform, so the
+// modifier is extracted from it instead.
+
+const std::string &bigint_lenmod()
+{
+  static const std::string lenmod = []() {
+    std::string errmsg;
+    const std::string bigfmt = BIGINT_FORMAT;
+    const auto specs = scan_format(bigfmt, errmsg);
+    if (specs.empty()) return std::string();
+    // the length modifier reaches from its offset to the conversion character
+    const std::size_t conv = specs[0].start + specs[0].len - 1;
+    return bigfmt.substr(specs[0].lenmod, conv - specs[0].lenmod);
+  }();
+  return lenmod;
+}
+}    // namespace
+
+std::string utils::check_format(const std::string &format, const std::vector<FmtArg> &expect)
+{
+  std::string errmsg;
+  const auto specs = scan_format(format, errmsg);
+  if (!errmsg.empty()) return errmsg;
+
+  // more conversions than values would consume arguments that were never
+  // passed.  fewer conversions are harmless: the surplus values are simply not
+  // printed, and literal text without any conversion is a valid format string.
+
+  if (specs.size() > expect.size())
+    return fmt::format("'{}' has {} conversion(s) but only {} value(s) are provided", format,
+                       specs.size(), expect.size());
+
+  for (std::size_t i = 0; i < specs.size(); ++i) {
+    if (fmtarg_group(specs[i].type) != fmtarg_group(expect[i]))
+      return fmt::format("conversion {} of '{}' formats {} values, but {} values are provided",
+                         i + 1, format, fmtarg_name(specs[i].type), fmtarg_name(expect[i]));
+
+    // a c conversion consumes an int and has no length modifier for 64-bit values
+    if ((specs[i].conv == 'c') && (expect[i] == FmtArg::BIGINT))
+      return fmt::format("conversion {} of '{}' cannot be used for {} values", i + 1, format,
+                         fmtarg_name(expect[i]));
+  }
+  return "";
+}
+
+std::string utils::check_format(const std::string &format, FmtArg expect)
+{
+  return check_format(format, std::vector<FmtArg>{expect});
+}
+
+std::string utils::adjust_format(const std::string &format, const std::vector<FmtArg> &expect)
+{
+  if (!check_format(format, expect).empty()) return format;
+
+  std::string errmsg;
+  const auto specs = scan_format(format, errmsg);
+  std::string adjusted;
+  std::size_t pos = 0;
+
+  for (std::size_t i = 0; i < specs.size(); ++i) {
+    // copy text and conversion prefix, then substitute the length modifier
+    adjusted += format.substr(pos, specs[i].lenmod - pos);
+    if ((expect[i] == FmtArg::BIGINT) && (specs[i].conv != 'c')) adjusted += bigint_lenmod();
+    pos = specs[i].start + specs[i].len - 1;
+  }
+  adjusted += format.substr(pos);
+  return adjusted;
+}
+
+std::string utils::adjust_format(const std::string &format, FmtArg expect)
+{
+  return adjust_format(format, std::vector<FmtArg>{expect});
+}
+
 std::string utils::errorurl(int errorcode)
 {
   if (errorcode == 0)

--- a/src/utils.h
+++ b/src/utils.h
@@ -262,6 +262,125 @@ template <typename... Args> std::string sprintf(const std::string &format, Args 
   return varargs_sprintf(format.c_str(), sprintf_arg(args)...);
 }
 
+/*! Type of value consumed by a printf() style conversion
+
+\verbatim embed:rst
+
+.. versionadded:: TBD
+
+Conversions are grouped by the kind of value they consume: the d, i, o, u,
+x, X, and c conversions consume integers, the e, E, f, F, g, G, a, and A
+conversions consume floating-point numbers, the s conversion consumes a
+string, and the p conversion consumes a pointer.  For checking a format
+string with :cpp:func:`utils::check_format()
+<LAMMPS_NS::utils::check_format>` the two integer types are equivalent,
+since a mismatch in the *width* of an integer argument is corrected by
+:cpp:func:`utils::adjust_format() <LAMMPS_NS::utils::adjust_format>`.
+
+\endverbatim */
+
+enum class FmtArg {
+  NONE,       /*!< no value, i.e. an invalid or literal conversion */
+  INTEGER,    /*!< value of type int */
+  BIGINT,     /*!< value of type bigint, i.e. a 64-bit integer */
+  FLOAT,      /*!< value of type double */
+  STRING,     /*!< string value, i.e. a char pointer */
+  POINTER     /*!< pointer value */
+};
+
+/*! Check a printf() style format string against the expected argument types
+
+\verbatim embed:rst
+
+.. versionadded:: TBD
+
+LAMMPS accepts printf() style format strings from users in multiple
+places, for example with :doc:`dump_modify format <dump_modify>` or
+:doc:`thermo_modify format <thermo_modify>`.  Passing an argument that
+does not match its conversion to a printf() style function has undefined
+behavior; in practice it silently produces incorrect output.  Since the
+format strings are only known at runtime, they must be checked before
+they are used.
+
+This function compares the conversions in *format* against the list of
+value types in *expect* and returns an empty string if they agree.  If
+they do not, or if the format string is malformed, the returned string
+describes the problem and is meant to be included in an error message.
+
+A format string may have *fewer* conversions than there are values, down
+to none at all: printf() simply ignores the surplus values, so literal
+text without any conversion is valid and may be used to label or decorate
+the output.  Having *more* conversions than values is an error, since
+those would consume arguments that were never passed.  For the same
+reason the ``n`` conversion, variable field widths or precisions given as
+``*``, length modifiers on ``s`` and ``p`` conversions, unknown conversion
+characters, and incomplete conversions at the end of the string are
+rejected.  A ``%%`` sequence is a literal percent sign and consumes no
+value.
+
+.. code-block:: c++
+
+   auto errmsg = utils::check_format(arg[2], {utils::FmtArg::FLOAT});
+   if (!errmsg.empty())
+     error->all(FLERR, 2, "Invalid dump_modify format float argument: {}", errmsg);
+
+\endverbatim
+ *
+ *  \param  format  printf() style format string
+ *  \param  expect  list of value types the format string must consume
+ *  \return         empty string if the format string is valid, otherwise a
+ *                  description of the problem */
+
+std::string check_format(const std::string &format, const std::vector<FmtArg> &expect);
+
+/*! \overload
+ *
+ *  \param  format  printf() style format string
+ *  \param  expect  single value type the format string must consume */
+
+std::string check_format(const std::string &format, FmtArg expect);
+
+/*! Adjust the length modifiers of a format string to the expected arguments
+
+\verbatim embed:rst
+
+.. versionadded:: TBD
+
+The C library derives the size of the value consumed by an integer
+conversion from its length modifier, so ``%d`` and ``%ld`` must be used
+with an ``int`` and a ``long`` argument, respectively.  Requiring users to
+get this right would make format strings depend on how LAMMPS was
+compiled, since types like ``bigint`` and ``tagint`` change size with the
+:ref:`size settings <size>`.  Worse, the correct modifier for a 64-bit
+integer is platform dependent: ``int64_t`` is ``long int`` on LP64
+platforms like Linux and macOS, but ``long long int`` on LLP64 platforms
+like Windows.  The modifier applied here is therefore taken from
+``BIGINT_FORMAT``, which is built from the ``PRId64`` macro of
+``<cinttypes>`` and thus spelled correctly on every platform.
+
+This function therefore replaces the length modifier of every conversion
+in *format* with the one matching the corresponding entry of *expect*, so
+that a user may write ``%d`` regardless of the integer size in use.  Any
+flags, field width, precision, and surrounding text are preserved.  The
+format string should be validated with :cpp:func:`utils::check_format()
+<LAMMPS_NS::utils::check_format>` first; a format string that does not
+match *expect* is returned unchanged.
+
+\endverbatim
+ *
+ *  \param  format  printf() style format string
+ *  \param  expect  list of value types the format string is used with
+ *  \return         format string with length modifiers adjusted */
+
+std::string adjust_format(const std::string &format, const std::vector<FmtArg> &expect);
+
+/*! \overload
+ *
+ *  \param  format  printf() style format string
+ *  \param  expect  single value type the format string is used with */
+
+std::string adjust_format(const std::string &format, FmtArg expect);
+
 /*! Return text redirecting the user to a specific paragraph in the manual
  *
  * The LAMMPS manual contains detailed explanations for errors and

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -552,8 +552,9 @@ void Variable::set(int narg, char **arg)
       error->all(FLERR, "Variable {}: format variable {} does not exist", arg[0], arg[2]);
     if (!equalstyle(jvar))
       error->all(FLERR, "Variable {}: format variable {} has incompatible style", arg[0], arg[2]);
-    if (!utils::strmatch(arg[3], "^% ?-?[0-9]*\\.?[0-9]*[efgEFG]$"))
-      error->all(FLERR, "Incorrect conversion in format string: {}", arg[3]);
+    auto errmsg = utils::check_format(arg[3], utils::FmtArg::FLOAT);
+    if (!errmsg.empty())
+      error->all(FLERR, 3, "Invalid format string for format style variable: {}", errmsg);
 
     newvar.num = 3;
     newvar.which = 0;

--- a/unittest/commands/test_thermo.cpp
+++ b/unittest/commands/test_thermo.cpp
@@ -421,8 +421,21 @@ TEST_F(ThermoTest, Format)
                  command("thermo_modify format 10 %d"););
     TEST_FAILURE(".*ERROR: Invalid thermo_modify format argument: -10.*",
                  command("thermo_modify format -10 %d"););
-    TEST_FAILURE(".*ERROR: Thermo_modify int format does not contain a d conversion character.*",
+    TEST_FAILURE(".*ERROR: Invalid thermo_modify int format: conversion 1 of '%f' formats "
+                 "floating-point values, but integer values are provided.*",
                  command("thermo_modify format int %f"););
+    TEST_FAILURE(".*ERROR: Invalid thermo_modify float format: conversion 1 of '%d' formats "
+                 "integer values, but floating-point values are provided.*",
+                 command("thermo_modify format float %d"););
+    TEST_FAILURE(".*ERROR: Invalid thermo format for column 3 .*conversion 1 of '%d' formats "
+                 "integer values.*",
+                 command("thermo_modify format 3 %d"); command("run 0 post no"););
+    // a column format without a conversion prints literal text and is allowed
+    HIDE_OUTPUT([&] {
+        command("thermo_modify format none");
+        command("thermo_modify format 3 n/a");
+    });
+    ASSERT_MATCH(run0(), "\n +0 +32 +n/a +-[0-9.]+ *\n");
 }
 
 TEST_F(ThermoTest, Colname)

--- a/unittest/commands/test_variables.cpp
+++ b/unittest/commands/test_variables.cpp
@@ -244,7 +244,8 @@ TEST_F(VariableTest, CreateDelete)
                  command("variable ten10 world xxx xxx"););
     TEST_FAILURE(".*ERROR: All universe and uloop style variables must have same # of values.*",
                  command("variable ten6   uloop     2"););
-    TEST_FAILURE(".*ERROR: Incorrect conversion in format string.*",
+    TEST_FAILURE(".*ERROR: Invalid format string for format style variable: conversion 1 of "
+                 "'%08x' formats integer values, but floating-point values are provided.*",
                  command("variable ten11  format    two \"%08x\""););
     TEST_FAILURE(".*ERROR.*Substitution for illegal variable xxx.*",
                  command("variable three  string \"${xxx} five\""););
@@ -874,17 +875,34 @@ TEST_F(VariableTest, Format)
     TEST_FAILURE(".*ERROR: Cannot redefine format style variable f2one as equal style.*",
                  command("variable f2one equal 0.5"););
     TEST_FAILURE(".*ERROR: Illegal variable command.*", command("variable xxx format \"xxx\""););
-    TEST_FAILURE(".*ERROR: Incorrect conversion in format string.*",
-                 command("variable xxx format one \"xxx\""););
-    TEST_FAILURE(".*ERROR: Incorrect conversion in format string.*",
+    // a format string without a conversion is harmless, it yields literal text
+    BEGIN_HIDE_OUTPUT();
+    command("variable fmtplain format one \"xxx\"");
+    END_HIDE_OUTPUT();
+    EXPECT_THAT(variable->retrieve("fmtplain"), StrEq("xxx"));
+    TEST_FAILURE(".*ERROR: Invalid format string for format style variable: conversion 1 of "
+                 "'%d' formats integer values, but floating-point values are provided.*",
                  command("variable xxx format one \"%d\""););
-    TEST_FAILURE(".*ERROR: Incorrect conversion in format string.*",
+    TEST_FAILURE(".*ERROR: Invalid format string for format style variable: '%g%g' has 2 "
+                 "conversion.* but only 1 value.* provided.*",
                  command("variable xxx format one \"%g%g\""););
-    TEST_FAILURE(".*ERROR: Incorrect conversion in format string.*",
+    // literal text around the conversion and all C library flags are accepted
+    char fmtbuf[64];
+    snprintf(fmtbuf, sizeof(fmtbuf), "<%+12.6e>", -0.622);
+    BEGIN_HIDE_OUTPUT();
+    command("variable fmtdeco format one \"<%+12.6e>\"");
+    END_HIDE_OUTPUT();
+    EXPECT_THAT(variable->retrieve("fmtdeco"), StrEq(fmtbuf));
+    TEST_FAILURE(".*ERROR: Invalid format string for format style variable: incomplete "
+                 "conversion '%5' in '%g%5'.*",
                  command("variable xxx format one \"%g%5\""););
-    TEST_FAILURE(".*ERROR: Incorrect conversion in format string.*",
-                 command("variable xxx format one \"%g%%\""););
-    //    TEST_FAILURE(".*ERROR: Incorrect conversion in format string.*",
+    // a %% sequence is a literal percent sign and consumes no value
+    snprintf(fmtbuf, sizeof(fmtbuf), "%g%%", -0.622);
+    BEGIN_HIDE_OUTPUT();
+    command("variable fmtpercent format one \"%g%%\"");
+    END_HIDE_OUTPUT();
+    EXPECT_THAT(variable->retrieve("fmtpercent"), StrEq(fmtbuf));
+    //    TEST_FAILURE(".*ERROR: Invalid format string for format style variable.*",
     //                 command("print \"${f1idx}\""););
 }
 

--- a/unittest/utils/test_sprintf.cpp
+++ b/unittest/utils/test_sprintf.cpp
@@ -312,3 +312,208 @@ TEST(Sprintf, oversize_output)
     ASSERT_EQ((int) text.size(), 2002);
     ASSERT_THAT(text, Eq('<' + big + '>'));
 }
+
+// these test the validation of user provided format strings that are
+// passed to utils::sprintf() and other printf() style functions
+
+using utils::FmtArg;
+
+TEST(CheckFormat, accept_float)
+{
+    for (const auto *fmt : {"%g", "%e", "%f", "%G", "%20.15g", "%-15.8e", "%+8.3f", "%08.4f",
+                            "% .6g", "%#g", "%.0f", "%La", "%lf", "[%g]", "x = %g", "%g\n"})
+        ASSERT_THAT(utils::check_format(fmt, FmtArg::FLOAT), Eq("")) << "format: " << fmt;
+}
+
+TEST(CheckFormat, accept_integer)
+{
+    for (const auto *fmt : {"%d", "%i", "%8d", "%-8d", "%08d", "%+d", "%.5d", "%x", "%X", "%o",
+                            "%u", "%ld", "%lld", "%zd", "id=%d", "%d\n"})
+        ASSERT_THAT(utils::check_format(fmt, FmtArg::INTEGER), Eq("")) << "format: " << fmt;
+}
+
+TEST(CheckFormat, accept_bigint)
+{
+    // integer conversions are interchangeable, the width is fixed up later
+    for (const auto *fmt : {"%d", "%ld", "%lld", "%20d"})
+        ASSERT_THAT(utils::check_format(fmt, FmtArg::BIGINT), Eq("")) << "format: " << fmt;
+}
+
+TEST(CheckFormat, accept_string)
+{
+    for (const auto *fmt : {"%s", "%-8s", "%.4s", "<%s>"})
+        ASSERT_THAT(utils::check_format(fmt, FmtArg::STRING), Eq("")) << "format: " << fmt;
+}
+
+TEST(CheckFormat, percent_literal_is_not_a_conversion)
+{
+    ASSERT_THAT(utils::check_format("%g%%", FmtArg::FLOAT), Eq(""));
+    ASSERT_THAT(utils::check_format("100%% done", std::vector<FmtArg>{}), Eq(""));
+    ASSERT_THAT(utils::check_format("%%%d", FmtArg::INTEGER), Eq(""));
+}
+
+TEST(CheckFormat, literal_text_is_valid)
+{
+    // a format string need not use all values, and need not have any
+    // conversion at all: printf() ignores the surplus arguments
+    ASSERT_THAT(utils::check_format("plain text", std::vector<FmtArg>{}), Eq(""));
+    ASSERT_THAT(utils::check_format("", std::vector<FmtArg>{}), Eq(""));
+    ASSERT_THAT(utils::check_format("plain text", FmtArg::FLOAT), Eq(""));
+    ASSERT_THAT(utils::check_format("x", FmtArg::INTEGER), Eq(""));
+    ASSERT_THAT(utils::check_format("", FmtArg::BIGINT), Eq(""));
+    ASSERT_THAT(utils::check_format("%g", {FmtArg::FLOAT, FmtArg::FLOAT}), Eq(""));
+    ASSERT_THAT(utils::check_format("just text", {FmtArg::FLOAT, FmtArg::STRING}), Eq(""));
+}
+
+TEST(CheckFormat, accept_char_conversion)
+{
+    // %c consumes an int and is harmless for one
+    ASSERT_THAT(utils::check_format("%c", FmtArg::INTEGER), Eq(""));
+    ASSERT_THAT(utils::check_format("%-3c", FmtArg::INTEGER), Eq(""));
+    // but there is no valid length modifier to make it consume a bigint
+    ASSERT_THAT(utils::check_format("%c", FmtArg::BIGINT),
+                Eq("conversion 1 of '%c' cannot be used for large integer values"));
+    ASSERT_THAT(utils::adjust_format("%c", FmtArg::INTEGER), Eq("%c"));
+}
+
+TEST(CheckFormat, reject_type_mismatch)
+{
+    // this is the case that silently produced garbage before
+    ASSERT_THAT(utils::check_format("%d", FmtArg::FLOAT), StartsWith("conversion 1"));
+    ASSERT_THAT(utils::check_format("%s", FmtArg::FLOAT), StartsWith("conversion 1"));
+    ASSERT_THAT(utils::check_format("%x", FmtArg::FLOAT), StartsWith("conversion 1"));
+    ASSERT_THAT(utils::check_format("%g", FmtArg::INTEGER), StartsWith("conversion 1"));
+    ASSERT_THAT(utils::check_format("%f", FmtArg::BIGINT), StartsWith("conversion 1"));
+    ASSERT_THAT(utils::check_format("%s", FmtArg::INTEGER), StartsWith("conversion 1"));
+    ASSERT_THAT(utils::check_format("%d", FmtArg::STRING), StartsWith("conversion 1"));
+}
+
+TEST(CheckFormat, mismatch_message_is_informative)
+{
+    ASSERT_THAT(utils::check_format("%d", FmtArg::FLOAT),
+                Eq("conversion 1 of '%d' formats integer values, "
+                   "but floating-point values are provided"));
+}
+
+TEST(CheckFormat, reject_surplus_conversions)
+{
+    // these would consume arguments that are never passed
+    ASSERT_THAT(utils::check_format("%g %g", FmtArg::FLOAT),
+                Eq("'%g %g' has 2 conversion(s) but only 1 value(s) are provided"));
+    // this slipped past the regular expression check for immediate variables
+    ASSERT_THAT(utils::check_format("%.3f%d", FmtArg::FLOAT),
+                StartsWith("'%.3f%d' has 2 conversion(s)"));
+    ASSERT_THAT(utils::check_format("%g", std::vector<FmtArg>{}),
+                StartsWith("'%g' has 1 conversion(s)"));
+}
+
+TEST(CheckFormat, reject_malformed)
+{
+    ASSERT_THAT(utils::check_format("%", FmtArg::FLOAT), StartsWith("incomplete conversion"));
+    ASSERT_THAT(utils::check_format("%g %", {FmtArg::FLOAT}), StartsWith("incomplete conversion"));
+    ASSERT_THAT(utils::check_format("%12.4", FmtArg::FLOAT), StartsWith("incomplete conversion"));
+    ASSERT_THAT(utils::check_format("%y", FmtArg::FLOAT), StartsWith("unsupported conversion"));
+    // %n writes through a pointer argument and must never be accepted
+    ASSERT_THAT(utils::check_format("%n", FmtArg::FLOAT), StartsWith("unsupported conversion"));
+    // '*' consumes an extra argument
+    ASSERT_THAT(utils::check_format("%*g", FmtArg::FLOAT), StartsWith("variable field width"));
+    ASSERT_THAT(utils::check_format("%.*g", FmtArg::FLOAT), StartsWith("variable precision"));
+    // a length modifier on a string conversion changes the argument type
+    ASSERT_THAT(utils::check_format("%ls", FmtArg::STRING), StartsWith("unsupported length"));
+}
+
+TEST(CheckFormat, multiple_conversions)
+{
+    // whole line format for dump atom without image flags
+    const std::vector<FmtArg> line = {FmtArg::BIGINT, FmtArg::INTEGER, FmtArg::FLOAT,
+                                      FmtArg::FLOAT, FmtArg::FLOAT};
+    ASSERT_THAT(utils::check_format("%d %d %g %g %g", line), Eq(""));
+    ASSERT_THAT(utils::check_format("%ld %d %20.15g %20.15g %20.15g", line), Eq(""));
+    // printing only the leading values is allowed
+    ASSERT_THAT(utils::check_format("%d %d %g %g", line), Eq(""));
+    ASSERT_THAT(utils::check_format("%d %d %g %g %g %g", line),
+                StartsWith("'%d %d %g %g %g %g' has 6 conversion(s)"));
+    ASSERT_THAT(utils::check_format("%d %g %g %g %d", line), StartsWith("conversion 2"));
+    // dump xyz passes the element name as a string
+    ASSERT_THAT(utils::check_format("%s %g %g %g",
+                                    {FmtArg::STRING, FmtArg::FLOAT, FmtArg::FLOAT, FmtArg::FLOAT}),
+                Eq(""));
+}
+
+TEST(CheckFormat, conversions_are_classified_in_order)
+{
+    // each conversion must be matched against the value in its own position
+    ASSERT_THAT(utils::check_format("%d %g %s", {FmtArg::INTEGER, FmtArg::FLOAT, FmtArg::STRING}),
+                Eq(""));
+    ASSERT_THAT(utils::check_format("%d %g %s", {FmtArg::INTEGER, FmtArg::STRING, FmtArg::FLOAT}),
+                StartsWith("conversion 2"));
+    ASSERT_THAT(utils::check_format("%s %g %d", {FmtArg::INTEGER, FmtArg::FLOAT, FmtArg::STRING}),
+                StartsWith("conversion 1"));
+    // the c conversion belongs to the integer group
+    ASSERT_THAT(utils::check_format("id %d = %c", {FmtArg::INTEGER, FmtArg::INTEGER}), Eq(""));
+    // a %% sequence is literal text and consumes no value
+    ASSERT_THAT(utils::check_format("100%% done", std::vector<FmtArg>{}), Eq(""));
+    ASSERT_THAT(utils::check_format("%d%% of %d", {FmtArg::INTEGER, FmtArg::INTEGER}), Eq(""));
+}
+
+TEST(AdjustFormat, bigint_length_modifier)
+{
+    // the resulting format must print a bigint value correctly
+    constexpr bigint big = 123456789012345;
+    for (const auto *fmt : {"%d", "%8d", "id=%d", "%-10d", "%ld", "%.5d", "%d\n"}) {
+        auto adjusted = utils::adjust_format(fmt, FmtArg::BIGINT);
+        auto text     = utils::sprintf(adjusted, big);
+        ASSERT_THAT(text, ::testing::HasSubstr("123456789012345"))
+            << "format: " << fmt << " adjusted: " << adjusted;
+    }
+}
+
+TEST(AdjustFormat, uses_platform_length_modifier)
+{
+    // int64_t is "long int" on LP64 and "long long int" on LLP64, so the
+    // length modifier must come from PRId64 rather than being hardcoded
+    ASSERT_THAT(utils::adjust_format("%d", FmtArg::BIGINT), Eq(std::string("%") + PRId64));
+    ASSERT_THAT(utils::adjust_format("%d", FmtArg::BIGINT), Eq(BIGINT_FORMAT));
+    // and the result must actually round-trip a value that needs all 64 bits
+    ASSERT_THAT(utils::sprintf(utils::adjust_format("%d", FmtArg::BIGINT), MAXBIGINT),
+                Eq(std::to_string(MAXBIGINT)));
+}
+
+TEST(AdjustFormat, preserves_surrounding_text)
+{
+    // find('d') used to mangle these into "illd=%d" and "%llld"
+    ASSERT_THAT(utils::adjust_format("id=%d", FmtArg::BIGINT),
+                Eq(std::string("id=") + BIGINT_FORMAT));
+    ASSERT_THAT(utils::adjust_format("%ld", FmtArg::BIGINT), Eq(BIGINT_FORMAT));
+    ASSERT_THAT(utils::adjust_format("%d %d", {FmtArg::BIGINT, FmtArg::BIGINT}),
+                Eq(std::string(BIGINT_FORMAT) + " " + BIGINT_FORMAT));
+}
+
+TEST(AdjustFormat, int_strips_length_modifier)
+{
+    ASSERT_THAT(utils::adjust_format("%ld", FmtArg::INTEGER), Eq("%d"));
+    ASSERT_THAT(utils::adjust_format("%8lld", FmtArg::INTEGER), Eq("%8d"));
+    ASSERT_THAT(utils::sprintf(utils::adjust_format("%5d", FmtArg::INTEGER), 42), Eq("   42"));
+}
+
+TEST(AdjustFormat, leaves_other_types_alone)
+{
+    ASSERT_THAT(utils::adjust_format("%20.15g", FmtArg::FLOAT), Eq("%20.15g"));
+    ASSERT_THAT(utils::adjust_format("%-8s", FmtArg::STRING), Eq("%-8s"));
+    // a format that does not match is returned unchanged
+    ASSERT_THAT(utils::adjust_format("%g", FmtArg::BIGINT), Eq("%g"));
+    ASSERT_THAT(utils::adjust_format("bogus %", FmtArg::BIGINT), Eq("bogus %"));
+}
+
+TEST(AdjustFormat, mixed_line_format)
+{
+    // dump atom with image flags: tagint, int, 3 doubles, 3 ints
+    const std::vector<FmtArg> line = {FmtArg::BIGINT, FmtArg::INTEGER, FmtArg::FLOAT,
+                                      FmtArg::FLOAT,  FmtArg::FLOAT,   FmtArg::INTEGER,
+                                      FmtArg::INTEGER, FmtArg::INTEGER};
+    auto adjusted = utils::adjust_format("%d %d %g %g %g %d %d %d", line);
+    ASSERT_THAT(adjusted, Eq(std::string(BIGINT_FORMAT) + " %d %g %g %g %d %d %d"));
+    // a format that uses only the leading values is adjusted the same way
+    adjusted = utils::adjust_format("id=%d type=%d", line);
+    ASSERT_THAT(adjusted, Eq(std::string("id=") + BIGINT_FORMAT + " type=%d"));
+}


### PR DESCRIPTION
**Summary**

This pull request implements utility functions to enforce proper custom format strings that match the data they are supposed to output. This includes automatic prefixing of integer format specifiers (%d) according to compile time settings. This fixes bugs where the existing checks were incomplete or would allow incorrect use (e.g. by including additional conversions) leading to illegal data accesses resulting in either crashes or garbage output. It thus improves the security of LAMMPS since it reduces the potential for buffer overflows.

**Related Issue(s)**

This fixes a bug discovered while reviewing PR #5022, but extends beyond it and should prevent similar bugs in the future.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

The implementation of the format checking functions and the unit tests were drafted by Claude code (Fable 5) and reviewed and revised by a human.

**Backward Compatibility**

Mostly. Correct use of the custom format should produce identical output; incorrect use should now produce either correct output or abort with an error.

**Implementation Notes**

An alternative approach of using `fmt::printf()` was rejected for portability reasons since `std::format()` has no equivalent (yet).

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree.
