### PR TITLE
KOKKOS: add accelerator variant for pair granular

### DIFF
--- a/examples/PACKAGES/granular/README
+++ b/examples/PACKAGES/granular/README
@@ -1,0 +1,44 @@
+Pair granular Kokkos example
+============================
+
+This example simulates the collision of two spherical particles using
+the modular pair_style granular command. The same input supports the
+standard CPU implementation and the Kokkos accelerator variant.
+
+Required packages
+-----------------
+
+CPU:
+  GRANULAR
+
+Kokkos:
+  GRANULAR
+  KOKKOS
+
+CPU execution
+-------------
+
+  lmp -suffix none -in in.granular_kokkos
+
+Kokkos GPU execution
+--------------------
+
+  lmp -k on g 1 -sf kk \
+      -pk kokkos neigh half comm device gpu/aware off \
+      -in in.granular_kokkos
+
+The -sf kk option automatically selects granular/kk and other available
+Kokkos accelerator styles.
+
+Validation performed on NVIDIA GH200
+------------------------------------
+
+The CPU and Kokkos GPU trajectories were compared for all 42 atom
+records produced by the example.
+
+  Maximum absolute difference: 5.115908e-13
+  Maximum relative difference: 2.412300e-12
+  Result: PASSED
+
+Differences at this level are attributable to floating-point operation
+ordering between CPU and GPU execution.

--- a/examples/PACKAGES/granular/in.granular_kokkos
+++ b/examples/PACKAGES/granular/in.granular_kokkos
@@ -1,0 +1,26 @@
+units si
+atom_style sphere
+boundary f f f
+newton off
+comm_modify vel yes
+region box block -2 2 -2 2 -2 2
+create_box 1 box
+create_atoms 1 single 0.0 0.0 0.0
+create_atoms 1 single 0.9 0.0 0.0
+set atom 1 diameter 1.0 density 1.0
+set atom 2 diameter 1.0 density 1.0
+group first id 1
+group second id 2
+velocity first set 0.10 0.20 0.00
+velocity second set -0.10 -0.10 0.00
+pair_style granular
+pair_coeff * * hooke 4000.0 100.0 tangential linear_history 1000.0 1.0 0.5 damping mass_velocity
+neighbor 0.2 bin
+neigh_modify every 1 delay 0 check yes
+timestep 0.00001
+fix int all nve/sphere
+thermo 1
+thermo_style custom step atoms ke
+dump out all custom 1 granular.dump id x y z vx vy vz omegax omegay omegaz fx fy fz
+dump_modify out sort id format line "%d %.16g %.16g %.16g %.16g %.16g %.16g %.16g %.16g %.16g %.16g %.16g %.16g"
+run 20

