### PR TITLE
KSPACE: skip force work for energy-only calculations

### DIFF
--- a/src/KSPACE/ewald.cpp
+++ b/src/KSPACE/ewald.cpp
@@ -428,45 +428,54 @@ void Ewald::compute(int eflag, int vflag)
   int kx,ky,kz;
   double cypz,sypz,exprl,expim,partial,partial_peratom;
 
-  for (i = 0; i < nlocal; i++) {
-    ek[i][0] = 0.0;
-    ek[i][1] = 0.0;
-    ek[i][2] = 0.0;
-  }
-
-  for (k = 0; k < kcount; k++) {
-    kx = kxvecs[k];
-    ky = kyvecs[k];
-    kz = kzvecs[k];
-
-    for (i = 0; i < nlocal; i++) {
-      cypz = cs[ky][1][i]*cs[kz][2][i] - sn[ky][1][i]*sn[kz][2][i];
-      sypz = sn[ky][1][i]*cs[kz][2][i] + cs[ky][1][i]*sn[kz][2][i];
-      exprl = cs[kx][0][i]*cypz - sn[kx][0][i]*sypz;
-      expim = sn[kx][0][i]*cypz + cs[kx][0][i]*sypz;
-      partial = expim*sfacrl_all[k] - exprl*sfacim_all[k];
-      ek[i][0] += partial*eg[k][0];
-      ek[i][1] += partial*eg[k][1];
-      ek[i][2] += partial*eg[k][2];
-
-      if (evflag_atom) {
-        partial_peratom = exprl*sfacrl_all[k] + expim*sfacim_all[k];
-        if (eflag_atom) eatom[i] += q[i]*ug[k]*partial_peratom;
-        if (vflag_atom)
-          for (j = 0; j < 6; j++)
-            vatom[i][j] += ug[k]*vg[k][j]*partial_peratom;
-      }
-    }
-  }
-
-  // convert E-field to force
-
   const double qscale = qqrd2e * scale;
 
-  for (i = 0; i < nlocal; i++) {
-    f[i][0] += qscale * q[i]*ek[i][0];
-    f[i][1] += qscale * q[i]*ek[i][1];
-    if (slabflag != 2) f[i][2] += qscale * q[i]*ek[i][2];
+  // The global energy and virial below are obtained directly from the
+  // structure factors.  Skip the O(N*kcount) E-field and force evaluation
+  // when the caller requested only global energy.  Per-atom requests retain
+  // the full path.
+
+  if (!eflag_only || evflag_atom) {
+    for (i = 0; i < nlocal; i++) {
+      ek[i][0] = 0.0;
+      ek[i][1] = 0.0;
+      ek[i][2] = 0.0;
+    }
+
+    for (k = 0; k < kcount; k++) {
+      kx = kxvecs[k];
+      ky = kyvecs[k];
+      kz = kzvecs[k];
+
+      for (i = 0; i < nlocal; i++) {
+        cypz = cs[ky][1][i]*cs[kz][2][i] - sn[ky][1][i]*sn[kz][2][i];
+        sypz = sn[ky][1][i]*cs[kz][2][i] + cs[ky][1][i]*sn[kz][2][i];
+        exprl = cs[kx][0][i]*cypz - sn[kx][0][i]*sypz;
+        expim = sn[kx][0][i]*cypz + cs[kx][0][i]*sypz;
+        partial = expim*sfacrl_all[k] - exprl*sfacim_all[k];
+        ek[i][0] += partial*eg[k][0];
+        ek[i][1] += partial*eg[k][1];
+        ek[i][2] += partial*eg[k][2];
+
+        if (evflag_atom) {
+          partial_peratom = exprl*sfacrl_all[k] + expim*sfacim_all[k];
+          if (eflag_atom) eatom[i] += q[i]*ug[k]*partial_peratom;
+          if (vflag_atom)
+            for (j = 0; j < 6; j++)
+              vatom[i][j] += ug[k]*vg[k][j]*partial_peratom;
+        }
+      }
+    }
+
+    // convert E-field to force
+
+    if (!eflag_only) {
+      for (i = 0; i < nlocal; i++) {
+        f[i][0] += qscale * q[i]*ek[i][0];
+        f[i][1] += qscale * q[i]*ek[i][1];
+        if (slabflag != 2) f[i][2] += qscale * q[i]*ek[i][2];
+      }
+    }
   }
 
   // sum global energy across Kspace vevs and add in volume-dependent term
@@ -1243,10 +1252,12 @@ void Ewald::slabcorr()
 
   // add on force corrections
 
-  double ffact = qscale * (-4.0*MY_PI/volume);
-  double **f = atom->f;
+  if (!eflag_only || evflag_atom) {
+    double ffact = qscale * (-4.0*MY_PI/volume);
+    double **f = atom->f;
 
-  for (int i = 0; i < nlocal; i++) f[i][2] += ffact * q[i]*(dipole_all - qsum*x[i][2]);
+    for (int i = 0; i < nlocal; i++) f[i][2] += ffact * q[i]*(dipole_all - qsum*x[i][2]);
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KSPACE/ewald_disp.cpp
+++ b/src/KSPACE/ewald_disp.cpp
@@ -772,7 +772,12 @@ void EwaldDisp::compute(int eflag, int vflag)
   // is no surface dipole correction term
 
   eik_dot_r();
-  compute_force();
+
+  // The global energy and virial are computed from the structure factors.
+  // Avoid the force and torque evaluation for global energy-only requests;
+  // per-atom tallies still require the full path.
+
+  if (!eflag_only || evflag_atom) compute_force();
 
   // update qsum and qsqsum, if atom count has changed and energy needed
 

--- a/src/KSPACE/pppm.cpp
+++ b/src/KSPACE/pppm.cpp
@@ -730,34 +730,41 @@ void PPPM::compute(int eflag, int vflag)
 
   poisson();
 
-  // all procs communicate E-field values
-  // to fill ghost cells surrounding their 3d bricks
+  // poisson() has already tallied the global energy and virial.  Skip the
+  // E-field communication and force interpolation when only global energy
+  // was requested.  Per-atom requests retain the full path.
 
-  if (differentiation_flag == 1)
-    gc->forward_comm(Grid3d::KSPACE,this,FORWARD_AD,1,sizeof(FFT_SCALAR),
-                     gc_buf1,gc_buf2,MPI_FFT_SCALAR);
-  else
-    gc->forward_comm(Grid3d::KSPACE,this,FORWARD_IK,3,sizeof(FFT_SCALAR),
-                     gc_buf1,gc_buf2,MPI_FFT_SCALAR);
+  if (!eflag_only || evflag_atom) {
 
-  // extra per-atom energy/virial communication
+    // all procs communicate E-field values
+    // to fill ghost cells surrounding their 3d bricks
 
-  if (evflag_atom) {
-    if (differentiation_flag == 1 && vflag_atom)
-      gc->forward_comm(Grid3d::KSPACE,this,FORWARD_AD_PERATOM,6,sizeof(FFT_SCALAR),
+    if (differentiation_flag == 1)
+      gc->forward_comm(Grid3d::KSPACE,this,FORWARD_AD,1,sizeof(FFT_SCALAR),
                        gc_buf1,gc_buf2,MPI_FFT_SCALAR);
-    else if (differentiation_flag == 0)
-      gc->forward_comm(Grid3d::KSPACE,this,FORWARD_IK_PERATOM,7,sizeof(FFT_SCALAR),
+    else
+      gc->forward_comm(Grid3d::KSPACE,this,FORWARD_IK,3,sizeof(FFT_SCALAR),
                        gc_buf1,gc_buf2,MPI_FFT_SCALAR);
+
+    // extra per-atom energy/virial communication
+
+    if (evflag_atom) {
+      if (differentiation_flag == 1 && vflag_atom)
+        gc->forward_comm(Grid3d::KSPACE,this,FORWARD_AD_PERATOM,6,sizeof(FFT_SCALAR),
+                         gc_buf1,gc_buf2,MPI_FFT_SCALAR);
+      else if (differentiation_flag == 0)
+        gc->forward_comm(Grid3d::KSPACE,this,FORWARD_IK_PERATOM,7,sizeof(FFT_SCALAR),
+                         gc_buf1,gc_buf2,MPI_FFT_SCALAR);
+    }
+
+    // calculate the force on my particles
+
+    fieldforce();
+
+    // extra per-atom energy/virial communication
+
+    if (evflag_atom) fieldforce_peratom();
   }
-
-  // calculate the force on my particles
-
-  fieldforce();
-
-  // extra per-atom energy/virial communication
-
-  if (evflag_atom) fieldforce_peratom();
 
   // sum global energy across procs and add in volume-dependent term
 
@@ -2049,6 +2056,12 @@ void PPPM::poisson_ik()
     }
   }
 
+  // The requested global tallies are complete.  Energy-only calls need no
+  // E-field, forces, or per-atom data, so the inverse transforms can be
+  // skipped.
+
+  if (eflag_only && !evflag_atom) return;
+
   // scale by 1/total-grid-pts to get rho(k)
   // multiply by Green's function to get V(k)
 
@@ -2250,6 +2263,12 @@ void PPPM::poisson_ad()
       }
     }
   }
