### PR TITLE
Update MBX to v1.4.3

### DIFF
--- a/cmake/Modules/Packages/MBX.cmake
+++ b/cmake/Modules/Packages/MBX.cmake
@@ -54,8 +54,8 @@ option(DOWNLOAD_MBX "Download MBX package instead of using an already installed 
 if(DOWNLOAD_MBX)
   message(STATUS "MBX download requested - we will build our own")
   SetDownloadSettings(MBXLIB "MBX"
-    "https://github.com/paesanilab/MBX/releases/download/v1.4.0/mbx-1.4.0.tar.gz"
-    "219de5af7cd81bdf8c3394c3aeee923cf4de7dd322769441a35c7cf4950bf912")
+    "https://github.com/paesanilab/MBX/releases/download/v1.4.0/mbx-1.4.3.tar.gz"
+    "1175a9158027e2a7dfe4d0109b8dcb4ed13a18e584297dc38268bb6ebfa1dd16")
 
   # apply patches to the MBX sources of known versions (e.g. so that they compile without OpenMP)
   get_filename_component(_mbx_archive "${MBXLIB_URL}" NAME)


### PR DESCRIPTION
**Summary**

Updated MBX to v1.4.3 to address issue when compiling without OpenMP. Closes https://github.com/paesanilab/MBX/issues/108

**Related Issue(s)**

Related to MBX issue https://github.com/paesanilab/MBX/issues/108

**Author(s)**

Henry Agnew, UC San Diego
Includes code by [Axel Kohlmeyer](https://github.com/akohlmey)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**


By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [X] The feature or features in this pull request is complete
- [X] Licensing information is complete
- [X] Corresponding author information is complete
- [X] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [X] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included