--- a/src/GRANULAR/gran_sub_mod_damping.h
+++ b/src/GRANULAR/gran_sub_mod_damping.h
@@ -25,6 +25,7 @@ namespace LAMMPS_NS::Granular_NS {
     void init() override;
     virtual double calculate_forces() = 0;
     [[nodiscard]] double get_damp_prefactor() const { return damp_prefactor; }
+    [[nodiscard]] double get_damp() const { return damp; }
 
    protected:
     double damp_prefactor;

--- a/src/GRANULAR/gran_sub_mod_normal.h
+++ b/src/GRANULAR/gran_sub_mod_normal.h
@@ -33,6 +33,7 @@ namespace LAMMPS_NS::Granular_NS {
     [[nodiscard]] double get_fncrit() const { return Fncrit; }
     [[nodiscard]] int get_material_properties() const { return material_properties; }
     [[nodiscard]] double get_poiss() const { return poiss; }
+    [[nodiscard]] virtual double get_k() const { return 0.0; }
 
     virtual void set_fncrit();
 
@@ -59,6 +60,7 @@ namespace LAMMPS_NS::Granular_NS {
     GranSubModNormalHooke(class GranularModel *, class LAMMPS *);
     void coeffs_to_local() override;
     double calculate_forces() override;
+    [[nodiscard]] double get_k() const override { return k; }
 
    protected:
     double k;
@@ -71,6 +73,7 @@ namespace LAMMPS_NS::Granular_NS {
     GranSubModNormalHertz(class GranularModel *, class LAMMPS *);
     void coeffs_to_local() override;
     double calculate_forces() override;
+    [[nodiscard]] double get_k() const override { return k; }
 
    protected:
     double k;

--- a/src/GRANULAR/gran_sub_mod_tangential.h
+++ b/src/GRANULAR/gran_sub_mod_tangential.h
@@ -27,6 +27,9 @@ namespace LAMMPS_NS::Granular_NS {
     [[nodiscard]] double get_k() const { return k; }
     [[nodiscard]] double get_damp() const { return damp; }
     [[nodiscard]] double get_mu() const { return mu; }
+    [[nodiscard]] virtual double get_xt() const { return 0.0; }
+    [[nodiscard]] virtual int get_mindlin_force() const { return 0; }
+    [[nodiscard]] virtual int get_mindlin_rescale() const { return 0; }
 
    protected:
     double k, damp, mu;    // Used by Marshall twisting model
@@ -47,6 +50,7 @@ namespace LAMMPS_NS::Granular_NS {
     GranSubModTangentialLinearNoHistory(class GranularModel *, class LAMMPS *);
     void coeffs_to_local() override;
     void calculate_forces() override;
+    [[nodiscard]] double get_xt() const override { return xt; }
 
    protected:
     double xt;
@@ -59,6 +63,7 @@ namespace LAMMPS_NS::Granular_NS {
     GranSubModTangentialLinearHistory(class GranularModel *, class LAMMPS *);
     void coeffs_to_local() override;
     void calculate_forces() override;
+    [[nodiscard]] double get_xt() const override { return xt; }
 
    protected:
     double xt;
@@ -87,6 +92,9 @@ namespace LAMMPS_NS::Granular_NS {
     void coeffs_to_local() override;
     void mix_coeffs(double *, double *) override;
     void calculate_forces() override;
+    [[nodiscard]] double get_xt() const override { return xt; }
+    [[nodiscard]] int get_mindlin_force() const override { return mindlin_force; }
+    [[nodiscard]] int get_mindlin_rescale() const override { return mindlin_rescale; }
 
    protected:
     int mindlin_rescale, mindlin_force;

--- a/src/GRANULAR/pair_granular.cpp
+++ b/src/GRANULAR/pair_granular.cpp
@@ -101,6 +101,10 @@ id_dummy = utils::strdup(std::string("NEIGH_HISTORY_GRANULAR_DUMMY") + std::to_s
 
 PairGranular::~PairGranular()
 {
+  // Kokkos functors are shallow copies of the pair object.  Their
+  // destructors must not release storage owned by the original instance.
+  if (copymode) return;
+
   delete[] svector;
 
   if (!fix_history) modify->delete_fix(id_dummy);

--- a/src/KOKKOS/pair_granular_kokkos.cpp
+++ b/src/KOKKOS/pair_granular_kokkos.cpp
@@ -1,0 +1,494 @@
+// clang-format off
+/* ----------------------------------------------------------------------
+   Kokkos implementation of the modular pair_style granular.
+
+   This first implementation supports the non-cohesive Hooke/Hertz normal
+   families, standard damping laws, and linear/Mindlin tangential models.
+------------------------------------------------------------------------- */
+
+#include "pair_granular_kokkos.h"
+
+#include "atom_kokkos.h"
+#include "atom_masks.h"
+#include "error.h"
+#include "fix_neigh_history_kokkos.h"
+#include "force.h"
+#include "granular_model.h"
+#include "gran_sub_mod.h"
+#include "gran_sub_mod_damping.h"
+#include "gran_sub_mod_normal.h"
+#include "gran_sub_mod_rolling.h"
+#include "gran_sub_mod_tangential.h"
+#include "gran_sub_mod_twisting.h"
+#include "gran_sub_mod_heat.h"
+#include "kokkos.h"
+#include "memory_kokkos.h"
+#include "modify.h"
+#include "neigh_list_kokkos.h"
+#include "neigh_request.h"
+#include "neighbor.h"
+#include "update.h"
+#include "utils.h"
+
+#include <cmath>
+#include <string>
+
+using namespace LAMMPS_NS;
+using namespace LAMMPS_NS::Granular_NS;
+
+template<class DeviceType>
+PairGranularKokkos<DeviceType>::PairGranularKokkos(LAMMPS *lmp) : PairGranular(lmp)
+{
+  kokkosable = 1;
+  atomKK = (AtomKokkos *) atom;
+  execution_space = ExecutionSpaceFromDevice<DeviceType>::space;
+  datamask_read = X_MASK | V_MASK | OMEGA_MASK | F_MASK | TORQUE_MASK |
+    TYPE_MASK | MASK_MASK | ENERGY_MASK | VIRIAL_MASK | RMASS_MASK | RADIUS_MASK;
+  datamask_modify = F_MASK | TORQUE_MASK | ENERGY_MASK | VIRIAL_MASK;
+  fix_historyKK = nullptr;
+  use_history_kk = size_history_kk = 0;
+}
+
+template<class DeviceType>
+PairGranularKokkos<DeviceType>::~PairGranularKokkos()
+{
+  if (copymode) return;
+  if (allocated) {
+    memoryKK->destroy_kokkos(k_eatom,eatom);
+    memoryKK->destroy_kokkos(k_vatom,vatom);
+    eatom = nullptr;
+    vatom = nullptr;
+  }
+}
+
+template<class DeviceType>
+void PairGranularKokkos<DeviceType>::create_kokkos_history()
+{
+  int size_max[NSUBMODELS] = {0};
+  use_history = 0;
+  size_history = 0;
+  beyond_contact = 0;
+  nondefault_history_transfer = 0;
+
+  for (int n = 0; n < nmodels; n++) {
+    auto *model = models_list[n];
+    if (model->beyond_contact) {
+      beyond_contact = 1;
+      use_history = 1;
+    }
+    if (model->size_history) use_history = 1;
+    if (model->nondefault_history_transfer) nondefault_history_transfer = 1;
+    for (int m = 0; m < NSUBMODELS; m++)
+      size_max[m] = MAX(size_max[m],model->sub_models[m]->size_history);
+  }
+
+  if (!use_history) return;
+  for (int m = 0; m < NSUBMODELS; m++) size_history += size_max[m];
+  size_history = MAX(size_history,1);
+  for (int n = 0; n < nmodels; n++) {
+    int next = 0;
+    for (int m = 0; m < NSUBMODELS; m++) {
+      models_list[n]->sub_models[m]->history_index = next;
+      next += size_max[m];
+    }
+  }
+
+  if (id_history == nullptr)
+    id_history = utils::strdup(std::string("NEIGH_HISTORY_GRANULAR") +
+                               std::to_string(instance_index()));
+
+  if (fix_history == nullptr) {
+    std::string cmd = std::string(id_history) + " all ";
+    if (execution_space == Device) cmd += "NEIGH_HISTORY/KK/DEVICE ";
+    else cmd += "NEIGH_HISTORY/KK/HOST ";
+    cmd += std::to_string(size_history);
+    fix_history = dynamic_cast<FixNeighHistory *>(modify->replace_fix(id_dummy,cmd,1));
+    fix_history->pair = this;
+  } else {
+    fix_history = dynamic_cast<FixNeighHistory *>(modify->get_fix_by_id(id_history));
+    if (!fix_history) error->all(FLERR,"Could not find Kokkos granular history fix");
+  }
+  fix_historyKK = dynamic_cast<FixNeighHistoryKokkos<DeviceType> *>(fix_history);
+  if (!fix_historyKK) error->all(FLERR,"Could not create Kokkos granular history fix");
+}
+
+template<class DeviceType>
+void PairGranularKokkos<DeviceType>::init_style()
+{
+  create_kokkos_history();
+  PairGranular::init_style();
+
+  neighflag = lmp->kokkos->neighflag;
+  auto request = neighbor->find_request(this);
+  request->set_kokkos_host(std::is_same_v<DeviceType,LMPHostType> &&
+                           !std::is_same_v<DeviceType,LMPDeviceType>);
+  request->set_kokkos_device(std::is_same_v<DeviceType,LMPDeviceType>);
+  if (neighflag == FULL)
+    error->all(FLERR,"Pair granular/kk requires a half or half/thread neighbor list");
+  if (use_history && force->newton_pair)
+    error->all(FLERR,"Pair granular/kk with contact history requires newton off");
+  if (fix_rigid)
+    error->all(FLERR,"Pair granular/kk does not yet support fix rigid masses");
+
+  use_history_kk = use_history;
+  size_history_kk = size_history;
+}
+
+template<class DeviceType>
+double PairGranularKokkos<DeviceType>::init_one(int i, int j)
+{
+  const double cut = PairGranular::init_one(i,j);
+  pack_models();
+  return cut;
+}
+
+template<class DeviceType>
+void PairGranularKokkos<DeviceType>::pack_models()
+{
+  d_model_i = decltype(d_model_i)("pair_granular:model_i",nmodels,MI_COUNT);
+  d_model_f = decltype(d_model_f)("pair_granular:model_f",nmodels,MF_COUNT);
+  d_type_model = decltype(d_type_model)("pair_granular:type_model",atom->ntypes+1,
+                                        atom->ntypes+1);
+  auto hmi = Kokkos::create_mirror_view(d_model_i);
+  auto hmf = Kokkos::create_mirror_view(d_model_f);
+  auto htm = Kokkos::create_mirror_view(d_type_model);
+
+  for (int n = 0; n < nmodels; n++) {
+    auto *gm = models_list[n];
+    const std::string &normal = gm->normal_model->name;
+    const std::string &damping = gm->damping_model->name;
+    const std::string &tangential = gm->tangential_model->name;
+
+    if (normal == "hooke") hmi(n,MI_NORMAL) = N_HOOKE;
+    else if (normal == "hertz" || normal == "hertz/material")
+      hmi(n,MI_NORMAL) = N_HERTZ;
+    else
+      error->all(FLERR,"Pair granular/kk does not yet support normal model {}",normal);
+
+    if (damping == "velocity") hmi(n,MI_DAMPING) = D_VELOCITY;
+    else if (damping == "mass_velocity") hmi(n,MI_DAMPING) = D_MASS_VELOCITY;
+    else if (damping == "viscoelastic") hmi(n,MI_DAMPING) = D_VISCOELASTIC;
+    else if (damping == "tsuji" || damping == "coeff_restitution")
+      hmi(n,MI_DAMPING) = D_TSUJI;
+    else
+      error->all(FLERR,"Pair granular/kk does not yet support damping model {}",damping);
+
+    if (tangential == "linear_nohistory")
+      hmi(n,MI_TANGENTIAL) = T_LINEAR_NOHISTORY;
+    else if (tangential == "linear_history")
+      hmi(n,MI_TANGENTIAL) = T_LINEAR_HISTORY;
+    else if (tangential == "linear_history_classic")
+      hmi(n,MI_TANGENTIAL) = T_LINEAR_CLASSIC;
+    else if (tangential == "mindlin_classic")
+      hmi(n,MI_TANGENTIAL) = T_MINDLIN_CLASSIC;
+    else if (tangential == "mindlin" || tangential == "mindlin/force")
+      hmi(n,MI_TANGENTIAL) = T_MINDLIN;
+    else
+      error->all(FLERR,"Pair granular/kk does not yet support tangential model {}",tangential);
+
+    if (gm->rolling_model->name != "none" || gm->twisting_model->name != "none" ||
+        gm->heat_model->name != "none")
+      error->all(FLERR,"Pair granular/kk does not yet support rolling, twisting, or heat models");
+    if (gm->synchronized_verlet)
+      error->all(FLERR,"Pair granular/kk does not yet support synchronized_verlet");
+    if (gm->tangential_model->get_mindlin_rescale())
+      error->all(FLERR,"Pair granular/kk does not yet support Mindlin rescale history");
+
+    hmi(n,MI_HISTORY_INDEX) = gm->tangential_model->history_index;
+    hmi(n,MI_LIMIT_DAMPING) = gm->limit_damping;
+    hmi(n,MI_MINDLIN_FORCE) = gm->tangential_model->get_mindlin_force();
+    hmi(n,MI_MINDLIN_RESCALE) = gm->tangential_model->get_mindlin_rescale();
+    hmf(n,MF_NORMAL_K) = gm->normal_model->get_k();
+    hmf(n,MF_DAMP) = gm->damping_model->get_damp();
+    hmf(n,MF_TANGENTIAL_K) = gm->tangential_model->get_k();
+    hmf(n,MF_XT) = gm->tangential_model->get_xt();
+    hmf(n,MF_MU) = gm->tangential_model->get_mu();
+  }
+  for (int i = 1; i <= atom->ntypes; i++)
+    for (int j = 1; j <= atom->ntypes; j++) htm(i,j) = types_indices[i][j];
+
+  Kokkos::deep_copy(d_model_i,hmi);
+  Kokkos::deep_copy(d_model_f,hmf);
+  Kokkos::deep_copy(d_type_model,htm);
+}
+
+template<class DeviceType>
+void PairGranularKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
+{
+  copymode = 1;
+  eflag = eflag_in;
+  vflag = vflag_in;
+  ev_init(eflag,vflag,0);
+  const int history_update = update->setupflag == 0;
+
+  if (eflag_atom) {
+    memoryKK->destroy_kokkos(k_eatom,eatom);
+    memoryKK->create_kokkos(k_eatom,eatom,maxeatom,"pair:eatom");
+    d_eatom = k_eatom.view<DeviceType>();
+  }
+  if (vflag_atom) {
+    memoryKK->destroy_kokkos(k_vatom,vatom);
+    memoryKK->create_kokkos(k_vatom,vatom,maxvatom,"pair:vatom");
+    d_vatom = k_vatom.view<DeviceType>();
+  }
+
+  atomKK->sync(execution_space,datamask_read);
+  if (eflag || vflag) atomKK->modified(execution_space,datamask_modify);
+  else atomKK->modified(execution_space,F_MASK | TORQUE_MASK);
+  x = atomKK->k_x.view<DeviceType>();
+  v = atomKK->k_v.view<DeviceType>();
+  omega = atomKK->k_omega.view<DeviceType>();
+  f = atomKK->k_f.view<DeviceType>();
+  torque = atomKK->k_torque.view<DeviceType>();
+  type = atomKK->k_type.view<DeviceType>();
+  mask = atomKK->k_mask.view<DeviceType>();
+  rmass = atomKK->k_rmass.view<DeviceType>();
+  radius = atomKK->k_radius.view<DeviceType>();
+  nlocal = atom->nlocal;
+  nall = atom->nlocal + atom->nghost;
+  newton_pair = force->newton_pair;
+  for (int k = 0; k < 4; k++) special_lj[k] = force->special_lj[k];
+  dt_kk = update->dt;
+
+  const int inum = list->inum;
+  auto *k_list = static_cast<NeighListKokkos<DeviceType> *>(list);
+  d_numneigh = k_list->d_numneigh;
+  d_neighbors = k_list->d_neighbors;
+  d_ilist = k_list->d_ilist;
+  if (use_history_kk) {
+    fix_historyKK->k_firstflag.template sync<DeviceType>();
+    fix_historyKK->k_firstvalue.template sync<DeviceType>();
+    d_firsttouch = fix_historyKK->k_firstflag.template view<DeviceType>();
+    d_firsthistory = fix_historyKK->k_firstvalue.template view<DeviceType>();
+    Kokkos::deep_copy(d_firsttouch,0);
+  }
+
+  EV_FLOAT ev;
+#define RUN_GRAN(NF,NP,VF,HU) \
+  if (VF) Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType,TagPairGranularCompute<NF,NP,1,HU>>(0,inum),*this,ev); \
+  else Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType,TagPairGranularCompute<NF,NP,0,HU>>(0,inum),*this)
+
+  if (neighflag == HALF) {
+    if (newton_pair) {
+      if (history_update) { if (vflag_either) RUN_GRAN(HALF,1,1,1); else RUN_GRAN(HALF,1,0,1); }
+      else { if (vflag_either) RUN_GRAN(HALF,1,1,0); else RUN_GRAN(HALF,1,0,0); }
+    } else {
+      if (history_update) { if (vflag_either) RUN_GRAN(HALF,0,1,1); else RUN_GRAN(HALF,0,0,1); }
+      else { if (vflag_either) RUN_GRAN(HALF,0,1,0); else RUN_GRAN(HALF,0,0,0); }
+    }
+  } else {
+    if (newton_pair) {
+      if (history_update) { if (vflag_either) RUN_GRAN(HALFTHREAD,1,1,1); else RUN_GRAN(HALFTHREAD,1,0,1); }
+      else { if (vflag_either) RUN_GRAN(HALFTHREAD,1,1,0); else RUN_GRAN(HALFTHREAD,1,0,0); }
+    } else {
+      if (history_update) { if (vflag_either) RUN_GRAN(HALFTHREAD,0,1,1); else RUN_GRAN(HALFTHREAD,0,0,1); }
+      else { if (vflag_either) RUN_GRAN(HALFTHREAD,0,1,0); else RUN_GRAN(HALFTHREAD,0,0,0); }
+    }
+  }
+#undef RUN_GRAN
+
+  if (use_history_kk) {
+    fix_historyKK->k_firstflag.template modify<DeviceType>();
+    fix_historyKK->k_firstvalue.template modify<DeviceType>();
+  }
+  if (eflag_atom) { k_eatom.template modify<DeviceType>(); k_eatom.sync_host(); }
+  if (vflag_global) for (int k = 0; k < 6; k++) virial[k] += (double) ev.v[k];
+  if (vflag_atom) { k_vatom.template modify<DeviceType>(); k_vatom.sync_host(); }
+  if (vflag_fdotr) pair_virial_fdotr_compute(this);
+  copymode = 0;
+}
+
+template<class DeviceType>
+template<int NEIGHFLAG, int NEWTON_PAIR, int VFLAG, int HISTORYUPDATE>
+KOKKOS_INLINE_FUNCTION
+void PairGranularKokkos<DeviceType>::operator()(
+    TagPairGranularCompute<NEIGHFLAG,NEWTON_PAIR,VFLAG,HISTORYUPDATE>,
+    const int ii, EV_FLOAT &ev) const
+{
+  using AtomicView = Kokkos::View<KK_ACC_FLOAT*[3],typename DAT::t_kkacc_1d_3::array_layout,
+    typename KKDevice<DeviceType>::value,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value>>;
+  AtomicView a_f = f;
+  AtomicView a_torque = torque;
+  const int i = d_ilist[ii];
+  const KK_FLOAT xi=x(i,0), yi=x(i,1), zi=x(i,2);
+  const KK_FLOAT vxi=v(i,0), vyi=v(i,1), vzi=v(i,2);
+  const KK_FLOAT wxi=omega(i,0), wyi=omega(i,1), wzi=omega(i,2);
+  const KK_FLOAT ri=radius[i], mi=rmass[i];
+  const int itype=type[i], maski=mask[i], jnum=d_numneigh[i];
+  KK_ACC_FLOAT fxi=0, fyi=0, fzi=0, txi=0, tyi=0, tzi=0;
+
+  for (int jj=0; jj<jnum; jj++) {
+    int j=d_neighbors(i,jj);
+    KK_FLOAT factor=(KK_FLOAT)special_lj[sbmask(j)];
+    j &= NEIGHMASK;
+    if (factor == 0) continue;
+    const KK_FLOAT dx=xi-x(j,0), dy=yi-x(j,1), dz=zi-x(j,2);
+    const KK_FLOAT rsq=dx*dx+dy*dy+dz*dz;
+    const KK_FLOAT rj=radius[j], radsum=ri+rj;
+    const int model=d_type_model(itype,type[j]);
+    if (rsq >= radsum*radsum) {
+      if (use_history_kk) {
+        for (int k=0; k<size_history_kk; k++)
+          d_firsthistory(i,size_history_kk*jj+k)=0;
+      }
+      continue;
+    }
+    if (use_history_kk) d_firsttouch(i,jj)=1;
+
+    const KK_FLOAT r=sqrt(rsq), rinv=1/r;
+    const KK_FLOAT nx=dx*rinv, ny=dy*rinv, nz=dz*rinv;
+    const KK_FLOAT delta=radsum-r;
+    const KK_FLOAT reff=ri*rj/radsum;
+    const KK_FLOAT contact_radius=sqrt(delta*reff);
+    const KK_FLOAT vrx=vxi-v(j,0), vry=vyi-v(j,1), vrz=vzi-v(j,2);
+    const KK_FLOAT vnnr=vrx*nx+vry*ny+vrz*nz;
+    const KK_FLOAT vtx=vrx-vnnr*nx, vty=vry-vnnr*ny, vtz=vrz-vnnr*nz;
+    const KK_FLOAT wrx=ri*wxi+rj*omega(j,0);
+    const KK_FLOAT wry=ri*wyi+rj*omega(j,1);
+    const KK_FLOAT wrz=ri*wzi+rj*omega(j,2);
+    const KK_FLOAT vtrx=vtx-(wry*nz-wrz*ny);
+    const KK_FLOAT vtry=vty-(wrz*nx-wrx*nz);
+    const KK_FLOAT vtrz=vtz-(wrx*ny-wry*nx);
+    const KK_FLOAT vrel=sqrt(vtrx*vtrx+vtry*vtry+vtrz*vtrz);
+
+    KK_FLOAT meff=mi*rmass[j]/(mi+rmass[j]);
+    if (maski & freeze_group_bit) meff=rmass[j];
+    if (mask[j] & freeze_group_bit) meff=mi;
+
+    KK_FLOAT fnormal;
+    if (d_model_i(model,MI_NORMAL)==N_HOOKE)
+      fnormal=d_model_f(model,MF_NORMAL_K)*delta;
+    else
+      fnormal=d_model_f(model,MF_NORMAL_K)*contact_radius*delta;
+
+    KK_FLOAT damp_pref;
+    const int damping=d_model_i(model,MI_DAMPING);
+    if (damping==D_VELOCITY) damp_pref=d_model_f(model,MF_DAMP);
+    else if (damping==D_MASS_VELOCITY) damp_pref=d_model_f(model,MF_DAMP)*meff;
+    else if (damping==D_VISCOELASTIC)
+      damp_pref=d_model_f(model,MF_DAMP)*meff*contact_radius;
+    else {
+      const KK_FLOAT arg=delta>0 ? meff*fnormal/delta : 0;
+      damp_pref=d_model_f(model,MF_DAMP)*sqrt(arg>0?arg:0);
+    }
+    KK_FLOAT fntot=fnormal-damp_pref*vnnr;
+    if (d_model_i(model,MI_LIMIT_DAMPING) && fntot<0) fntot=0;
+    const KK_FLOAT fscrit=d_model_f(model,MF_MU)*fabs(fntot);
+    const int tangential=d_model_i(model,MI_TANGENTIAL);
+    const KK_FLOAT tdamp=d_model_f(model,MF_XT)*damp_pref;
+    KK_FLOAT fsx=0,fsy=0,fsz=0;
+
+    if (tangential==T_LINEAR_NOHISTORY) {
+      const KK_FLOAT ft=(vrel>0) ? (fscrit<tdamp*vrel?fscrit:tdamp*vrel)/vrel : 0;
+      fsx=-ft*vtrx; fsy=-ft*vtry; fsz=-ft*vtrz;
+    } else {
+      const int hi=d_model_i(model,MI_HISTORY_INDEX)+size_history_kk*jj;
+      KK_FLOAT hx=d_firsthistory(i,hi), hy=d_firsthistory(i,hi+1), hz=d_firsthistory(i,hi+2);
+      const KK_FLOAT k0=d_model_f(model,MF_TANGENTIAL_K);
+      KK_FLOAT kscaled=k0;
+      if (tangential==T_MINDLIN || tangential==T_MINDLIN_CLASSIC)
+        kscaled*=contact_radius;
+      if (HISTORYUPDATE) {
+        if (tangential==T_LINEAR_CLASSIC || tangential==T_MINDLIN_CLASSIC) {
+          hx+=dt_kk*vtrx; hy+=dt_kk*vtry; hz+=dt_kk*vtrz;
+          const KK_FLOAT proj=hx*nx+hy*ny+hz*nz;
+          hx-=proj*nx; hy-=proj*ny; hz-=proj*nz;
+        } else {
+          const KK_FLOAT proj=hx*nx+hy*ny+hz*nz;
+          const KK_FLOAT hmag2=hx*hx+hy*hy+hz*hz;
+          const KK_FLOAT tang2=hmag2-proj*proj;
+          if (tang2>0 && fabs(proj)*kscaled>1.0e-10*fscrit) {
+            const KK_FLOAT scale=sqrt(hmag2/tang2);
+            hx=(hx-proj*nx)*scale; hy=(hy-proj*ny)*scale; hz=(hz-proj*nz)*scale;
+          }
+          if (d_model_i(model,MI_MINDLIN_FORCE)) {
+            hx-=kscaled*dt_kk*vtrx; hy-=kscaled*dt_kk*vtry; hz-=kscaled*dt_kk*vtrz;
+          } else {
+            hx+=dt_kk*vtrx; hy+=dt_kk*vtry; hz+=dt_kk*vtrz;
+          }
+        }
+      }
+      if (d_model_i(model,MI_MINDLIN_FORCE)) { fsx=hx; fsy=hy; fsz=hz; }
+      else { fsx=-kscaled*hx; fsy=-kscaled*hy; fsz=-kscaled*hz; }
+      const KK_FLOAT fdx=-tdamp*vtrx, fdy=-tdamp*vtry, fdz=-tdamp*vtrz;
+      fsx+=fdx; fsy+=fdy; fsz+=fdz;
+      const KK_FLOAT fsmag=sqrt(fsx*fsx+fsy*fsy+fsz*fsz);
+      const KK_FLOAT hmag=sqrt(hx*hx+hy*hy+hz*hz);
+      if (fsmag>fscrit) {
+        if (hmag>0) {
+          const KK_FLOAT scale=fscrit/fsmag;
+          fsx*=scale; fsy*=scale; fsz*=scale;
+          hx=fsx-fdx; hy=fsy-fdy; hz=fsz-fdz;
+          if (!d_model_i(model,MI_MINDLIN_FORCE)) {
+            hx/=-kscaled; hy/=-kscaled; hz/=-kscaled;
+          }
+        } else fsx=fsy=fsz=0;
+      }
+      if (HISTORYUPDATE) {
+        d_firsthistory(i,hi)=hx; d_firsthistory(i,hi+1)=hy; d_firsthistory(i,hi+2)=hz;
+      }
+    }
+
+    KK_FLOAT fx=(fntot*nx+fsx)*factor;
+    KK_FLOAT fy=(fntot*ny+fsy)*factor;
+    KK_FLOAT fz=(fntot*nz+fsz)*factor;
+    fxi+=fx; fyi+=fy; fzi+=fz;
+    const KK_FLOAT cx=ny*fsz-nz*fsy;
+    const KK_FLOAT cy=nz*fsx-nx*fsz;
+    const KK_FLOAT cz=nx*fsy-ny*fsx;
+    const KK_FLOAT di=(ri-0.5*delta)*factor;
+    const KK_FLOAT dj=(rj-0.5*delta)*factor;
+    txi-=di*cx; tyi-=di*cy; tzi-=di*cz;
+    if (NEWTON_PAIR || j<nlocal) {
+      a_f(j,0)-=fx; a_f(j,1)-=fy; a_f(j,2)-=fz;
+      a_torque(j,0)-=dj*cx; a_torque(j,1)-=dj*cy; a_torque(j,2)-=dj*cz;
+    }
+    if (VFLAG) ev_tally_xyz<NEIGHFLAG,NEWTON_PAIR>(ev,i,j,fx,fy,fz,dx,dy,dz);
+  }
+  a_f(i,0)+=fxi; a_f(i,1)+=fyi; a_f(i,2)+=fzi;
+  a_torque(i,0)+=txi; a_torque(i,1)+=tyi; a_torque(i,2)+=tzi;
+}
+
+template<class DeviceType>
+template<int NEIGHFLAG, int NEWTON_PAIR, int VFLAG, int HISTORYUPDATE>
+KOKKOS_INLINE_FUNCTION
+void PairGranularKokkos<DeviceType>::operator()(
+    TagPairGranularCompute<NEIGHFLAG,NEWTON_PAIR,VFLAG,HISTORYUPDATE> tag,
+    const int ii) const
+{
+  EV_FLOAT ev;
+  this->template operator()<NEIGHFLAG,NEWTON_PAIR,VFLAG,HISTORYUPDATE>(tag,ii,ev);
+}
+
+template<class DeviceType>
+template<int NEIGHFLAG, int NEWTON_PAIR>
+KOKKOS_INLINE_FUNCTION
+void PairGranularKokkos<DeviceType>::ev_tally_xyz(EV_FLOAT &ev, int i, int j,
+    KK_FLOAT fx, KK_FLOAT fy, KK_FLOAT fz, KK_FLOAT dx, KK_FLOAT dy, KK_FLOAT dz) const
+{
+  using VView = Kokkos::View<KK_ACC_FLOAT*[6],typename DAT::t_kkacc_1d_6::array_layout,
+    typename KKDevice<DeviceType>::value,Kokkos::MemoryTraits<AtomicF<NEIGHFLAG>::value>>;
+  VView va=d_vatom;
+  if (!(vflag_global || vflag_atom)) return;
+  const KK_ACC_FLOAT vv[6]={(KK_ACC_FLOAT)(dx*fx),(KK_ACC_FLOAT)(dy*fy),
+    (KK_ACC_FLOAT)(dz*fz),(KK_ACC_FLOAT)(dx*fy),(KK_ACC_FLOAT)(dx*fz),
+    (KK_ACC_FLOAT)(dy*fz)};
+  if (vflag_global) {
+    if (NEWTON_PAIR) for (int k=0;k<6;k++) ev.v[k]+=vv[k];
+    else {
+      if (i<nlocal) for (int k=0;k<6;k++) ev.v[k]+=0.5*vv[k];
+      if (j<nlocal) for (int k=0;k<6;k++) ev.v[k]+=0.5*vv[k];
+    }
+  }
+  if (vflag_atom) {
+    if (NEWTON_PAIR || i<nlocal) for (int k=0;k<6;k++) va(i,k)+=0.5*vv[k];
+    if (NEWTON_PAIR || j<nlocal) for (int k=0;k<6;k++) va(j,k)+=0.5*vv[k];
+  }
+}
+
+namespace LAMMPS_NS {
+template class PairGranularKokkos<LMPDeviceType>;
+#ifdef LMP_KOKKOS_GPU
+template class PairGranularKokkos<LMPHostType>;
+#endif
+}

--- a/src/KOKKOS/pair_granular_kokkos.h
+++ b/src/KOKKOS/pair_granular_kokkos.h
@@ -1,0 +1,99 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+------------------------------------------------------------------------- */
+
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(granular/kk,PairGranularKokkos<LMPDeviceType>);
+PairStyle(granular/kk/device,PairGranularKokkos<LMPDeviceType>);
+PairStyle(granular/kk/host,PairGranularKokkos<LMPHostType>);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_GRANULAR_KOKKOS_H
+#define LMP_PAIR_GRANULAR_KOKKOS_H
+
+#include "pair_granular.h"
+#include "pair_kokkos.h"
+#include "kokkos_type.h"
+
+namespace LAMMPS_NS {
+
+template <class DeviceType> class FixNeighHistoryKokkos;
+
+template<int NEIGHFLAG, int NEWTON_PAIR, int VFLAG, int HISTORYUPDATE>
+struct TagPairGranularCompute {};
+
+template <class DeviceType>
+class PairGranularKokkos : public PairGranular {
+ public:
+  using device_type = DeviceType;
+  using AT = ArrayTypes<DeviceType>;
+  using value_type = EV_FLOAT;
+
+  PairGranularKokkos(class LAMMPS *);
+  ~PairGranularKokkos() override;
+  void compute(int, int) override;
+  void init_style() override;
+  double init_one(int, int) override;
+
+  template<int NEIGHFLAG, int NEWTON_PAIR, int VFLAG, int HISTORYUPDATE>
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagPairGranularCompute<NEIGHFLAG,NEWTON_PAIR,VFLAG,HISTORYUPDATE>,
+                  const int, EV_FLOAT &) const;
+  template<int NEIGHFLAG, int NEWTON_PAIR, int VFLAG, int HISTORYUPDATE>
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagPairGranularCompute<NEIGHFLAG,NEWTON_PAIR,VFLAG,HISTORYUPDATE>,
+                  const int) const;
+
+  template<int NEIGHFLAG, int NEWTON_PAIR>
+  KOKKOS_INLINE_FUNCTION
+  void ev_tally_xyz(EV_FLOAT &, int, int, KK_FLOAT, KK_FLOAT, KK_FLOAT,
+                    KK_FLOAT, KK_FLOAT, KK_FLOAT) const;
+
+ protected:
+  enum {N_HOOKE=1, N_HERTZ=2};
+  enum {D_VELOCITY=1, D_MASS_VELOCITY=2, D_VISCOELASTIC=3, D_TSUJI=4};
+  enum {T_LINEAR_NOHISTORY=1, T_LINEAR_HISTORY=2, T_LINEAR_CLASSIC=3,
+        T_MINDLIN_CLASSIC=4, T_MINDLIN=5};
+  enum {MI_NORMAL=0, MI_DAMPING, MI_TANGENTIAL, MI_HISTORY_INDEX,
+        MI_LIMIT_DAMPING, MI_MINDLIN_FORCE, MI_MINDLIN_RESCALE, MI_COUNT};
+  enum {MF_NORMAL_K=0, MF_DAMP, MF_TANGENTIAL_K, MF_XT, MF_MU, MF_COUNT};
+
+  typename AT::t_kkfloat_1d_3_lr_randomread x;
+  typename AT::t_kkfloat_1d_3_randomread v, omega;
+  typename AT::t_kkacc_1d_3 f, torque;
+  typename AT::t_int_1d_randomread type, mask;
+  typename AT::t_kkfloat_1d_randomread rmass, radius;
+  typename AT::t_neighbors_2d d_neighbors;
+  typename AT::t_int_1d_randomread d_ilist, d_numneigh;
+  typename AT::t_int_2d d_firsttouch;
+  typename AT::t_kkfloat_2d d_firsthistory;
+
+  Kokkos::View<int**,Kokkos::LayoutRight,DeviceType> d_model_i;
+  Kokkos::View<KK_FLOAT**,Kokkos::LayoutRight,DeviceType> d_model_f;
+  Kokkos::View<int**,Kokkos::LayoutRight,DeviceType> d_type_model;
+
+  DAT::ttransform_kkacc_1d k_eatom;
+  DAT::ttransform_kkacc_1d_6 k_vatom;
+  typename AT::t_kkacc_1d d_eatom;
+  typename AT::t_kkacc_1d_6 d_vatom;
+
+  FixNeighHistoryKokkos<DeviceType> *fix_historyKK;
+  int neighflag, newton_pair, nlocal, nall, eflag, vflag;
+  int use_history_kk, size_history_kk;
+  KK_FLOAT dt_kk;
+
+  void create_kokkos_history();
+  void pack_models();
+
+  KOKKOS_INLINE_FUNCTION
+  int sbmask(const int &j) const { return j >> SBBITS & 3; }
+
+  friend void pair_virial_fdotr_compute<PairGranularKokkos>(PairGranularKokkos*);
+};
+
+} // namespace LAMMPS_NS
+
+#endif
+#endif


### PR DESCRIPTION
**Summary**

This pull request adds Kokkos host and device accelerator variants of the modular `pair_style granular` implementation:

* `granular/kk`
* `granular/kk/host`
* `granular/kk/device`

The initial implementation supports Hooke and Hertz normal models, supported velocity-based damping models, and linear and Mindlin tangential models. It includes Kokkos-compatible granular contact-history storage and restart initialization.

A small example input that can run with either the conventional CPU implementation or the Kokkos GPU implementation is included under `examples/PACKAGES/granular`.

**Related Issue(s)**

There is no related GitHub issue.

**Author(s)**

Madan B K
Department of Mechanical and Aerospace Engineering
Western Michigan University
Corresponding email: madan.bk@wmich.edu

**Licensing**

By submitting this pull request, I agree that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

By submitting this pull request, I confirm that I used OpenAI ChatGPT to assist with refining and debugging the Kokkos implementation and to suggest some changes to `pair_granular_kokkos.cpp`, `pair_granular_kokkos.h`, the granular-history initialization, and the example documentation. I defined the implementation requirements, reviewed and adapted the suggested changes, integrated the implementation into LAMMPS, resolved compilation and runtime issues, and performed the CPU and GPU numerical validation. I have reviewed and take responsibility for all changes included in this pull request.

**Backward Compatibility**

This pull request does not change the behavior or syntax of the existing `pair_style granular` implementation. It adds Kokkos suffix variants that are selected explicitly or through the `-sf kk` command-line option.

Existing CPU input scripts remain compatible and continue to select the conventional implementation unless the Kokkos suffix is requested.

**Implementation Notes**

The implementation adds `PairGranularKokkos<DeviceType>`, with host and device instantiations. The granular-model parameters selected by `pair_coeff` are packed into Kokkos device views and evaluated in a Kokkos parallel pair-force kernel.

The implementation supports the following initial model set:

* Normal: `hooke`, `hertz`, and `hertz/material`
* Damping: `velocity`, `mass_velocity`, `viscoelastic`, `tsuji`, and `coeff_restitution`
* Tangential: `linear_nohistory`, `linear_history`, `linear_history_classic`, `mindlin_classic`, `mindlin`, and `mindlin/force`

Contact history is stored using the Kokkos neighbor-history implementation. For contact-history models, `newton off` and a half or half/thread neighbor list are required.

The current implementation reports explicit errors for unsupported combinations, including rolling, twisting, heat, synchronized Verlet, rigid-body masses, and Mindlin history rescaling.

The code was compiled with the CMake build system using:

* `PKG_GRANULAR=ON`
* `PKG_KOKKOS=ON`
* `Kokkos_ENABLE_CUDA=ON`
* Kokkos 5.2.1
* NVIDIA GH200 GPU

Runtime output confirmed use of:

* `pair granular/kk`
* `half/bin/newtoff/size/kk/device`
* Kokkos device neighbor binning
* Granular contact-history storage

A two-particle trajectory was run with both the conventional CPU implementation and the Kokkos GPU implementation. All 42 atom records were compared:

* Maximum absolute difference: `5.115908e-13`
* Maximum relative difference: `2.412300e-12`
* Validation result: passed

**Post Submission Checklist**

* [x] The feature or features in this pull request are complete for the supported model set
* [x] Licensing information is complete
* [x] Corresponding author information is complete
* [ ] The source code follows all LAMMPS formatting guidelines
* [x] Suitable example documentation is included
* [ ] The added/updated documentation is integrated and tested with the documentation build system
* [ ] The feature has been verified with the conventional build system
* [x] The feature has been verified with the CMake-based build system
* [ ] Suitable tests have been added to the unittest tree
* [x] A package-specific README file has been included or updated
* [x] One or more example input decks are included

**Further Information, Files, and Links**