+
+  // The requested global tallies are complete.  Energy-only calls need no
+  // potential gradient, forces, or per-atom data, so the inverse transform
+  // can be skipped.
+
+  if (eflag_only && !evflag_atom) return;
 
   // scale by 1/total-grid-pts to get rho(k)
   // multiply by Green's function to get V(k)
@@ -2995,10 +3014,12 @@ void PPPM::slabcorr()
 
   // add on force corrections
 
-  double ffact = qscale * (-4.0*MY_PI/volume);
-  double **f = atom->f;
+  if (!eflag_only || evflag_atom) {
+    double ffact = qscale * (-4.0*MY_PI/volume);
+    double **f = atom->f;
 
-  for (int i = 0; i < nlocal; i++) f[i][2] += ffact * q[i]*(dipole_all - qsum*x[i][2]);
+    for (int i = 0; i < nlocal; i++) f[i][2] += ffact * q[i]*(dipole_all - qsum*x[i][2]);
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KSPACE/pppm_cg.cpp
+++ b/src/KSPACE/pppm_cg.cpp
@@ -180,34 +180,41 @@ void PPPMCG::compute(int eflag, int vflag)
 
   poisson();
 
-  // all procs communicate E-field values
-  // to fill ghost cells surrounding their 3d bricks
+  // poisson() has already tallied the global energy and virial.  Skip the
+  // E-field communication and force interpolation when only global energy
+  // was requested.  Per-atom requests retain the full path.
 
-  if (differentiation_flag == 1)
-    gc->forward_comm(Grid3d::KSPACE,this,FORWARD_AD,1,sizeof(FFT_SCALAR),
-                     gc_buf1,gc_buf2,MPI_FFT_SCALAR);
-  else
-    gc->forward_comm(Grid3d::KSPACE,this,FORWARD_IK,3,sizeof(FFT_SCALAR),
-                     gc_buf1,gc_buf2,MPI_FFT_SCALAR);
+  if (!eflag_only || evflag_atom) {
 
-  // extra per-atom energy/virial communication
+    // all procs communicate E-field values
+    // to fill ghost cells surrounding their 3d bricks
 
-  if (evflag_atom) {
-    if (differentiation_flag == 1 && vflag_atom)
-      gc->forward_comm(Grid3d::KSPACE,this,FORWARD_AD_PERATOM,6,sizeof(FFT_SCALAR),
+    if (differentiation_flag == 1)
+      gc->forward_comm(Grid3d::KSPACE,this,FORWARD_AD,1,sizeof(FFT_SCALAR),
                        gc_buf1,gc_buf2,MPI_FFT_SCALAR);
-    else if (differentiation_flag == 0)
-      gc->forward_comm(Grid3d::KSPACE,this,FORWARD_IK_PERATOM,7,sizeof(FFT_SCALAR),
+    else
+      gc->forward_comm(Grid3d::KSPACE,this,FORWARD_IK,3,sizeof(FFT_SCALAR),
                        gc_buf1,gc_buf2,MPI_FFT_SCALAR);
+
+    // extra per-atom energy/virial communication
+
+    if (evflag_atom) {
+      if (differentiation_flag == 1 && vflag_atom)
+        gc->forward_comm(Grid3d::KSPACE,this,FORWARD_AD_PERATOM,6,sizeof(FFT_SCALAR),
+                         gc_buf1,gc_buf2,MPI_FFT_SCALAR);
+      else if (differentiation_flag == 0)
+        gc->forward_comm(Grid3d::KSPACE,this,FORWARD_IK_PERATOM,7,sizeof(FFT_SCALAR),
+                         gc_buf1,gc_buf2,MPI_FFT_SCALAR);
+    }
+
+    // calculate the force on my particles
+
+    fieldforce();
+
+    // extra per-atom energy/virial communication
+
+    if (evflag_atom) fieldforce_peratom();
   }
-
-  // calculate the force on my particles
-
-  fieldforce();
-
-  // extra per-atom energy/virial communication
-
-  if (evflag_atom) fieldforce_peratom();
 
   // sum global energy across procs and add in volume-dependent term
 
@@ -640,12 +647,14 @@ void PPPMCG::slabcorr()
 
   // add on force corrections
 
-  const double ffact = qscale * (-MY_4PI/volume);
-  double * const * const f = atom->f;
+  if (!eflag_only || evflag_atom) {
+    const double ffact = qscale * (-MY_4PI/volume);
+    double * const * const f = atom->f;
 
-  for (j = 0; j < num_charged; j++) {
-    i = is_charged[j];
-    f[i][2] += ffact * q[i]*(dipole_all - qsum*x[i][2]);
+    for (j = 0; j < num_charged; j++) {
+      i = is_charged[j];
+      f[i][2] += ffact * q[i]*(dipole_all - qsum*x[i][2]);
+    }
   }
 }
 

--- a/src/KSPACE/pppm_disp.cpp
+++ b/src/KSPACE/pppm_disp.cpp
@@ -1199,14 +1199,19 @@ void PPPMDisp::compute(int eflag, int vflag)
                  virial_1,vg,vg2,
                  u_brick,v0_brick,v1_brick,v2_brick,v3_brick,v4_brick,v5_brick);
 
-      gc->forward_comm(Grid3d::KSPACE,this,FORWARD_AD,1,sizeof(FFT_SCALAR),
-                       gc_buf1,gc_buf2,MPI_FFT_SCALAR);
+      // poisson_ad() has tallied the requested global values.  Skip force
+      // communication and interpolation for global energy-only requests.
 
-      fieldforce_c_ad();
-
-      if (vflag_atom)
-        gc->forward_comm(Grid3d::KSPACE,this,FORWARD_AD_PERATOM,6,sizeof(FFT_SCALAR),
+      if (!eflag_only || evflag_atom) {
+        gc->forward_comm(Grid3d::KSPACE,this,FORWARD_AD,1,sizeof(FFT_SCALAR),
                          gc_buf1,gc_buf2,MPI_FFT_SCALAR);
+
+        fieldforce_c_ad();
+
+        if (vflag_atom)
+          gc->forward_comm(Grid3d::KSPACE,this,FORWARD_AD_PERATOM,6,sizeof(FFT_SCALAR),
+                           gc_buf1,gc_buf2,MPI_FFT_SCALAR);
+      }
 
     } else {
       poisson_ik(work1,work2,density_fft,fft1,fft2,
@@ -1218,14 +1223,16 @@ void PPPMDisp::compute(int eflag, int vflag)
                  vdx_brick,vdy_brick,vdz_brick,virial_1,vg,vg2,
                  u_brick,v0_brick,v1_brick,v2_brick,v3_brick,v4_brick,v5_brick);
 
-      gc->forward_comm(Grid3d::KSPACE,this,FORWARD_IK,3,sizeof(FFT_SCALAR),
-                       gc_buf1,gc_buf2,MPI_FFT_SCALAR);
-
-      fieldforce_c_ik();
-
-      if (evflag_atom)
-        gc->forward_comm(Grid3d::KSPACE,this,FORWARD_IK_PERATOM,7,sizeof(FFT_SCALAR),
+      if (!eflag_only || evflag_atom) {
+        gc->forward_comm(Grid3d::KSPACE,this,FORWARD_IK,3,sizeof(FFT_SCALAR),
                          gc_buf1,gc_buf2,MPI_FFT_SCALAR);
+
+        fieldforce_c_ik();
+
+        if (evflag_atom)
+          gc->forward_comm(Grid3d::KSPACE,this,FORWARD_IK_PERATOM,7,sizeof(FFT_SCALAR),
+                           gc_buf1,gc_buf2,MPI_FFT_SCALAR);
+      }
     }
 
     if (evflag_atom) fieldforce_c_peratom();
@@ -1258,14 +1265,16 @@ void PPPMDisp::compute(int eflag, int vflag)
                  u_brick_g,v0_brick_g,v1_brick_g,v2_brick_g,
                  v3_brick_g,v4_brick_g,v5_brick_g);
 
-      gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_AD_GEOM,1,sizeof(FFT_SCALAR),
-                        gc6_buf1,gc6_buf2,MPI_FFT_SCALAR);
-
-      fieldforce_g_ad();
-
-      if (vflag_atom)
-        gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_AD_PERATOM_GEOM,6,sizeof(FFT_SCALAR),
+      if (!eflag_only || evflag_atom) {
+        gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_AD_GEOM,1,sizeof(FFT_SCALAR),
                           gc6_buf1,gc6_buf2,MPI_FFT_SCALAR);
+
+        fieldforce_g_ad();
+
+        if (vflag_atom)
+          gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_AD_PERATOM_GEOM,6,sizeof(FFT_SCALAR),
+                            gc6_buf1,gc6_buf2,MPI_FFT_SCALAR);
+      }
 
     } else {
       poisson_ik(work1_6,work2_6,density_fft_g,fft1_6,fft2_6,
@@ -1278,14 +1287,16 @@ void PPPMDisp::compute(int eflag, int vflag)
                  u_brick_g,v0_brick_g,v1_brick_g,v2_brick_g,
                  v3_brick_g,v4_brick_g,v5_brick_g);
 
-      gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_IK_GEOM,3,sizeof(FFT_SCALAR),
-                        gc6_buf1,gc6_buf2,MPI_FFT_SCALAR);
-
-      fieldforce_g_ik();
-
-      if (evflag_atom)
-        gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_IK_PERATOM_GEOM,7,sizeof(FFT_SCALAR),
+      if (!eflag_only || evflag_atom) {
+        gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_IK_GEOM,3,sizeof(FFT_SCALAR),
                           gc6_buf1,gc6_buf2,MPI_FFT_SCALAR);
