### PR TITLE
docs: fix typo envrionment -> environment

### DIFF
--- a/doc/src/Howto_python.rst
+++ b/doc/src/Howto_python.rst
@@ -138,7 +138,7 @@ Creating a virtualenv with lammps installed
 
 .. code-block:: bash
 
-   # create virtual envrionment named 'testing'
+   # create virtual environment named 'testing'
    python3 -m venv $HOME/python/testing
 
    # activate 'testing' environment


### PR DESCRIPTION
Corrects the misspelling `envrionment` -> `environment` in `doc/src/Howto_python.rst`.

Documentation only, no behaviour change.