+
+        fieldforce_g_ik();
+
+        if (evflag_atom)
+          gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_IK_PERATOM_GEOM,7,sizeof(FFT_SCALAR),
+                            gc6_buf1,gc6_buf2,MPI_FFT_SCALAR);
+      }
     }
 
     if (evflag_atom) fieldforce_g_peratom();
@@ -1332,14 +1343,16 @@ void PPPMDisp::compute(int eflag, int vflag)
                     u_brick_a4,v0_brick_a4,v1_brick_a4,v2_brick_a4,
                     v3_brick_a4,v4_brick_a4,v5_brick_a4);
 
-      gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_AD_ARITH,7,sizeof(FFT_SCALAR),
-                        gc6_buf1,gc6_buf2,MPI_FFT_SCALAR);
-
-      fieldforce_a_ad();
-
-      if (evflag_atom)
-        gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_AD_PERATOM_ARITH,42,sizeof(FFT_SCALAR),
+      if (!eflag_only || evflag_atom) {
+        gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_AD_ARITH,7,sizeof(FFT_SCALAR),
                           gc6_buf1,gc6_buf2,MPI_FFT_SCALAR);
+
+        fieldforce_a_ad();
+
+        if (evflag_atom)
+          gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_AD_PERATOM_ARITH,42,sizeof(FFT_SCALAR),
+                            gc6_buf1,gc6_buf2,MPI_FFT_SCALAR);
+      }
 
     }  else {
       poisson_ik(work1_6,work2_6,density_fft_a3,fft1_6,fft2_6,
@@ -1373,14 +1386,16 @@ void PPPMDisp::compute(int eflag, int vflag)
                     u_brick_a4,v0_brick_a4,v1_brick_a4,v2_brick_a4,
                     v3_brick_a4,v4_brick_a4,v5_brick_a4);
 
-      gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_IK_ARITH,21,sizeof(FFT_SCALAR),
-                        gc6_buf1,gc6_buf2,MPI_FFT_SCALAR);
-
-      fieldforce_a_ik();
-
-      if (evflag_atom)
-        gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_IK_PERATOM_ARITH,49,sizeof(FFT_SCALAR),
+      if (!eflag_only || evflag_atom) {
+        gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_IK_ARITH,21,sizeof(FFT_SCALAR),
                           gc6_buf1,gc6_buf2,MPI_FFT_SCALAR);
+
+        fieldforce_a_ik();
+
+        if (evflag_atom)
+          gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_IK_PERATOM_ARITH,49,sizeof(FFT_SCALAR),
+                            gc6_buf1,gc6_buf2,MPI_FFT_SCALAR);
+      }
     }
 
     if (evflag_atom) fieldforce_a_peratom();
@@ -1412,14 +1427,16 @@ void PPPMDisp::compute(int eflag, int vflag)
         n += 2;
       }
 
-      gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_AD_NONE,1*nsplit_alloc,sizeof(FFT_SCALAR),
-                        gc6_buf1,gc6_buf2,MPI_FFT_SCALAR);
-
-      fieldforce_none_ad();
-
-      if (vflag_atom)
-        gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_AD_PERATOM_NONE,6*nsplit_alloc,sizeof(FFT_SCALAR),
+      if (!eflag_only || evflag_atom) {
+        gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_AD_NONE,1*nsplit_alloc,sizeof(FFT_SCALAR),
                           gc6_buf1,gc6_buf2,MPI_FFT_SCALAR);
+
+        fieldforce_none_ad();
+
+        if (vflag_atom)
+          gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_AD_PERATOM_NONE,6*nsplit_alloc,sizeof(FFT_SCALAR),
+                            gc6_buf1,gc6_buf2,MPI_FFT_SCALAR);
+      }
 
     } else {
       int n = 0;
@@ -1432,14 +1449,16 @@ void PPPMDisp::compute(int eflag, int vflag)
         n += 2;
       }
 
-      gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_IK_NONE,3*nsplit_alloc,sizeof(FFT_SCALAR),
-                        gc6_buf1,gc6_buf2,MPI_FFT_SCALAR);
-
-      fieldforce_none_ik();
-
-      if (evflag_atom)
-        gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_IK_PERATOM_NONE,7*nsplit_alloc,sizeof(FFT_SCALAR),
+      if (!eflag_only || evflag_atom) {
+        gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_IK_NONE,3*nsplit_alloc,sizeof(FFT_SCALAR),
                           gc6_buf1,gc6_buf2,MPI_FFT_SCALAR);
+
+        fieldforce_none_ik();
+
+        if (evflag_atom)
+          gc6->forward_comm(Grid3d::KSPACE,this,FORWARD_IK_PERATOM_NONE,7*nsplit_alloc,sizeof(FFT_SCALAR),
+                            gc6_buf1,gc6_buf2,MPI_FFT_SCALAR);
+      }
     }
 
     if (evflag_atom) fieldforce_none_peratom();
@@ -4881,6 +4900,11 @@ void PPPMDisp::poisson_ik(FFT_SCALAR* wk1, FFT_SCALAR* wk2,
     }
   }
 
+  // Global tallies are complete.  Energy-only calls need no E-field, force,
+  // or per-atom data, so the inverse transforms can be skipped.
+
+  if (eflag_only && !evflag_atom) return;
+
   // scale by 1/total-grid-pts to get rho(k)
   // multiply by Green's function to get V(k)
 
@@ -5105,6 +5129,11 @@ void PPPMDisp::poisson_ad(FFT_SCALAR* wk1, FFT_SCALAR* wk2,
     }
   }
 
+  // Global tallies are complete.  Energy-only calls need no potential,
+  // force, or per-atom data, so the inverse transform can be skipped.
+
+  if (eflag_only && !evflag_atom) return;
+
   // scale by 1/total-grid-pts to get rho(k)
   // multiply by Green's function to get V(k)
 
@@ -5259,6 +5288,11 @@ poisson_2s_ik(FFT_SCALAR* dfft_1, FFT_SCALAR* dfft_2,
       }
     }
 
+    // Global tallies are complete.  Energy-only calls need no gradients,
+    // potential, or per-atom data, so the inverse transforms can be skipped.
+
+    if (eflag_only && !evflag_atom) return;
+
     // gradients + per-atom potential for each density; density 1's V(k) is
     // already in work1_6, density 2 is re-transformed (work2_6 is scratch)
     for (int pass = 0; pass < 2; pass++) {
@@ -5381,6 +5415,8 @@ poisson_2s_ik(FFT_SCALAR* dfft_1, FFT_SCALAR* dfft_2,
       work1_6[i] += work2_6[i];
     }
   }
+
+  if (eflag_only && !evflag_atom) return;
 
   n = 0;
   for (i = 0; i < nfft_6; i++) {
@@ -5529,6 +5565,8 @@ poisson_none_ik(int n1, int n2,FFT_SCALAR* dfft_1, FFT_SCALAR* dfft_2,
       }
     }
 
+    if (eflag_only && !evflag_atom) return;
+
     for (int pass = 0; pass < 2; pass++) {
       FFT_SCALAR *dfft = (pass == 0) ? dfft_1 : dfft_2;
       int np = (pass == 0) ? n1 : n2;
@@ -5649,6 +5687,8 @@ poisson_none_ik(int n1, int n2,FFT_SCALAR* dfft_1, FFT_SCALAR* dfft_2,
     for ( i = 0; i < 2*nfft_6; i++)
       work1_6[i] += work2_6[i];
   }
+
+  if (eflag_only && !evflag_atom) return;
 
   n = 0;
   for (i = 0; i < nfft_6; i++) {
@@ -5823,6 +5863,8 @@ poisson_2s_ad(FFT_SCALAR* dfft_1, FFT_SCALAR* dfft_2,
   }
 
 
+  if (eflag_only && !evflag_atom) return;
+
   n = 0;
   for (i = 0; i < nfft_6; i++) {
     work1_6[n++] *= scaleinv * greensfn_6[i];
@@ -5924,6 +5966,8 @@ poisson_none_ad(int n1, int n2, FFT_SCALAR* dfft_1, FFT_SCALAR* dfft_2,
     for (i = 0; i < 2*nfft_6; i++)
       work1_6[i] += work2_6[i];
   }
+
+  if (eflag_only && !evflag_atom) return;
 
   n = 0;
   for (i = 0; i < nfft_6; i++) {
@@ -8696,10 +8740,12 @@ void PPPMDisp::slabcorr(int /*eflag*/)
 
   // add on force corrections
 
-  double ffact = qscale * (-4.0*MY_PI/volume);
-  double **f = atom->f;
+  if (!eflag_only || evflag_atom) {
+    double ffact = qscale * (-4.0*MY_PI/volume);
+    double **f = atom->f;
 
-  for (int i = 0; i < nlocal; i++) f[i][2] += ffact * q[i]*(dipole_all - qsum*x[i][2]);
+    for (int i = 0; i < nlocal; i++) f[i][2] += ffact * q[i]*(dipole_all - qsum*x[i][2]);
+  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KSPACE/pppm_stagger.cpp
+++ b/src/KSPACE/pppm_stagger.cpp
@@ -158,34 +158,41 @@ void PPPMStagger::compute(int eflag, int vflag)
 
     poisson();
 
-    // all procs communicate E-field values
-    // to fill ghost cells surrounding their 3d bricks
+    // poisson() has already tallied this stagger's global energy and virial.
+    // Skip E-field communication and force interpolation for global
+    // energy-only requests.  Per-atom requests retain the full path.
 
-    if (differentiation_flag == 1)
-      gc->forward_comm(Grid3d::KSPACE,this,FORWARD_AD,1,sizeof(FFT_SCALAR),
-                       gc_buf1,gc_buf2,MPI_FFT_SCALAR);
-    else
-      gc->forward_comm(Grid3d::KSPACE,this,FORWARD_IK,3,sizeof(FFT_SCALAR),
-                       gc_buf1,gc_buf2,MPI_FFT_SCALAR);
+    if (!eflag_only || evflag_atom) {
 
-    // extra per-atom energy/virial communication
+      // all procs communicate E-field values
+      // to fill ghost cells surrounding their 3d bricks
 
-    if (evflag_atom) {
-      if (differentiation_flag == 1 && vflag_atom)
-        gc->forward_comm(Grid3d::KSPACE,this,FORWARD_AD_PERATOM,6,sizeof(FFT_SCALAR),
+      if (differentiation_flag == 1)
+        gc->forward_comm(Grid3d::KSPACE,this,FORWARD_AD,1,sizeof(FFT_SCALAR),
                          gc_buf1,gc_buf2,MPI_FFT_SCALAR);
-      else if (differentiation_flag == 0)
-        gc->forward_comm(Grid3d::KSPACE,this,FORWARD_IK_PERATOM,7,sizeof(FFT_SCALAR),
+      else
+        gc->forward_comm(Grid3d::KSPACE,this,FORWARD_IK,3,sizeof(FFT_SCALAR),
                          gc_buf1,gc_buf2,MPI_FFT_SCALAR);
+
+      // extra per-atom energy/virial communication
+
+      if (evflag_atom) {
+        if (differentiation_flag == 1 && vflag_atom)
+          gc->forward_comm(Grid3d::KSPACE,this,FORWARD_AD_PERATOM,6,sizeof(FFT_SCALAR),
+                           gc_buf1,gc_buf2,MPI_FFT_SCALAR);
+        else if (differentiation_flag == 0)
+          gc->forward_comm(Grid3d::KSPACE,this,FORWARD_IK_PERATOM,7,sizeof(FFT_SCALAR),
+                           gc_buf1,gc_buf2,MPI_FFT_SCALAR);
+      }
+
+      // calculate the force on my particles
+
+      fieldforce();
+
+      // extra per-atom energy/virial communication
+
+      if (evflag_atom) fieldforce_peratom();
     }
-
-    // calculate the force on my particles
-
-    fieldforce();
-
-    // extra per-atom energy/virial communication
-
-    if (evflag_atom) fieldforce_peratom();
 
     stagger += 1.0/nstagger;
   }

--- a/src/kspace.h
+++ b/src/kspace.h
@@ -267,6 +267,13 @@ class KSpace : protected Pointers {
   double **gcons, **dgcons;    // accumulated per-atom energy/virial
 
   int evflag, evflag_atom;
+  // eflag_only is set when the caller requested the global energy via the
+  // ENERGY_ONLY flag (e.g. Monte Carlo fixes evaluating trial-move energies).
+  // Contract: when (eflag_only && !evflag_atom) a style must still produce the
+  // global energy and requested global virial, but may skip force-producing
+  // work (inverse FFTs, E-field interpolation, or Ewald force loops).  When
+  // per-atom energy/virial is requested (evflag_atom), the full path is taken.
+  // Styles that cannot separate energy from force simply ignore eflag_only.
   int eflag_either, eflag_global, eflag_atom, eflag_only;
   int vflag_either, vflag_global, vflag_atom;
   int maxeatom, maxvatom;

--- a/unittest/commands/CMakeLists.txt
+++ b/unittest/commands/CMakeLists.txt
@@ -60,6 +60,10 @@ target_compile_definitions(test_kspace_auto_slab PRIVATE -DTEST_INPUT_FOLDER=${C
 target_link_libraries(test_kspace_auto_slab PRIVATE lammps GTest::GMock)
 add_test(NAME KSpaceAutoSlab COMMAND test_kspace_auto_slab)
 
+add_executable(test_kspace_energy_only test_kspace_energy_only.cpp)
+target_link_libraries(test_kspace_energy_only PRIVATE lammps GTest::GMock)
+add_test(NAME KSpaceEnergyOnly COMMAND test_kspace_energy_only)
+
 add_executable(test_kspace_group_group_slab test_kspace_group_group_slab.cpp)
 target_compile_definitions(test_kspace_group_group_slab PRIVATE -DTEST_INPUT_FOLDER=${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(test_kspace_group_group_slab PRIVATE lammps GTest::GMock)

--- a/unittest/commands/test_kspace_energy_only.cpp
+++ b/unittest/commands/test_kspace_energy_only.cpp
@@ -1,0 +1,305 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS Development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under the
+   GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+// Verify that global energy and global virial from a KSpace style remain
+// unchanged when the ENERGY_ONLY path skips force-producing work.  Also
+// verify that requesting per-atom tallies with ENERGY_ONLY retains the full
+// path.  Monte Carlo fixes use this interface for trial-move energies.
+
+#include "../testing/core.h"
+
+#include "atom.h"
+#include "comm.h"
+#include "force.h"
+#include "kspace.h"
+#include "utils.h"
+#include "gtest/gtest.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <mpi.h>
+#include <string>
+#include <vector>
+
+bool verbose = false;
+
+namespace LAMMPS_NS {
+
+class KSpaceEnergyOnlyTest : public LAMMPSTest {
+protected:
+    void build_system(const std::string &kspace_cmd, const std::string &modify_cmd, bool triclinic,
+                      bool slab = false)
+    {
+        HIDE_OUTPUT([&] {
+            command("clear");
+            command("units real");
+            command("atom_style charge");
+            if (slab)
+                command("boundary p p f");
+            else
+                command("boundary p p p");
+            if (triclinic)
+                command("region box prism 0 40 0 40 0 40 5 3 4");
+            else
+                command("region box block 0 40 0 40 0 40");
+            command("create_box 1 box");
+
+            uint64_t state    = 246813579ULL;
+            auto next_uniform = [&state]() {
+                state = state * 6364136223846793005ULL + 1442695040888963407ULL;
+                return static_cast<double>((state >> 11) & ((1ULL << 53) - 1)) /
+                       static_cast<double>(1ULL << 53);
+            };
+
+            for (int atom_id = 1; atom_id <= 100; ++atom_id) {
+                const double x = 1.0 + 38.0 * next_uniform();
+                const double y = 1.0 + 38.0 * next_uniform();
+                const double z = 1.0 + 38.0 * next_uniform();
+                command(fmt::format("create_atoms 1 single {:.15g} {:.15g} {:.15g} units box", x, y,
+                                    z));
+                const double charge = (atom_id % 2 == 1) ? 1.0 : -1.0;
+                command(fmt::format("set atom {} charge {:.1f}", atom_id, charge));
+            }
+
+            command("mass 1 1.0");
+            command("pair_style coul/long 8.0");
+            command("pair_coeff * *");
+            command("pair_modify table 0");
+            command(kspace_cmd);
+            if (!modify_cmd.empty()) command(modify_cmd);
+            command("neighbor 2.0 bin");
+            command("run 0 post no");
+        });
+    }
+
+    void build_system_disp(const std::string &kspace_cmd, const std::string &mix_cmd)
+    {
+        HIDE_OUTPUT([&] {
+            command("clear");
+            command("units real");
+            command("atom_style charge");
+            command("boundary p p p");
+            command("region box block 0 40 0 40 0 40");
+            command("create_box 2 box");
+
+            uint64_t state    = 246813579ULL;
+            auto next_uniform = [&state]() {
+                state = state * 6364136223846793005ULL + 1442695040888963407ULL;
+                return static_cast<double>((state >> 11) & ((1ULL << 53) - 1)) /
+                       static_cast<double>(1ULL << 53);
+            };
+
+            for (int atom_id = 1; atom_id <= 100; ++atom_id) {
+                const double x = 1.0 + 38.0 * next_uniform();
+                const double y = 1.0 + 38.0 * next_uniform();
+                const double z = 1.0 + 38.0 * next_uniform();
+                const int type = (atom_id % 2 == 1) ? 1 : 2;
+                command(fmt::format("create_atoms {} single {:.15g} {:.15g} {:.15g} units box",
+                                    type, x, y, z));
+                const double charge = (atom_id % 2 == 1) ? 1.0 : -1.0;
+                command(fmt::format("set atom {} charge {:.1f}", atom_id, charge));
+            }
+
+            command("mass * 1.0");
+            command("pair_style lj/long/coul/long long long 8.0");
+            command("pair_coeff 1 1 0.2 2.5");
+            command("pair_coeff 2 2 0.1 3.0");
+            if (!mix_cmd.empty()) command(mix_cmd);
+            command(kspace_cmd);
+            command("kspace_modify disp/auto yes");
+            command("neighbor 2.0 bin");
+            command("run 0 post no");
+        });
+    }
+
+    void compute_and_snapshot(int eflag, int vflag, double &e, double v[6])
+    {
+        KSpace *ks = lmp->force->kspace;
+        ks->compute(eflag, vflag);
+        e = ks->energy;
+        for (int i = 0; i < 6; ++i)
+            v[i] = ks->virial[i];
+    }
+
+    std::vector<std::array<double, 3>> snapshot_forces()
+    {
+        std::vector<std::array<double, 3>> result(lmp->atom->nlocal);
+        for (int i = 0; i < lmp->atom->nlocal; ++i)
+            result[i] = {lmp->atom->f[i][0], lmp->atom->f[i][1], lmp->atom->f[i][2]};
+        return result;
+    }
+
+    static double relerr(double a, double b)
+    {
+        const double den = std::max({std::fabs(a), std::fabs(b), 1.0});
+        return std::fabs(a - b) / den;
+    }
+
+    void check_energy_only(const std::string &label)
+    {
+        double e_full, v_full[6];
+        double e_only, v_only[6];
+
+        compute_and_snapshot(ENERGY_GLOBAL, VIRIAL_PAIR, e_full, v_full);
+        const auto forces_after_full = snapshot_forces();
+        compute_and_snapshot(ENERGY_GLOBAL | ENERGY_ONLY, VIRIAL_PAIR, e_only, v_only);
+
+        EXPECT_LT(relerr(e_full, e_only), 1.0e-12) << label << " energy";
+        for (int i = 0; i < 6; ++i)
+            EXPECT_LT(relerr(v_full[i], v_only[i]), 1.0e-12) << label << " virial[" << i << "]";
+
+        ASSERT_EQ(forces_after_full.size(), static_cast<size_t>(lmp->atom->nlocal));
+        for (int i = 0; i < lmp->atom->nlocal; ++i) {
+            EXPECT_DOUBLE_EQ(forces_after_full[i][0], lmp->atom->f[i][0])
+                << label << " fx[" << i << "]";
+            EXPECT_DOUBLE_EQ(forces_after_full[i][1], lmp->atom->f[i][1])
+                << label << " fy[" << i << "]";
+            EXPECT_DOUBLE_EQ(forces_after_full[i][2], lmp->atom->f[i][2])
+                << label << " fz[" << i << "]";
+        }
+
+        // Per-atom requests must retain the full path even when ENERGY_ONLY
+        // is also present, because they require the force-producing data.
+        double e_pa, v_pa[6];
+        compute_and_snapshot(ENERGY_GLOBAL | ENERGY_ATOM | ENERGY_ONLY, VIRIAL_PAIR | VIRIAL_ATOM,
+                             e_pa, v_pa);
+        EXPECT_LT(relerr(e_full, e_pa), 1.0e-12) << label << " per-atom-fallback energy";
+        for (int i = 0; i < 6; ++i)
+            EXPECT_LT(relerr(v_full[i], v_pa[i]), 1.0e-12)
+                << label << " per-atom-fallback virial[" << i << "]";
+
+        if (verbose && (lmp->comm->me == 0))
+            utils::print("{:<16} e_full={:.12g} e_only={:.12g} rel.err E={:.2e}\n", label, e_full,
+                         e_only, relerr(e_full, e_only));
+    }
+};
+
+TEST_F(KSpaceEnergyOnlyTest, Ewald)
+{
+    if (!info->has_style("kspace", "ewald")) GTEST_SKIP();
+    if (!info->has_style("pair", "coul/long")) GTEST_SKIP();
+
+    build_system("kspace_style ewald 1.0e-4", "", false);
+    check_energy_only("ewald");
+
+    build_system("kspace_style ewald 1.0e-4", "", true);
+    check_energy_only("ewald/triclinic");
+}
+
+TEST_F(KSpaceEnergyOnlyTest, PPPMik)
+{
+    if (!info->has_style("kspace", "pppm")) GTEST_SKIP();
+    if (!info->has_style("pair", "coul/long")) GTEST_SKIP();
+
+    build_system("kspace_style pppm 1.0e-4", "", false);
+    check_energy_only("pppm/ik");
+
+    build_system("kspace_style pppm 1.0e-4", "", true);
+    check_energy_only("pppm/ik/triclinic");
+}
+
+TEST_F(KSpaceEnergyOnlyTest, EwaldSlab)
+{
+    if (!info->has_style("kspace", "ewald")) GTEST_SKIP();
+    if (!info->has_style("pair", "coul/long")) GTEST_SKIP();
+
+    build_system("kspace_style ewald 1.0e-4", "kspace_modify slab 3.0", false, true);
+    check_energy_only("ewald/slab");
+}
+
+TEST_F(KSpaceEnergyOnlyTest, PPPMSlab)
+{
+    if (!info->has_style("kspace", "pppm")) GTEST_SKIP();
+    if (!info->has_style("pair", "coul/long")) GTEST_SKIP();
+
+    build_system("kspace_style pppm 1.0e-4", "kspace_modify slab 3.0", false, true);
+    check_energy_only("pppm/slab");
+}
+
+TEST_F(KSpaceEnergyOnlyTest, PPPMad)
+{
+    if (!info->has_style("kspace", "pppm")) GTEST_SKIP();
+    if (!info->has_style("pair", "coul/long")) GTEST_SKIP();
+
+    build_system("kspace_style pppm 1.0e-4", "kspace_modify diff ad", false);
+    check_energy_only("pppm/ad");
+}
+
+TEST_F(KSpaceEnergyOnlyTest, PPPMcg)
+{
+    if (!info->has_style("kspace", "pppm/cg")) GTEST_SKIP();
+    if (!info->has_style("pair", "coul/long")) GTEST_SKIP();
+
+    build_system("kspace_style pppm/cg 1.0e-4", "", false);
+    check_energy_only("pppm/cg");
+
+    build_system("kspace_style pppm/cg 1.0e-4", "", true);
+    check_energy_only("pppm/cg/triclinic");
+}
+
+TEST_F(KSpaceEnergyOnlyTest, PPPMstagger)
+{
+    if (!info->has_style("kspace", "pppm/stagger")) GTEST_SKIP();
+    if (!info->has_style("pair", "coul/long")) GTEST_SKIP();
+
+    build_system("kspace_style pppm/stagger 1.0e-4", "", false);
+    check_energy_only("pppm/stagger");
+}
+
+TEST_F(KSpaceEnergyOnlyTest, PPPMdisp)
+{
+    if (!info->has_style("kspace", "pppm/disp")) GTEST_SKIP();
+    if (!info->has_style("pair", "lj/long/coul/long")) GTEST_SKIP();
+
+    build_system_disp("kspace_style pppm/disp 1.0e-4", "pair_modify mix geometric");
+    check_energy_only("pppm/disp/geom");
+
+    build_system_disp("kspace_style pppm/disp 1.0e-4", "pair_modify mix arithmetic");
+    check_energy_only("pppm/disp/arith");
+
+    build_system_disp("kspace_style pppm/disp 1.0e-4", "pair_coeff 1 2 0.15 2.7");
+    check_energy_only("pppm/disp/none");
+}
+
+TEST_F(KSpaceEnergyOnlyTest, EwaldDisp)
+{
+    if (!info->has_style("kspace", "ewald/disp")) GTEST_SKIP();
+    if (!info->has_style("pair", "lj/long/coul/long")) GTEST_SKIP();
+
+    build_system_disp("kspace_style ewald/disp 1.0e-4", "pair_modify mix geometric");
+    check_energy_only("ewald/disp");
+}
+
+} // namespace LAMMPS_NS
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+    ::testing::InitGoogleMock(&argc, argv);
+
+    if (const char *var = getenv("TEST_ARGS")) {
+        std::vector<std::string> env = LAMMPS_NS::utils::split_words(var);
+        for (const auto &arg : env) {
+            if (arg == "-v") verbose = true;
+        }
+    }
+
+    if ((argc > 1) && (std::string(argv[1]) == "-v")) verbose = true;
+
+    const int rv = RUN_ALL_TESTS();
+    MPI_Finalize();
+    return rv;
+}


### PR DESCRIPTION
**Summary**

This is Part 1 of #5016. It reuses the existing `ENERGY_ONLY` flag to avoid
force-producing work when a KSpace style is asked for global energy (and global
virial, if requested) without per-atom tallies.

The optimized paths cover Ewald, Ewald/disp, PPPM, PPPM/disp, PPPM/cg, and
PPPM/stagger. The change skips the E-field/force loops, force interpolation,
and the corresponding inverse transforms where those results are not needed.
Normal force calculations and per-atom energy/virial requests retain the full
existing path.

**Related Issue(s)**

This is a staged contribution for #5016. It intentionally does not close the
Issue; the GCMC and broader MC refactoring work belongs in separately reviewed
follow-up pull requests.

**Author(s)**

Wen Yifan, Sichuan University

Corresponding author e-mail: wen.yf@foxmail.com

**Licensing**

By submitting this pull request, I agree, that my contribution will be
included in LAMMPS and redistributed under either the GNU General Public
License version 2 (GPL v2) or the GNU Lesser General Public License version
2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

OpenAI Codex was used to implement the changes, prepare the regression test,
run the builds and tests, and perform the code review. A Codex subagent was
invoked for a read-only audit attempt of the upstream and prototype KSpace
paths; its output was not used to justify the code changes. The patch is being
submitted by the named author under the licensing terms above; the author will
review and address maintainer feedback.

**Backward Compatibility**

There is no change to the input language or user-facing API. The existing
behavior is unchanged unless a caller already requests global energy with the
pre-existing `ENERGY_ONLY` flag. Per-atom requests and unsupported or
non-optimized styles retain their existing full calculation paths.

**Implementation Notes**

- The `KSpace` header documents the internal `ENERGY_ONLY` contract used by
  the optimized styles.
- Ewald and PPPM variants keep the global energy/virial accumulation and skip
  only the force-producing stage when no per-atom result is requested.
- Slab force corrections are skipped under the same condition; slab energy and
  per-atom corrections are preserved.
- The new `KSpaceEnergyOnly` test covers Ewald, PPPM IK/AD, PPPM/cg,
  PPPM/stagger, slab corrections, Ewald/disp, and PPPM/disp geometric,
  arithmetic, and explicit no-mix paths. It also checks the per-atom fallback.
- Validation on `nscc-cd`: CMake Release/MPI and conventional Make/MPI builds
  succeeded; the focused test passed 9/9 with one MPI rank and 9/9 with four
  MPI ranks; 883/883 CTest tests passed after excluding `LibraryProperties`.
  That test reports the same negative memory value in a clean `develop`
  baseline on this host, so it is an environment/test-baseline issue rather
  than a failure introduced by this change.
- The modified C++ files pass the repository formatting check with LLVM
  `clang-format --dry-run --Werror`, and `git diff --check` reports no
  whitespace errors.
- This pull request is limited to the KSpace performance foundation. It does
  not claim to implement the complete MC refactoring, incremental neighbor or
  ghost updates, or multi-MPI MC move architecture described in #5016.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete for the Part 1 scope
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included (no user-facing API or input change in this part)
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [x] Suitable tests have been added to the unittest tree

**Further Information, Files, and Links**

- Issue: https://github.com/lammps/lammps/issues/5016
- Existing `ENERGY_ONLY` plumbing: https://github.com/lammps/lammps/pull/4914
- Staged implementation proposal: https://github.com/lammps/lammps/issues/5016#issuecomment-5476172113
